### PR TITLE
Make RepositoryStatus to return native file paths

### DIFF
--- a/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
+++ b/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
@@ -45,6 +45,7 @@
     <Compile Include="ConfigurationFixture.cs" />
     <Compile Include="LazyFixture.cs" />
     <Compile Include="RemoteFixture.cs" />
+    <Compile Include="RepositoryStatusFixture.cs" />
     <Compile Include="TestHelpers\BaseFixture.cs" />
     <Compile Include="BlobFixture.cs" />
     <Compile Include="BranchFixture.cs" />
@@ -82,6 +83,6 @@
     <ItemGroup>
       <NativeBinaries Include="$(MSBuildProjectDirectory)\..\Lib\NativeBinaries\**\*.*" />
     </ItemGroup>
-	<Copy SourceFiles="@(NativeBinaries)" DestinationFiles="@(NativeBinaries->'$(OutputPath)NativeBinaries\%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(NativeBinaries)" DestinationFiles="@(NativeBinaries->'$(OutputPath)NativeBinaries\%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true" />
   </Target>
 </Project>

--- a/LibGit2Sharp.Tests/RepositoryStatusFixture.cs
+++ b/LibGit2Sharp.Tests/RepositoryStatusFixture.cs
@@ -1,0 +1,56 @@
+﻿using NUnit.Framework;
+using LibGit2Sharp.Tests.TestHelpers;
+
+using System.IO;
+using System.Collections.Generic;
+
+namespace LibGit2Sharp.Tests
+{
+    [TestFixture]
+    public class RepositoryStatusFixture : BaseFixture
+    {
+        private List<string> m_directories = new List<string>();
+
+        [Test]
+        public void CanGetNativeFileStatusPaths()
+        {
+            // Create a new repository
+            SelfCleaningDirectory scd = BuildSelfCleaningDirectory();
+            string dir = Repository.Init(scd.DirectoryPath, false);
+
+            string filename = "Testfile.txt";
+
+            // Create a file and insert some content
+            string filePath = Path.Combine(scd.RootedDirectoryPath, filename);
+
+            FileStream fs = File.Create(filePath);
+            StreamWriter sw = new StreamWriter(fs);
+
+            sw.WriteLine("Anybody out there?");
+            sw.Flush();
+            sw.Close();
+            fs.Close();
+
+            // Open the repository
+            Repository repo = new Repository(dir);
+
+            // Add the file to the index
+            repo.Index.Stage(filePath);
+
+            // Get the repository status
+            RepositoryStatus repoStatus = repo.Index.RetrieveStatus();
+
+            foreach (string relpath in repoStatus.Added)
+            {
+                string fullpath = Path.Combine(scd.RootedDirectoryPath, relpath);
+
+                // There is only one file
+                // => So we can stop here
+                Assert.IsTrue(fullpath == filePath);
+
+            }
+
+        }
+
+    }
+}

--- a/LibGit2Sharp/RepositoryStatus.cs
+++ b/LibGit2Sharp/RepositoryStatus.cs
@@ -43,6 +43,8 @@ namespace LibGit2Sharp
 
         private int StateChanged(string filePath, uint state, IntPtr payload)
         {
+            filePath = PosixPathHelper.ToNative(filePath);
+	
             var gitStatus = (FileStatus)state;
             statusEntries.Add(new StatusEntry(filePath, gitStatus));
 


### PR DESCRIPTION
I did some very minor changes to RepositoryStatus to deal with native paths on windows systems.

In addition I wrote a very simple test to make sure the changes are working.
