### PR TITLE
Make IndexEntry to cope with native Windows directory separator char

### DIFF
--- a/LibGit2Sharp.Tests/IndexFixture.cs
+++ b/LibGit2Sharp.Tests/IndexFixture.cs
@@ -531,5 +531,45 @@ namespace LibGit2Sharp.Tests
                 repoStatus.Added.Single().ShouldEqual(statusEntry.FilePath);
             }
         }
+
+        [Test]
+        public void RetrievingNativeFilePathsFromIndexEntries()
+        {
+            // Initialize a new repository
+            SelfCleaningDirectory scd = BuildSelfCleaningDirectory();
+            string dir = Repository.Init(scd.DirectoryPath);
+            
+            const string directoryName = "directory";
+            const string fileName = "Testfile.txt";
+            
+            // Create a file and insert some content
+            string directoryPath = Path.Combine(scd.RootedDirectoryPath, directoryName);
+            string filePath = Path.Combine(directoryPath, fileName);
+            
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(filePath, "Anybody out there?");
+               
+            // Open the repository
+            using (Repository repo = new Repository(dir))
+            {
+                // Stage the file
+                repo.Index.Stage(filePath);
+                
+                // Get the index
+                Index index = repo.Index;
+                
+                // Build relative path
+                string relFilePath = Path.Combine(directoryName, fileName);
+                
+                // Get the index entry
+                IndexEntry ie = index[relFilePath];
+                
+                // Make sure the IndexEntry could be found
+                Assert.NotNull(ie);
+                
+                // Make sure that the (native) relFilePath and ie.Path are equal
+                ie.Path.ShouldEqual(relFilePath);
+            }
+        }
     }
 }

--- a/LibGit2Sharp/Index.cs
+++ b/LibGit2Sharp/Index.cs
@@ -43,6 +43,9 @@ namespace LibGit2Sharp
         {
             get
             {
+
+                path = PosixPathHelper.ToPosix(path);
+
                 Ensure.ArgumentNotNullOrEmptyString(path, "path");
 
                 int res = NativeMethods.git_index_find(handle, path);

--- a/LibGit2Sharp/IndexEntry.cs
+++ b/LibGit2Sharp/IndexEntry.cs
@@ -35,7 +35,7 @@ namespace LibGit2Sharp
             var entry = (GitIndexEntry)Marshal.PtrToStructure(ptr, typeof(GitIndexEntry));
             return new IndexEntry
                        {
-                           Path = entry.Path,
+                           Path = PosixPathHelper.ToNative(entry.Path),
                            Id = new ObjectId(entry.oid),
                            state = () => repo.Index.RetrieveStatus(entry.Path)
                        };


### PR DESCRIPTION
A few changes to make IndexEntry object to cope with windows paths.

Test is included.
