### PR TITLE
Set up the test environment in a Fixture base class

### DIFF
--- a/LibGit2Sharp.Tests/BaseFixture.cs
+++ b/LibGit2Sharp.Tests/BaseFixture.cs
@@ -1,0 +1,33 @@
+﻿using System.IO;
+using LibGit2Sharp.Tests.TestHelpers;
+
+namespace LibGit2Sharp.Tests
+{
+    public class BaseFixture
+    {
+        static BaseFixture()
+        {
+            // Do the set up in the static ctor so it only happens once
+            SetUpTestEnvironment();
+        }
+
+        private static void SetUpTestEnvironment()
+        {
+            var source = new DirectoryInfo(@"..\..\..\Resources");
+            var target = new DirectoryInfo(@"Resources");
+
+            if (target.Exists)
+            {
+                target.Delete(recursive: true);
+            }
+
+            DirectoryHelper.CopyFilesRecursively(source, target);
+
+            // The test repo under source control has its .git folder renamed to dot_git to avoid confusing git,
+            // so we need to rename it back to .git in our copy under the target folder
+
+            string tempDotGit = Path.Combine(Constants.TestRepoWithWorkingDirRootPath, "dot_git");
+            Directory.Move(tempDotGit, Constants.TestRepoWithWorkingDirPath);
+        }
+    }
+}

--- a/LibGit2Sharp.Tests/BlobFixture.cs
+++ b/LibGit2Sharp.Tests/BlobFixture.cs
@@ -6,7 +6,7 @@ using NUnit.Framework;
 namespace LibGit2Sharp.Tests
 {
     [TestFixture]
-    public class BlobFixture
+    public class BlobFixture : BaseFixture
     {
         [Test]
         public void CanGetBlobAsUtf8()

--- a/LibGit2Sharp.Tests/BranchFixture.cs
+++ b/LibGit2Sharp.Tests/BranchFixture.cs
@@ -7,7 +7,7 @@ using NUnit.Framework;
 namespace LibGit2Sharp.Tests
 {
     [TestFixture]
-    public class BranchFixture
+    public class BranchFixture : BaseFixture
     {
         private readonly List<string> expectedBranches = new List<string> {"packed-test", "packed", "br2", "master", "test", "deadbeef"};
 

--- a/LibGit2Sharp.Tests/CommitFixture.cs
+++ b/LibGit2Sharp.Tests/CommitFixture.cs
@@ -8,7 +8,7 @@ using NUnit.Framework;
 namespace LibGit2Sharp.Tests
 {
     [TestFixture]
-    public class CommitFixture
+    public class CommitFixture : BaseFixture
     {
         private const string sha = "8496071c1b46c854b31185ea97743be6a8774479";
         private readonly List<string> expectedShas = new List<string> {"a4a7d", "c4780", "9fd73", "4a202", "5b5b0", "84960"};

--- a/LibGit2Sharp.Tests/IndexFixture.cs
+++ b/LibGit2Sharp.Tests/IndexFixture.cs
@@ -7,7 +7,7 @@ using NUnit.Framework;
 namespace LibGit2Sharp.Tests
 {
     [TestFixture]
-    public class IndexFixture
+    public class IndexFixture : BaseFixture
     {
         private readonly List<string> expectedEntries = new List<string>
                                                             {
@@ -21,27 +21,6 @@ namespace LibGit2Sharp.Tests
                                                                 "modified_unstaged_file.txt",
                                                                 "new_tracked_file.txt"
                                                             };
-
-        [TestFixtureSetUp]
-        public void Setup()
-        {
-            const string tempDotGit = "./Resources/testrepo_wd/dot_git";
-
-            bool gitRepoExists = Directory.Exists(Constants.TestRepoWithWorkingDirPath);
-            bool dotGitDirExists = Directory.Exists(tempDotGit);
-
-            if (gitRepoExists)
-            {
-                if (dotGitDirExists)
-                {
-                    DirectoryHelper.DeleteDirectory(tempDotGit);
-                }
-
-                return;
-            }
-
-            Directory.Move(tempDotGit, Constants.TestRepoWithWorkingDirPath);
-        }
 
         [Test]
         public void CanCountEntriesInIndex()
@@ -193,7 +172,7 @@ namespace LibGit2Sharp.Tests
                 const string filename = "new_untracked_file.txt";
                 string fullPath = Path.Combine(repo.Info.WorkingDirectory, filename);
                 File.Exists(fullPath).ShouldBeTrue();
-                
+
                 repo.Index.Stage(filename);
                 repo.Index.Count.ShouldEqual(count + 1);
 

--- a/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
+++ b/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
@@ -42,6 +42,7 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BaseFixture.cs" />
     <Compile Include="BlobFixture.cs" />
     <Compile Include="BranchFixture.cs" />
     <Compile Include="CommitFixture.cs" />
@@ -67,7 +68,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PreBuildEvent>xcopy "$(SolutionDir)Resources\*.*" "$(TargetDir)Resources" /E /I /Y /F /H &gt; NUL</PreBuildEvent>
+    <PreBuildEvent>
+    </PreBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/LibGit2Sharp.Tests/ReferenceFixture.cs
+++ b/LibGit2Sharp.Tests/ReferenceFixture.cs
@@ -7,7 +7,7 @@ using NUnit.Framework;
 namespace LibGit2Sharp.Tests
 {
     [TestFixture]
-    public class ReferenceFixture
+    public class ReferenceFixture : BaseFixture
     {
         private readonly List<string> expectedRefs = new List<string> { "refs/heads/packed-test", "refs/heads/packed", "refs/heads/br2", "refs/heads/master", "refs/heads/test",
             "refs/heads/deadbeef", "refs/tags/test", "refs/tags/e90810b", "refs/tags/lw" };

--- a/LibGit2Sharp.Tests/RepositoryFixture.cs
+++ b/LibGit2Sharp.Tests/RepositoryFixture.cs
@@ -7,7 +7,7 @@ using NUnit.Framework;
 namespace LibGit2Sharp.Tests
 {
     [TestFixture]
-    public class RepositoryFixture
+    public class RepositoryFixture : BaseFixture
     {
         private const string commitSha = "8496071c1b46c854b31185ea97743be6a8774479";
 

--- a/LibGit2Sharp.Tests/TagFixture.cs
+++ b/LibGit2Sharp.Tests/TagFixture.cs
@@ -8,7 +8,7 @@ using NUnit.Framework;
 namespace LibGit2Sharp.Tests
 {
     [TestFixture]
-    public class TagFixture
+    public class TagFixture : BaseFixture
     {
         private readonly List<string> expectedTags = new List<string> {"test", "e90810b", "lw"};
 

--- a/LibGit2Sharp.Tests/TreeFixture.cs
+++ b/LibGit2Sharp.Tests/TreeFixture.cs
@@ -5,7 +5,7 @@ using NUnit.Framework;
 namespace LibGit2Sharp.Tests
 {
     [TestFixture]
-    public class TreeFixture
+    public class TreeFixture : BaseFixture
     {
         private const string sha = "581f9824ecaf824221bd36edf5430f2739a7c4f5";
 


### PR DESCRIPTION
The main idea is to get rid of the pre-build event and instead set that up in code.
