### PR TITLE
Always new up a CommitEnumerator

### DIFF
--- a/LibGit2Sharp/CommitCollection.cs
+++ b/LibGit2Sharp/CommitCollection.cs
@@ -11,7 +11,6 @@ namespace LibGit2Sharp
     public class CommitCollection : IEnumerable<Commit>
     {
         private readonly Repository repo;
-        private CommitEnumerator enumerator;
         private string pushedSha;
         private GitSortOptions sortOptions = GitSortOptions.None;
 
@@ -22,11 +21,6 @@ namespace LibGit2Sharp
         public CommitCollection(Repository repo)
         {
             this.repo = repo;
-        }
-
-        private CommitEnumerator Enumerator
-        {
-            get { return enumerator ?? (enumerator = new CommitEnumerator(repo)); }
         }
 
         /// <summary>
@@ -41,14 +35,15 @@ namespace LibGit2Sharp
 
         public IEnumerator<Commit> GetEnumerator()
         {
-            Enumerator.Sort(sortOptions);
+            var enumerator = new CommitEnumerator(repo);
+            enumerator.Sort(sortOptions);
             if (string.IsNullOrEmpty(pushedSha))
             {
                 throw new NotImplementedException();
             }
 
-            Enumerator.Push(pushedSha);
-            return Enumerator;
+            enumerator.Push(pushedSha);
+            return enumerator;
         }
 
         IEnumerator IEnumerable.GetEnumerator()


### PR DESCRIPTION
I know we've gone back and forth on whether or not the revwalker is a _use once_ object or not, but it only seems to play nice when it is _used once_. I was previously creating and storing an instance of the revwalker in the Repository, but it only really let's you walk once before exploding. 

This changes the implementation to always create a new walker when someone wants to traverse commit history.
