### PR TITLE
Improve reliability in running unit tests

### DIFF
--- a/LibGit2Sharp.Tests/BlobFixture.cs
+++ b/LibGit2Sharp.Tests/BlobFixture.cs
@@ -11,7 +11,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanGetBlobAsUtf8()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 var blob = repo.Lookup<Blob>("a8233120f6ad708f843d861ce2b7228ec4e3dec6");
 
@@ -23,7 +23,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanGetBlobSize()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 var blob = repo.Lookup<Blob>("a8233120f6ad708f843d861ce2b7228ec4e3dec6");
                 blob.Size.ShouldEqual(10);
@@ -33,7 +33,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanLookUpBlob()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 var blob = repo.Lookup<Blob>("a8233120f6ad708f843d861ce2b7228ec4e3dec6");
                 blob.ShouldNotBeNull();
@@ -43,7 +43,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanReadBlobContent()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 var blob = repo.Lookup<Blob>("a8233120f6ad708f843d861ce2b7228ec4e3dec6");
                 byte[] bytes = blob.Content;
@@ -57,7 +57,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanReadBlobStream()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 var blob = repo.Lookup<Blob>("a8233120f6ad708f843d861ce2b7228ec4e3dec6");
 

--- a/LibGit2Sharp.Tests/BranchFixture.cs
+++ b/LibGit2Sharp.Tests/BranchFixture.cs
@@ -107,7 +107,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CreatingABranchFromANonCommitObjectThrows()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 const string name = "sorry-dude-i-do-not-do-blobs-nor-trees";
                 Assert.Throws<LibGit2Exception>(() => repo.CreateBranch(name, "refs/tags/point_to_blob"));
@@ -119,7 +119,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CreatingBranchWithUnknownNamedTargetThrows()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<LibGit2Exception>(() => repo.Branches.Create("my_new_branch", "my_old_branch"));
             }
@@ -128,7 +128,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CreatingBranchWithUnknownShaTargetThrows()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<LibGit2Exception>(() => repo.Branches.Create("my_new_branch", Constants.UnknownSha));
                 Assert.Throws<LibGit2Exception>(() => repo.Branches.Create("my_new_branch", Constants.UnknownSha.Substring(0, 7)));
@@ -138,7 +138,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CreatingABranchPointingAtANonCanonicalReferenceThrows()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<LibGit2Exception>(() => repo.Branches.Create("nocanonicaltarget", "br2"));
             }
@@ -147,7 +147,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CreatingBranchWithBadParamsThrows()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<ArgumentNullException>(() => repo.Branches.Create(null, repo.Head.CanonicalName));
                 Assert.Throws<ArgumentException>(() => repo.Branches.Create(string.Empty, repo.Head.CanonicalName));
@@ -159,7 +159,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanListAllBranches()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 CollectionAssert.AreEqual(expectedBranches, repo.Branches.Select(b => b.Name).ToArray());
 
@@ -170,7 +170,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanListAllBranchesIncludingRemoteRefs()
         {
-            TemporaryCloneOfTestRepo path = BuildTemporaryCloneOfTestRepo(Constants.StandardTestRepoPath);
+            TemporaryCloneOfTestRepo path = BuildTemporaryCloneOfTestRepo(StandardTestRepoPath);
             using (var repo = new Repository(path.RepositoryPath))
             {
                 var expectedBranchesIncludingRemoteRefs = new[]
@@ -189,7 +189,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanLookupABranchByItsCanonicalName()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Branch branch = repo.Branches["refs/heads/br2"];
                 branch.ShouldNotBeNull();
@@ -207,7 +207,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanLookupLocalBranch()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Branch master = repo.Branches["master"];
                 master.ShouldNotBeNull();
@@ -222,7 +222,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void LookingOutABranchByNameWithBadParamsThrows()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Branch branch;
                 Assert.Throws<ArgumentNullException>(() => branch = repo.Branches[null]);
@@ -233,7 +233,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void TrackingInformationIsEmptyForNonTrackingBranch()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Branch branch = repo.Branches["test"];
                 branch.IsTracking.ShouldBeFalse();
@@ -246,7 +246,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanGetTrackingInformationForTrackingBranch()
         {
-            using (var repo = new Repository(Constants.StandardTestRepoPath))
+            using (var repo = new Repository(StandardTestRepoPath))
             {
                 Branch master = repo.Branches["master"];
                 master.IsTracking.ShouldBeTrue();
@@ -259,7 +259,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanWalkCommitsFromAnotherBranch()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Branch master = repo.Branches["test"];
                 master.Commits.Count().ShouldEqual(2);
@@ -269,7 +269,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanWalkCommitsFromBranch()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Branch master = repo.Branches["master"];
                 master.Commits.Count().ShouldEqual(7);
@@ -326,7 +326,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CheckingOutANonExistingBranchThrows()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<LibGit2Exception>(() => repo.Branches.Checkout("i-do-not-exist"));
             }
@@ -335,7 +335,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CheckingOutABranchWithBadParamsThrows()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<ArgumentException>(() => repo.Branches.Checkout(string.Empty));
                 Assert.Throws<ArgumentNullException>(() => repo.Branches.Checkout(null));
@@ -345,7 +345,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void DeletingABranchWhichIsTheCurrentHeadThrows()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<LibGit2Exception>(() => repo.Branches.Delete(repo.Head.Name));
             }
@@ -354,7 +354,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void DeletingABranchWithBadParamsThrows()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<ArgumentException>(() => repo.Branches.Delete(string.Empty));
                 Assert.Throws<ArgumentNullException>(() => repo.Branches.Delete(null));
@@ -364,7 +364,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void OnlyOneBranchIsTheHead()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Branch head = null;
 
@@ -422,7 +422,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void BlindlyMovingABranchOverAnExistingOneThrows()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<LibGit2Exception>(() => repo.Branches.Move("br2", "test"));
             }

--- a/LibGit2Sharp.Tests/CommitFixture.cs
+++ b/LibGit2Sharp.Tests/CommitFixture.cs
@@ -17,7 +17,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanCountCommits()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 repo.Commits.Count().ShouldEqual(7);
             }
@@ -26,7 +26,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanCorrectlyCountCommitsWhenSwitchingToAnotherBranch()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 repo.Branches.Checkout("test");
                 repo.Commits.Count().ShouldEqual(2);
@@ -42,7 +42,7 @@ namespace LibGit2Sharp.Tests
         public void CanEnumerateCommits()
         {
             int count = 0;
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 foreach (Commit commit in repo.Commits)
                 {
@@ -71,7 +71,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void DefaultOrderingWhenEnumeratingCommitsIsTimeBased()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 repo.Commits.SortedBy.ShouldEqual(GitSortOptions.Time);
             }
@@ -81,7 +81,7 @@ namespace LibGit2Sharp.Tests
         public void CanEnumerateCommitsFromSha()
         {
             int count = 0;
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 foreach (Commit commit in repo.Commits.QueryBy(new Filter { Since = "a4a7dce85cf63874e984719f4fdd239f5145052f" }))
                 {
@@ -95,7 +95,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void QueryingTheCommitHistoryWithUnknownShaOrInvalidEntryPointThrows()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<LibGit2Exception>(() => repo.Commits.QueryBy(new Filter { Since = Constants.UnknownSha }).Count());
                 Assert.Throws<LibGit2Exception>(() => repo.Commits.QueryBy(new Filter { Since = "refs/heads/deadbeef" }).Count());
@@ -119,7 +119,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void QueryingTheCommitHistoryWithBadParamsThrows()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<ArgumentException>(() => repo.Commits.QueryBy(new Filter { Since = string.Empty }));
                 Assert.Throws<ArgumentNullException>(() => repo.Commits.QueryBy(new Filter { Since = null }));
@@ -132,7 +132,7 @@ namespace LibGit2Sharp.Tests
         {
             expectedShas.Reverse();
             int count = 0;
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 foreach (Commit commit in repo.Commits.QueryBy(new Filter { Since = "a4a7dce85cf63874e984719f4fdd239f5145052f", SortBy = GitSortOptions.Time | GitSortOptions.Reverse }))
                 {
@@ -147,7 +147,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanEnumerateCommitsWithReverseTopoSorting()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 List<Commit> commits = repo.Commits.QueryBy(new Filter { Since = "a4a7dce85cf63874e984719f4fdd239f5145052f", SortBy = GitSortOptions.Time | GitSortOptions.Reverse }).ToList();
                 foreach (Commit commit in commits)
@@ -166,7 +166,7 @@ namespace LibGit2Sharp.Tests
         public void CanEnumerateCommitsWithTimeSorting()
         {
             int count = 0;
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 foreach (Commit commit in repo.Commits.QueryBy(new Filter { Since = "a4a7dce85cf63874e984719f4fdd239f5145052f", SortBy = GitSortOptions.Time }))
                 {
@@ -181,7 +181,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanEnumerateCommitsWithTopoSorting()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 List<Commit> commits = repo.Commits.QueryBy(new Filter { Since = "a4a7dce85cf63874e984719f4fdd239f5145052f", SortBy = GitSortOptions.Topological }).ToList();
                 foreach (Commit commit in commits)
@@ -322,7 +322,7 @@ namespace LibGit2Sharp.Tests
 
         private static void AssertEnumerationOfCommits(Func<Repository, Filter> filterBuilder, IEnumerable<string> abbrevIds)
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 AssertEnumerationOfCommitsInRepo(repo, filterBuilder, abbrevIds);
             }
@@ -340,7 +340,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanLookupCommitGeneric()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 var commit = repo.Lookup<Commit>(sha);
                 commit.Message.ShouldEqual("testing\n");
@@ -352,7 +352,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanReadCommitData()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 GitObject obj = repo.Lookup(sha);
                 obj.ShouldNotBeNull();
@@ -383,7 +383,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanReadCommitWithMultipleParents()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 var commit = repo.Lookup<Commit>("a4a7dce85cf63874e984719f4fdd239f5145052f");
                 commit.Parents.Count().ShouldEqual(2);
@@ -393,7 +393,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanDirectlyAccessABlobOfTheCommit()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 var commit = repo.Lookup<Commit>("4c062a6");
 
@@ -407,7 +407,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanDirectlyAccessATreeOfTheCommit()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 var commit = repo.Lookup<Commit>("4c062a6");
 
@@ -419,7 +419,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void DirectlyAccessingAnUnknownTreeEntryOfTheCommitReturnsNull()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 var commit = repo.Lookup<Commit>("4c062a6");
 

--- a/LibGit2Sharp.Tests/ConfigurationFixture.cs
+++ b/LibGit2Sharp.Tests/ConfigurationFixture.cs
@@ -54,7 +54,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanDeleteConfiguration()
         {
-            var path = BuildTemporaryCloneOfTestRepo(Constants.StandardTestRepoPath);
+            var path = BuildTemporaryCloneOfTestRepo(StandardTestRepoPath);
             using (var repo = new Repository(path.RepositoryPath))
             {
                 repo.Config.Get<bool>("unittests.boolsetting", false).ShouldBeFalse();
@@ -71,7 +71,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanGetGlobalStringValue()
         {
-            using (var repo = new Repository(Constants.StandardTestRepoPath))
+            using (var repo = new Repository(StandardTestRepoPath))
             {
                 InconclusiveIf(() => !repo.Config.HasGlobalConfig, "No Git global configuration available");
 
@@ -82,7 +82,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanReadBooleanValue()
         {
-            using (var repo = new Repository(Constants.StandardTestRepoPath))
+            using (var repo = new Repository(StandardTestRepoPath))
             {
                 Assert.IsTrue(repo.Config.Get<bool>("core.ignorecase", false));
                 Assert.IsTrue(repo.Config.Get<bool>("core", "ignorecase", false));
@@ -92,7 +92,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanReadIntValue()
         {
-            using (var repo = new Repository(Constants.StandardTestRepoPath))
+            using (var repo = new Repository(StandardTestRepoPath))
             {
                 Assert.AreEqual(2, repo.Config.Get<int>("unittests.intsetting", 42));
                 Assert.AreEqual(2, repo.Config.Get<int>("unittests", "intsetting", 42));
@@ -102,7 +102,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanReadLongValue()
         {
-            using (var repo = new Repository(Constants.StandardTestRepoPath))
+            using (var repo = new Repository(StandardTestRepoPath))
             {
                 Assert.AreEqual(15234, repo.Config.Get<long>("unittests.longsetting", 42));
                 Assert.AreEqual(15234, repo.Config.Get<long>("unittests", "longsetting", 42));
@@ -112,7 +112,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanReadStringValue()
         {
-            using (var repo = new Repository(Constants.StandardTestRepoPath))
+            using (var repo = new Repository(StandardTestRepoPath))
             {
                 Assert.AreEqual("+refs/heads/*:refs/remotes/origin/*", repo.Config.Get<string>("remote.origin.fetch", null));
                 Assert.AreEqual("+refs/heads/*:refs/remotes/origin/*", repo.Config.Get<string>("remote", "origin", "fetch", null));
@@ -122,7 +122,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanSetBooleanValue()
         {
-            var path = BuildTemporaryCloneOfTestRepo(Constants.StandardTestRepoPath);
+            var path = BuildTemporaryCloneOfTestRepo(StandardTestRepoPath);
             using (var repo = new Repository(path.RepositoryPath))
             {
                 repo.Config.Set("unittests.boolsetting", true);
@@ -134,7 +134,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanSetGlobalStringValue()
         {
-            using (var repo = new Repository(Constants.StandardTestRepoPath))
+            using (var repo = new Repository(StandardTestRepoPath))
             {
                 InconclusiveIf(() => !repo.Config.HasGlobalConfig, "No Git global configuration available");
 
@@ -157,7 +157,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanSetIntValue()
         {
-            var path = BuildTemporaryCloneOfTestRepo(Constants.StandardTestRepoPath);
+            var path = BuildTemporaryCloneOfTestRepo(StandardTestRepoPath);
             using (var repo = new Repository(path.RepositoryPath))
             {
                 repo.Config.Set("unittests.intsetting", 3);
@@ -169,7 +169,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanSetLongValue()
         {
-            var path = BuildTemporaryCloneOfTestRepo(Constants.StandardTestRepoPath);
+            var path = BuildTemporaryCloneOfTestRepo(StandardTestRepoPath);
             using (var repo = new Repository(path.RepositoryPath))
             {
                 repo.Config.Set("unittests.longsetting", (long)451);
@@ -181,7 +181,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanSetStringValue()
         {
-            var path = BuildTemporaryCloneOfTestRepo(Constants.StandardTestRepoPath);
+            var path = BuildTemporaryCloneOfTestRepo(StandardTestRepoPath);
             using (var repo = new Repository(path.RepositoryPath))
             {
                 repo.Config.Set("unittests.stringsetting", "val");
@@ -193,7 +193,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void ReadingUnsupportedTypeThrows()
         {
-            using (var repo = new Repository(Constants.StandardTestRepoPath))
+            using (var repo = new Repository(StandardTestRepoPath))
             {
                 Assert.Throws<ArgumentException>(() => repo.Config.Get<short>("unittests.setting", 42));
                 Assert.Throws<ArgumentException>(() => repo.Config.Get<Configuration>("unittests.setting", null));
@@ -203,7 +203,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void ReadingValueThatDoesntExistReturnsDefault()
         {
-            using (var repo = new Repository(Constants.StandardTestRepoPath))
+            using (var repo = new Repository(StandardTestRepoPath))
             {
                 repo.Config.Get<string>("unittests.ghostsetting", null).ShouldBeNull();
                 repo.Config.Get<int>("unittests.ghostsetting", 0).ShouldEqual(0);
@@ -219,7 +219,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void SettingUnsupportedTypeThrows()
         {
-            using (var repo = new Repository(Constants.StandardTestRepoPath))
+            using (var repo = new Repository(StandardTestRepoPath))
             {
                 Assert.Throws<ArgumentException>(() => repo.Config.Set("unittests.setting", (short)123));
                 Assert.Throws<ArgumentException>(() => repo.Config.Set("unittests.setting", repo.Config));

--- a/LibGit2Sharp.Tests/IndexFixture.cs
+++ b/LibGit2Sharp.Tests/IndexFixture.cs
@@ -27,7 +27,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanCountEntriesInIndex()
         {
-            using (var repo = new Repository(Constants.StandardTestRepoPath))
+            using (var repo = new Repository(StandardTestRepoPath))
             {
                 repo.Index.Count.ShouldEqual(expectedEntries.Count());
             }
@@ -36,7 +36,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanEnumerateIndex()
         {
-            using (var repo = new Repository(Constants.StandardTestRepoPath))
+            using (var repo = new Repository(StandardTestRepoPath))
             {
                 CollectionAssert.AreEqual(expectedEntries, repo.Index.Select(e => e.Path).ToArray());
             }
@@ -45,7 +45,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanFetchAnIndexEntryByItsName()
         {
-            using (var repo = new Repository(Constants.StandardTestRepoPath))
+            using (var repo = new Repository(StandardTestRepoPath))
             {
                 IndexEntry entry = repo.Index["README"];
                 entry.Path.ShouldEqual("README");
@@ -58,7 +58,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void FetchingAnUnknownIndexEntryReturnsNull()
         {
-            using (var repo = new Repository(Constants.StandardTestRepoPath))
+            using (var repo = new Repository(StandardTestRepoPath))
             {
                 IndexEntry entry = repo.Index["I-do-not-exist.txt"];
                 entry.ShouldBeNull();
@@ -68,7 +68,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void ReadIndexWithBadParamsFails()
         {
-            using (var repo = new Repository(Constants.StandardTestRepoPath))
+            using (var repo = new Repository(StandardTestRepoPath))
             {
                 Assert.Throws<ArgumentNullException>(() => { IndexEntry entry = repo.Index[null]; });
                 Assert.Throws<ArgumentException>(() => { IndexEntry entry = repo.Index[string.Empty]; });
@@ -83,7 +83,7 @@ namespace LibGit2Sharp.Tests
         [TestCase("new_tracked_file.txt", FileStatus.Added, true, FileStatus.Added, true, 0)]
         public void CanStage(string relativePath, FileStatus currentStatus, bool doesCurrentlyExistInTheIndex, FileStatus expectedStatusOnceStaged, bool doesExistInTheIndexOnceStaged, int expectedIndexCountVariation)
         {
-            TemporaryCloneOfTestRepo path = BuildTemporaryCloneOfTestRepo(Constants.StandardTestRepoWorkingDirPath);
+            TemporaryCloneOfTestRepo path = BuildTemporaryCloneOfTestRepo(StandardTestRepoWorkingDirPath);
             using (var repo = new Repository(path.RepositoryPath))
             {
                 int count = repo.Index.Count;
@@ -101,7 +101,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanStageTheUpdationOfAStagedFile()
         {
-            TemporaryCloneOfTestRepo path = BuildTemporaryCloneOfTestRepo(Constants.StandardTestRepoWorkingDirPath);
+            TemporaryCloneOfTestRepo path = BuildTemporaryCloneOfTestRepo(StandardTestRepoWorkingDirPath);
             using (var repo = new Repository(path.RepositoryPath))
             {
                 int count = repo.Index.Count;
@@ -126,7 +126,7 @@ namespace LibGit2Sharp.Tests
         [TestCase("deleted_staged_file.txt", FileStatus.Removed)]
         public void StagingAnUnknownFileThrows(string relativePath, FileStatus status)
         {
-            using (var repo = new Repository(Constants.StandardTestRepoPath))
+            using (var repo = new Repository(StandardTestRepoPath))
             {
                 repo.Index[relativePath].ShouldBeNull();
                 repo.Index.RetrieveStatus(relativePath).ShouldEqual(status);
@@ -138,7 +138,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanStageTheRemovalOfAStagedFile()
         {
-            TemporaryCloneOfTestRepo path = BuildTemporaryCloneOfTestRepo(Constants.StandardTestRepoWorkingDirPath);
+            TemporaryCloneOfTestRepo path = BuildTemporaryCloneOfTestRepo(StandardTestRepoWorkingDirPath);
             using (var repo = new Repository(path.RepositoryPath))
             {
                 int count = repo.Index.Count;
@@ -161,7 +161,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void StagingANewVersionOfAFileThenUnstagingItRevertsTheBlobToTheVersionOfHead()
         {
-            var path = BuildTemporaryCloneOfTestRepo(Constants.StandardTestRepoWorkingDirPath);
+            var path = BuildTemporaryCloneOfTestRepo(StandardTestRepoWorkingDirPath);
             using (var repo = new Repository(path.RepositoryPath))
             {
                 int count = repo.Index.Count;
@@ -187,7 +187,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanStageANewFileInAPersistentManner()
         {
-            TemporaryCloneOfTestRepo path = BuildTemporaryCloneOfTestRepo(Constants.StandardTestRepoPath);
+            TemporaryCloneOfTestRepo path = BuildTemporaryCloneOfTestRepo(StandardTestRepoPath);
             using (var repo = new Repository(path.RepositoryPath))
             {
                 const string filename = "unit_test.txt";
@@ -216,7 +216,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanStageANewFileWithAFullPath()
         {
-            TemporaryCloneOfTestRepo path = BuildTemporaryCloneOfTestRepo(Constants.StandardTestRepoWorkingDirPath);
+            TemporaryCloneOfTestRepo path = BuildTemporaryCloneOfTestRepo(StandardTestRepoWorkingDirPath);
             using (var repo = new Repository(path.RepositoryPath))
             {
                 int count = repo.Index.Count;
@@ -235,7 +235,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanStageANewFileWithARelativePathContainingNativeDirectorySeparatorCharacters()
         {
-            TemporaryCloneOfTestRepo path = BuildTemporaryCloneOfTestRepo(Constants.StandardTestRepoWorkingDirPath);
+            TemporaryCloneOfTestRepo path = BuildTemporaryCloneOfTestRepo(StandardTestRepoWorkingDirPath);
             using (var repo = new Repository(path.RepositoryPath))
             {
                 int count = repo.Index.Count;
@@ -259,7 +259,7 @@ namespace LibGit2Sharp.Tests
         public void StagingANewFileWithAFullPathWhichEscapesOutOfTheWorkingDirThrows()
         {
             SelfCleaningDirectory scd = BuildSelfCleaningDirectory();
-            TemporaryCloneOfTestRepo path = BuildTemporaryCloneOfTestRepo(Constants.StandardTestRepoWorkingDirPath);
+            TemporaryCloneOfTestRepo path = BuildTemporaryCloneOfTestRepo(StandardTestRepoWorkingDirPath);
             using (var repo = new Repository(path.RepositoryPath))
             {
                 DirectoryInfo di = Directory.CreateDirectory(scd.DirectoryPath);
@@ -275,7 +275,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void StageFileWithBadParamsThrows()
         {
-            using (var repo = new Repository(Constants.StandardTestRepoPath))
+            using (var repo = new Repository(StandardTestRepoPath))
             {
                 Assert.Throws<ArgumentException>(() => repo.Index.Stage(string.Empty));
                 Assert.Throws<ArgumentNullException>(() => repo.Index.Stage(null));
@@ -290,7 +290,7 @@ namespace LibGit2Sharp.Tests
         [TestCase("new_tracked_file.txt", FileStatus.Added, true, FileStatus.Untracked, false, -1)]
         public void CanUnStage(string relativePath, FileStatus currentStatus, bool doesCurrentlyExistInTheIndex, FileStatus expectedStatusOnceStaged, bool doesExistInTheIndexOnceStaged, int expectedIndexCountVariation)
         {
-            TemporaryCloneOfTestRepo path = BuildTemporaryCloneOfTestRepo(Constants.StandardTestRepoWorkingDirPath);
+            TemporaryCloneOfTestRepo path = BuildTemporaryCloneOfTestRepo(StandardTestRepoWorkingDirPath);
             using (var repo = new Repository(path.RepositoryPath))
             {
                 int count = repo.Index.Count;
@@ -308,7 +308,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanUnstageTheRemovalOfAFile()
         {
-            TemporaryCloneOfTestRepo path = BuildTemporaryCloneOfTestRepo(Constants.StandardTestRepoWorkingDirPath);
+            TemporaryCloneOfTestRepo path = BuildTemporaryCloneOfTestRepo(StandardTestRepoWorkingDirPath);
             using (var repo = new Repository(path.RepositoryPath))
             {
                 int count = repo.Index.Count;
@@ -330,7 +330,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void UnstagingFileWithBadParamsThrows()
         {
-            using (var repo = new Repository(Constants.StandardTestRepoPath))
+            using (var repo = new Repository(StandardTestRepoPath))
             {
                 Assert.Throws<ArgumentException>(() => repo.Index.Unstage(string.Empty));
                 Assert.Throws<ArgumentNullException>(() => repo.Index.Unstage(null));
@@ -392,7 +392,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanRemoveAFile()
         {
-            TemporaryCloneOfTestRepo path = BuildTemporaryCloneOfTestRepo(Constants.StandardTestRepoWorkingDirPath);
+            TemporaryCloneOfTestRepo path = BuildTemporaryCloneOfTestRepo(StandardTestRepoWorkingDirPath);
             using (var repo = new Repository(path.RepositoryPath))
             {
                 int count = repo.Index.Count;
@@ -414,7 +414,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void RemovingANonStagedFileThrows()
         {
-            using (var repo = new Repository(Constants.StandardTestRepoPath))
+            using (var repo = new Repository(StandardTestRepoPath))
             {
                 Assert.Throws<LibGit2Exception>(() => repo.Index.Remove("shadowcopy_of_an_unseen_ghost.txt"));
             }
@@ -423,7 +423,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanRetrieveTheStatusOfAFile()
         {
-            using (var repo = new Repository(Constants.StandardTestRepoPath))
+            using (var repo = new Repository(StandardTestRepoPath))
             {
                 FileStatus status = repo.Index.RetrieveStatus("new_tracked_file.txt");
                 status.ShouldEqual(FileStatus.Added);
@@ -433,7 +433,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanRetrieveTheStatusOfTheWholeWorkingDirectory()
         {
-            TemporaryCloneOfTestRepo path = BuildTemporaryCloneOfTestRepo(Constants.StandardTestRepoWorkingDirPath);
+            TemporaryCloneOfTestRepo path = BuildTemporaryCloneOfTestRepo(StandardTestRepoWorkingDirPath);
             using (var repo = new Repository(path.RepositoryPath))
             {
                 const string file = "modified_staged_file.txt";

--- a/LibGit2Sharp.Tests/ReferenceFixture.cs
+++ b/LibGit2Sharp.Tests/ReferenceFixture.cs
@@ -111,7 +111,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CreateWithEmptyStringForTargetThrows()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<ArgumentException>(() => repo.Refs.Create("refs/heads/newref", string.Empty));
             }
@@ -120,7 +120,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CreateWithEmptyStringThrows()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<ArgumentException>(() => repo.Refs.Create(string.Empty, "refs/heads/master"));
             }
@@ -129,7 +129,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CreateWithNullForTargetThrows()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<ArgumentNullException>(() => repo.Refs.Create("refs/heads/newref", null));
             }
@@ -138,7 +138,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CreateWithNullStringThrows()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<ArgumentNullException>(() => repo.Refs.Create(null, "refs/heads/master"));
             }
@@ -190,7 +190,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void DeleteWithEmptyNameThrows()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<ArgumentException>(() => repo.Refs.Delete(string.Empty));
             }
@@ -199,7 +199,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void DeleteWithNullNameThrows()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<ArgumentNullException>(() => repo.Refs.Delete(null));
             }
@@ -222,7 +222,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanResolveHeadByName()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 var head = (SymbolicReference)repo.Refs["HEAD"];
                 head.ShouldNotBeNull();
@@ -243,7 +243,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanResolveReferenceToALightweightTag()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 var lwTag = (DirectReference)repo.Refs["refs/tags/lw"];
                 lwTag.ShouldNotBeNull();
@@ -257,7 +257,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanResolveReferenceToAnAnnotatedTag()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 var annTag = (DirectReference)repo.Refs["refs/tags/test"];
                 annTag.ShouldNotBeNull();
@@ -271,7 +271,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanResolveRefsByName()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 var master = (DirectReference)repo.Refs["refs/heads/master"];
                 master.ShouldNotBeNull();
@@ -285,7 +285,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void ResolvingWithEmptyStringThrows()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<ArgumentException>(() => { Reference head = repo.Refs[string.Empty]; });
             }
@@ -294,7 +294,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void ResolvingWithNullThrows()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<ArgumentNullException>(() => { Reference head = repo.Refs[null]; });
             }
@@ -379,7 +379,7 @@ namespace LibGit2Sharp.Tests
         public void UpdatingASymbolicRefWithOidFails()
         {
             const string masterRef = "refs/heads/master";
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<ArgumentException>(() => repo.Refs.UpdateTarget(masterRef, "refs/heads/test"));
             }
@@ -388,7 +388,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void UpdatingAReferenceTargetWithBadParametersFails()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<ArgumentException>(() => repo.Refs.UpdateTarget(string.Empty, "refs/heads/packed"));
                 Assert.Throws<ArgumentException>(() => repo.Refs.UpdateTarget("master", string.Empty));
@@ -444,7 +444,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void MovingANonExistingReferenceThrows()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<LibGit2Exception>(() => repo.Refs.Move("refs/tags/i-am-void", "refs/atic/tagtest"));
             }
@@ -469,7 +469,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void BlindlyOverwritingAExistingReferenceThrows()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<LibGit2Exception>(() => repo.Refs.Move("refs/heads/packed", "refs/heads/br2"));
             }

--- a/LibGit2Sharp.Tests/RemoteFixture.cs
+++ b/LibGit2Sharp.Tests/RemoteFixture.cs
@@ -9,7 +9,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanGetRemoteOrigin()
         {
-            using (var repo = new Repository(Constants.StandardTestRepoPath))
+            using (var repo = new Repository(StandardTestRepoPath))
             {
                 var origin = repo.Remotes["origin"];
                 origin.ShouldNotBeNull();
@@ -21,7 +21,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void GettingRemoteThatDoesntExistThrows()
         {
-            using (var repo = new Repository(Constants.StandardTestRepoPath))
+            using (var repo = new Repository(StandardTestRepoPath))
             {
                 repo.Remotes["test"].ShouldBeNull();
             }

--- a/LibGit2Sharp.Tests/RepositoryFixture.cs
+++ b/LibGit2Sharp.Tests/RepositoryFixture.cs
@@ -104,7 +104,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanOpenRepoWithFullPath()
         {
-            string path = Path.GetFullPath(Constants.BareTestRepoPath);
+            string path = Path.GetFullPath(BareTestRepoPath);
             using (var repo = new Repository(path))
             {
                 repo.ShouldNotBeNull();
@@ -112,19 +112,9 @@ namespace LibGit2Sharp.Tests
         }
 
         [Test]
-        [Platform(Exclude = "Linux,Unix", Reason = "No need to test windows path separators on non-windows platforms")]
-        // See http://www.nunit.org/index.php?p=platform&r=2.6 for other platforms that can be excluded/included.
-        public void CanOpenRepoWithWindowsPathSeparators()
-        {
-            using (new Repository(@".\Resources\testrepo.git"))
-            {
-            }
-        }
-
-        [Test]
         public void CanOpenRepository()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 repo.Info.Path.ShouldNotBeNull();
                 repo.Info.WorkingDirectory.ShouldBeNull();
@@ -150,7 +140,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanLookupACommitByTheNameOfABranch()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 GitObject gitObject = repo.Lookup("refs/heads/master");
                 gitObject.ShouldNotBeNull();
@@ -161,7 +151,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanLookupACommitByTheNameOfALightweightTag()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 GitObject gitObject = repo.Lookup("refs/tags/lw");
                 gitObject.ShouldNotBeNull();
@@ -172,7 +162,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanLookupATagAnnotationByTheNameOfAnAnnotatedTag()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 GitObject gitObject = repo.Lookup("refs/tags/e90810b");
                 gitObject.ShouldNotBeNull();
@@ -183,7 +173,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanLookupObjects()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 repo.Lookup(commitSha).ShouldNotBeNull();
                 repo.Lookup<Commit>(commitSha).ShouldNotBeNull();
@@ -194,7 +184,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanLookupSameObjectTwiceAndTheyAreEqual()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 GitObject commit = repo.Lookup(commitSha);
                 GitObject commit2 = repo.Lookup(commitSha);
@@ -206,7 +196,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void LookupObjectByWrongShaReturnsNull()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 repo.Lookup(Constants.UnknownSha).ShouldBeNull();
                 repo.Lookup<GitObject>(Constants.UnknownSha).ShouldBeNull();
@@ -216,7 +206,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void LookupObjectByWrongTypeReturnsNull()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 repo.Lookup(commitSha).ShouldNotBeNull();
                 repo.Lookup<Commit>(commitSha).ShouldNotBeNull();
@@ -227,7 +217,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void LookupObjectByUnknownReferenceNameReturnsNull()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 repo.Lookup("refs/heads/chopped/off").ShouldBeNull();
                 repo.Lookup<GitObject>(Constants.UnknownSha).ShouldBeNull();
@@ -266,7 +256,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void LookingUpWithBadParamsThrows()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<ArgumentException>(() => repo.Lookup(string.Empty));
                 Assert.Throws<ArgumentException>(() => repo.Lookup<GitObject>(string.Empty));
@@ -280,7 +270,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanCheckForObjectExistence()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 repo.HasObject("8496071c1b46c854b31185ea97743be6a8774479").ShouldBeTrue();
                 repo.HasObject("1385f264afb75a56a5bec74243be9b367ba4ca08").ShouldBeTrue();
@@ -292,7 +282,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CheckingForObjectExistenceWithBadParamsThrows()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<ArgumentException>(() => repo.HasObject(string.Empty));
                 Assert.Throws<ArgumentNullException>(() => repo.HasObject(null));
@@ -302,36 +292,36 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanDiscoverABareRepoGivenTheRepoPath()
         {
-            string path = Repository.Discover(Constants.BareTestRepoPath);
-            path.ShouldEqual(Path.GetFullPath(Constants.BareTestRepoPath + Path.DirectorySeparatorChar));
+            string path = Repository.Discover(BareTestRepoPath);
+            path.ShouldEqual(Path.GetFullPath(BareTestRepoPath + Path.DirectorySeparatorChar));
         }
 
         [Test]
         public void CanDiscoverABareRepoGivenASubDirectoryOfTheRepoPath()
         {
-            string path = Repository.Discover(Path.Combine(Constants.BareTestRepoPath, "objects/4a"));
-            path.ShouldEqual(Path.GetFullPath(Constants.BareTestRepoPath + Path.DirectorySeparatorChar));
+            string path = Repository.Discover(Path.Combine(BareTestRepoPath, "objects/4a"));
+            path.ShouldEqual(Path.GetFullPath(BareTestRepoPath + Path.DirectorySeparatorChar));
         }
 
         [Test]
         public void CanDiscoverAStandardRepoGivenTheRepoPath()
         {
-            string path = Repository.Discover(Constants.StandardTestRepoPath);
-            path.ShouldEqual(Path.GetFullPath(Constants.StandardTestRepoPath + Path.DirectorySeparatorChar));
+            string path = Repository.Discover(StandardTestRepoPath);
+            path.ShouldEqual(Path.GetFullPath(StandardTestRepoPath + Path.DirectorySeparatorChar));
         }
 
         [Test]
         public void CanDiscoverAStandardRepoGivenASubDirectoryOfTheRepoPath()
         {
-            string path = Repository.Discover(Path.Combine(Constants.StandardTestRepoPath, "objects/4a"));
-            path.ShouldEqual(Path.GetFullPath(Constants.StandardTestRepoPath + Path.DirectorySeparatorChar));
+            string path = Repository.Discover(Path.Combine(StandardTestRepoPath, "objects/4a"));
+            path.ShouldEqual(Path.GetFullPath(StandardTestRepoPath + Path.DirectorySeparatorChar));
         }
 
         [Test]
         public void CanDiscoverAStandardRepoGivenTheWorkingDirPath()
         {
-            string path = Repository.Discover(Constants.StandardTestRepoWorkingDirPath);
-            path.ShouldEqual(Path.GetFullPath(Constants.StandardTestRepoPath + Path.DirectorySeparatorChar));
+            string path = Repository.Discover(StandardTestRepoWorkingDirPath);
+            path.ShouldEqual(Path.GetFullPath(StandardTestRepoPath + Path.DirectorySeparatorChar));
         }
 
         [Test]

--- a/LibGit2Sharp.Tests/TagFixture.cs
+++ b/LibGit2Sharp.Tests/TagFixture.cs
@@ -198,7 +198,7 @@ namespace LibGit2Sharp.Tests
         [Description("Ported from cgit (https://github.com/git/git/blob/1c08bf50cfcf924094eca56c2486a90e2bf1e6e2/t/t7004-tag.sh#L42)")]
         public void CreatingATagForAnUnknowReferenceThrows()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<LibGit2Exception>(() => repo.ApplyTag("mytagnorev", "aaaaaaaaaaa"));
             }
@@ -207,7 +207,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CreatingATagForANonCanonicalReferenceThrows()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<LibGit2Exception>(() => repo.ApplyTag("noncanonicaltarget", "br2"));
             }
@@ -217,7 +217,7 @@ namespace LibGit2Sharp.Tests
         [Description("Ported from cgit (https://github.com/git/git/blob/1c08bf50cfcf924094eca56c2486a90e2bf1e6e2/t/t7004-tag.sh#L42)")]
         public void CreatingATagForAnUnknowObjectIdThrows()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<LibGit2Exception>(() => repo.ApplyTag("mytagnorev", Constants.UnknownSha));
             }
@@ -257,7 +257,7 @@ namespace LibGit2Sharp.Tests
         [Description("Ported from cgit (https://github.com/git/git/blob/1c08bf50cfcf924094eca56c2486a90e2bf1e6e2/t/t7004-tag.sh#L90)")]
         public void CreatingATagWithANonValidNameShouldFail()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<ArgumentException>(() => repo.ApplyTag(""));
                 Assert.Throws<LibGit2Exception>(() => repo.ApplyTag(".othertag"));
@@ -364,7 +364,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void BlindlyCreatingALightweightTagOverAnExistingOneThrows()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<LibGit2Exception>(() => repo.Tags.Create("e90810b", "refs/heads/br2"));
             }
@@ -373,7 +373,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void BlindlyCreatingAnAnnotatedTagOverAnExistingOneThrows()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<LibGit2Exception>(() => repo.Tags.Create("e90810b", "refs/heads/br2", signatureNtk, "a nice message"));
             }
@@ -382,7 +382,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CreateTagWithADuplicateNameThrows()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<LibGit2Exception>(() => repo.Tags.Create("test", tagTestSha, signatureTim, "message"));
             }
@@ -391,7 +391,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CreateTagWithEmptyNameThrows()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<ArgumentException>(() => repo.Tags.Create(string.Empty, "refs/heads/master", signatureTim, "message"));
             }
@@ -400,7 +400,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CreateTagWithEmptyTargetThrows()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<ArgumentException>(() => repo.Tags.Create("test_tag", string.Empty, signatureTim, "message"));
             }
@@ -409,7 +409,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CreateTagWithNotExistingTargetThrows()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<LibGit2Exception>(() => repo.Tags.Create("test_tag", Constants.UnknownSha, signatureTim, "message"));
             }
@@ -418,7 +418,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CreateTagWithNullMessageThrows()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<ArgumentNullException>(() => repo.Tags.Create("test_tag", "refs/heads/master", signatureTim, null));
             }
@@ -427,7 +427,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CreateTagWithNullNameThrows()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<ArgumentNullException>(() => repo.Tags.Create(null, "refs/heads/master", signatureTim, "message"));
             }
@@ -436,7 +436,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CreateTagWithNullSignatureThrows()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<ArgumentNullException>(() => repo.Tags.Create("test_tag", "refs/heads/master", null, "message"));
             }
@@ -445,7 +445,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CreateTagWithNullTargetThrows()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<ArgumentNullException>(() => repo.Tags.Create("test_tag", null, signatureTim, "message"));
             }
@@ -508,7 +508,7 @@ namespace LibGit2Sharp.Tests
         [Description("Ported from cgit (https://github.com/git/git/blob/1c08bf50cfcf924094eca56c2486a90e2bf1e6e2/t/t7004-tag.sh#L108)")]
         public void DeletingAnUnknownTagShouldFail()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<LibGit2Exception>(() => repo.Tags.Delete("unknown-tag"));
             }
@@ -517,7 +517,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void GetTagByNameWithBadParamsThrows()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Tag tag;
                 Assert.Throws<ArgumentNullException>(() => tag = repo.Tags[null]);
@@ -528,7 +528,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanListTags()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 CollectionAssert.AreEqual(expectedTags, repo.Tags.Select(t => t.Name).ToArray());
 
@@ -554,7 +554,7 @@ namespace LibGit2Sharp.Tests
         [Description("Ported from cgit (https://github.com/git/git/blob/1c08bf50cfcf924094eca56c2486a90e2bf1e6e2/t/t7004-tag.sh#L165)")]
         public void ListAllTagsShouldOutputThemInAnOrderedWay()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 List<string> tagNames = repo.Tags.Select(t => t.Name).ToList();
 
@@ -568,7 +568,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanLookupALightweightTag()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Tag tag = repo.Tags["lw"];
                 tag.ShouldNotBeNull();
@@ -583,7 +583,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanLookupATagByItsCanonicalName()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Tag tag = repo.Tags["refs/tags/lw"];
                 tag.ShouldNotBeNull();
@@ -601,7 +601,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanLookupAnAnnotatedTag()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Tag tag = repo.Tags["e90810b"];
                 tag.ShouldNotBeNull();
@@ -621,7 +621,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void LookupEmptyTagNameThrows()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<ArgumentException>(() => { Tag t = repo.Tags[string.Empty]; });
             }
@@ -630,7 +630,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void LookupNullTagNameThrows()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<ArgumentNullException>(() => { Tag t = repo.Tags[null]; });
             }

--- a/LibGit2Sharp.Tests/TestHelpers/BaseFixture.cs
+++ b/LibGit2Sharp.Tests/TestHelpers/BaseFixture.cs
@@ -15,23 +15,33 @@ namespace LibGit2Sharp.Tests.TestHelpers
             SetUpTestEnvironment();
         }
 
+        public static string BareTestRepoPath { get; private set; }
+        public static string StandardTestRepoWorkingDirPath { get; private set; }
+        public static string StandardTestRepoPath { get; private set; }
+        public static DirectoryInfo ResourcesDirectory { get; private set; }
+
         private static void SetUpTestEnvironment()
         {
             var source = new DirectoryInfo(@"../../Resources");
-            var target = new DirectoryInfo(@"Resources");
+            ResourcesDirectory = new DirectoryInfo(string.Format(@"Resources/{0}", Guid.NewGuid()));
+            var parent = new DirectoryInfo(@"Resources");
 
-            if (target.Exists)
+            if (parent.Exists)
             {
-                target.Delete(recursive: true);
+                DirectoryHelper.DeleteSubdirectories(parent.FullName);
             }
 
-            DirectoryHelper.CopyFilesRecursively(source, target);
+            DirectoryHelper.CopyFilesRecursively(source, ResourcesDirectory);
+
+            // Setup standard paths to our test repositories
+            BareTestRepoPath = Path.Combine(ResourcesDirectory.FullName, "testrepo.git");
+            StandardTestRepoWorkingDirPath = Path.Combine(ResourcesDirectory.FullName, "testrepo_wd");
+            StandardTestRepoPath = Path.Combine(StandardTestRepoWorkingDirPath, ".git");
 
             // The test repo under source control has its .git folder renamed to dot_git to avoid confusing git,
             // so we need to rename it back to .git in our copy under the target folder
-
-            string tempDotGit = Path.Combine(Constants.StandardTestRepoWorkingDirPath, "dot_git");
-            Directory.Move(tempDotGit, Constants.StandardTestRepoPath);
+            string tempDotGit = Path.Combine(StandardTestRepoWorkingDirPath, "dot_git");
+            Directory.Move(tempDotGit, StandardTestRepoPath);
         }
 
         protected void CreateCorruptedDeadBeefHead(string repoPath)
@@ -53,7 +63,7 @@ namespace LibGit2Sharp.Tests.TestHelpers
 
         protected TemporaryCloneOfTestRepo BuildTemporaryCloneOfTestRepo()
         {
-            return BuildTemporaryCloneOfTestRepo(Constants.BareTestRepoPath);
+            return BuildTemporaryCloneOfTestRepo(BareTestRepoPath);
         }
 
         protected TemporaryCloneOfTestRepo BuildTemporaryCloneOfTestRepo(string path)

--- a/LibGit2Sharp.Tests/TestHelpers/Constants.cs
+++ b/LibGit2Sharp.Tests/TestHelpers/Constants.cs
@@ -1,13 +1,9 @@
 ﻿using System;
-using System.IO;
 
 namespace LibGit2Sharp.Tests.TestHelpers
 {
     public static class Constants
     {
-        public const string BareTestRepoPath = "./Resources/testrepo.git";
-        public const string StandardTestRepoWorkingDirPath = "./Resources/testrepo_wd";
-        public static string StandardTestRepoPath = Path.Combine(StandardTestRepoWorkingDirPath, ".git");
         public const string TemporaryReposPath = "TestRepos";
         public const string UnknownSha = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
         public static readonly Signature Signature = new Signature("A. U. Thor", "thor@valhalla.asgard.com", new DateTimeOffset(2011, 06, 16, 10, 58, 27, TimeSpan.FromHours(2)));

--- a/LibGit2Sharp.Tests/TestHelpers/DirectoryHelper.cs
+++ b/LibGit2Sharp.Tests/TestHelpers/DirectoryHelper.cs
@@ -18,6 +18,15 @@ namespace LibGit2Sharp.Tests.TestHelpers
             }
         }
 
+        public static void DeleteSubdirectories(string parentPath)
+        {
+            string[] dirs = Directory.GetDirectories(parentPath);
+            foreach (string dir in dirs)
+            {
+                DeleteDirectory(dir);
+            }
+        }
+
         public static void DeleteDirectory(string directoryPath)
         {
             // From http://stackoverflow.com/questions/329355/cannot-delete-directory-with-directory-deletepath-true/329502#329502

--- a/LibGit2Sharp.Tests/TreeFixture.cs
+++ b/LibGit2Sharp.Tests/TreeFixture.cs
@@ -12,7 +12,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanCompareTwoTreeEntries()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 var tree = repo.Lookup<Tree>(sha);
                 TreeEntry treeEntry1 = tree["README"];
@@ -25,7 +25,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanConvertEntryToBlob()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 var tree = repo.Lookup<Tree>(sha);
                 TreeEntry treeEntry = tree["README"];
@@ -38,7 +38,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanConvertEntryToTree()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 var tree = repo.Lookup<Tree>(sha);
                 TreeEntry treeEntry = tree["1"];
@@ -51,7 +51,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanEnumerateBlobs()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 var tree = repo.Lookup<Tree>(sha);
                 tree.Files.Count().ShouldEqual(3);
@@ -61,7 +61,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanEnumerateSubTrees()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 var tree = repo.Lookup<Tree>(sha);
                 tree.Trees.Count().ShouldEqual(1);
@@ -71,7 +71,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanEnumerateTreeEntries()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 var tree = repo.Lookup<Tree>(sha);
                 tree.Count().ShouldEqual(tree.Count);
@@ -83,7 +83,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanGetEntryByName()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 var tree = repo.Lookup<Tree>(sha);
                 TreeEntry treeEntry = tree["README"];
@@ -95,7 +95,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void GettingAnUknownTreeEntryReturnsNull()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 var tree = repo.Lookup<Tree>(sha);
                 TreeEntry treeEntry = tree["I-do-not-exist"];
@@ -106,7 +106,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanGetEntryCountFromTree()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 var tree = repo.Lookup<Tree>(sha);
                 tree.Count.ShouldEqual(4);
@@ -116,7 +116,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanReadEntryAttributes()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 var tree = repo.Lookup<Tree>(sha);
                 tree["README"].Attributes.ShouldEqual(33188);
@@ -126,7 +126,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanReadTheTreeData()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 var tree = repo.Lookup<Tree>(sha);
                 tree.ShouldNotBeNull();
@@ -136,7 +136,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void TreeDataIsPresent()
         {
-            using (var repo = new Repository(Constants.BareTestRepoPath))
+            using (var repo = new Repository(BareTestRepoPath))
             {
                 GitObject tree = repo.Lookup(sha);
                 tree.ShouldNotBeNull();


### PR DESCRIPTION
This fixes what has been a huge pain for me in running the libgit2sharp unit tests lately. I think the issue is that different test runners end up preventing the Resources directory from getting cleaned/deleted. You often end up having to run the test(s) 2 or 3 times before they will actually run. The solution in this commit is to create a unique resources directory for each test run while still trying to cleanup the directories from the previous run. If there are still issues, we could let the cleanup step gracefully fail (leaving behind the previous run temp dir) and defer that cleanup until the next time the tests are run.
