### PR TITLE
Enable build with mono on Ubuntu 11.10

### DIFF
--- a/LibGit2Sharp.Tests/LazyFixture.cs
+++ b/LibGit2Sharp.Tests/LazyFixture.cs
@@ -11,7 +11,7 @@ namespace LibGit2Sharp.Tests
         [Test]
         public void CanReturnTheValue()
         {
-            var lazy = new Lazy<int>(() => 2);
+            var lazy = new LibGit2Sharp.Core.Lazy<int>(() => 2);
             lazy.Value.ShouldEqual(2);
         }
 
@@ -22,7 +22,7 @@ namespace LibGit2Sharp.Tests
 
             var evaluator = new Func<int>(() => ++i);
 
-            var lazy = new Lazy<int>(evaluator);
+            var lazy = new LibGit2Sharp.Core.Lazy<int>(evaluator);
             lazy.Value.ShouldEqual(1);
         }
 
@@ -33,7 +33,7 @@ namespace LibGit2Sharp.Tests
 
             var evaluator = new Func<int>(() => ++i);
 
-            var lazy = new Lazy<int>(evaluator);
+            var lazy = new LibGit2Sharp.Core.Lazy<int>(evaluator);
 
             lazy.Value.ShouldEqual(1);
             lazy.Value.ShouldEqual(1);

--- a/LibGit2Sharp/Branch.cs
+++ b/LibGit2Sharp/Branch.cs
@@ -13,7 +13,7 @@ namespace LibGit2Sharp
         private static readonly LambdaEqualityHelper<Branch> equalityHelper =
             new LambdaEqualityHelper<Branch>(new Func<Branch, object>[] { x => x.CanonicalName, x => x.Tip });
 
-        private readonly Lazy<Branch> trackedBranch;
+        private readonly LibGit2Sharp.Core.Lazy<Branch> trackedBranch;
 
         /// <summary>
         ///   Initializes a new instance of the <see cref = "Branch" /> class.
@@ -42,7 +42,7 @@ namespace LibGit2Sharp
         private Branch(Repository repo, Reference reference, Func<Reference, string> canonicalNameSelector)
             : base(repo, reference, canonicalNameSelector)
         {
-            trackedBranch = new Lazy<Branch>(ResolveTrackedBranch);
+            trackedBranch = new LibGit2Sharp.Core.Lazy<Branch>(ResolveTrackedBranch);
         }
 
         /// <summary>

--- a/LibGit2Sharp/Commit.cs
+++ b/LibGit2Sharp/Commit.cs
@@ -11,16 +11,16 @@ namespace LibGit2Sharp
     public class Commit : GitObject
     {
         private readonly Repository repo;
-        private readonly Lazy<IEnumerable<Commit>> parents;
-        private readonly Lazy<Tree> tree;
-        private readonly Lazy<string> shortMessage;
+        private readonly LibGit2Sharp.Core.Lazy<IEnumerable<Commit>> parents;
+        private readonly LibGit2Sharp.Core.Lazy<Tree> tree;
+        private readonly LibGit2Sharp.Core.Lazy<string> shortMessage;
 
         internal Commit(ObjectId id, ObjectId treeId, Repository repo)
             : base(id)
         {
-            tree = new Lazy<Tree>(() => repo.Lookup<Tree>(treeId));
-            parents = new Lazy<IEnumerable<Commit>>(() => RetrieveParentsOfCommit(id));
-            shortMessage = new Lazy<string>(ExtractShortMessage);
+            tree = new LibGit2Sharp.Core.Lazy<Tree>(() => repo.Lookup<Tree>(treeId));
+            parents = new LibGit2Sharp.Core.Lazy<IEnumerable<Commit>>(() => RetrieveParentsOfCommit(id));
+            shortMessage = new LibGit2Sharp.Core.Lazy<string>(ExtractShortMessage);
             this.repo = repo;
         }
 

--- a/LibGit2Sharp/Configuration.cs
+++ b/LibGit2Sharp/Configuration.cs
@@ -115,7 +115,12 @@ namespace LibGit2Sharp
             systemHandle.SafeDispose();
         }
 
-        private static T ProcessReadResult<T>(int res, T value, T defaultValue, Func<object, T> postProcessor = null)
+        private static T ProcessReadResult<T>(int res, T value, T defaultValue)
+        {
+            return ProcessReadResult<T>(res, value, defaultValue, null);
+        }
+
+        private static T ProcessReadResult<T>(int res, T value, T defaultValue, Func<object, T> postProcessor)
         {
             if (res == (int)GitErrorCode.GIT_ENOTFOUND)
             {

--- a/LibGit2Sharp/NamedReference.cs
+++ b/LibGit2Sharp/NamedReference.cs
@@ -6,7 +6,7 @@ namespace LibGit2Sharp
     public abstract class NamedReference<TObject> where TObject : GitObject
     {
         protected readonly Repository repo;
-        private readonly Lazy<TObject> objectBuilder;
+        private readonly LibGit2Sharp.Core.Lazy<TObject> objectBuilder;
 
         protected internal NamedReference(Repository repo, Reference reference, Func<Reference, string> canonicalNameSelector)
         {
@@ -15,7 +15,7 @@ namespace LibGit2Sharp
 
             this.repo = repo;
             CanonicalName = canonicalNameSelector(reference);
-            objectBuilder = new Lazy<TObject>(() => RetrieveTargetObject(reference));
+            objectBuilder = new LibGit2Sharp.Core.Lazy<TObject>(() => RetrieveTargetObject(reference));
         }
 
         /// <summary>

--- a/LibGit2Sharp/Reference.cs
+++ b/LibGit2Sharp/Reference.cs
@@ -61,7 +61,7 @@ namespace LibGit2Sharp
                     var oid = (GitOid)Marshal.PtrToStructure(oidPtr, typeof(GitOid));
                     var targetOid = new ObjectId(oid);
 
-                    var targetBuilder = new Lazy<GitObject>(() => repo.Lookup(targetOid));
+                    var targetBuilder = new LibGit2Sharp.Core.Lazy<GitObject>(() => repo.Lookup(targetOid));
                     reference = new DirectReference(targetBuilder) { CanonicalName = name, TargetIdentifier = targetOid.Sha };
                     break;
 

--- a/LibGit2Sharp/Repository.cs
+++ b/LibGit2Sharp/Repository.cs
@@ -11,13 +11,13 @@ namespace LibGit2Sharp
     {
         private readonly BranchCollection branches;
         private readonly CommitCollection commits;
-        private readonly Lazy<Configuration> config;
+        private readonly LibGit2Sharp.Core.Lazy<Configuration> config;
         private readonly RepositorySafeHandle handle;
         private readonly Index index;
         private readonly ReferenceCollection refs;
-        private readonly Lazy<RemoteCollection> remotes;
+        private readonly LibGit2Sharp.Core.Lazy<RemoteCollection> remotes;
         private readonly TagCollection tags;
-        private readonly Lazy<RepositoryInformation> info;
+        private readonly LibGit2Sharp.Core.Lazy<RepositoryInformation> info;
         private readonly bool isBare;
 
         /// <summary>
@@ -43,9 +43,9 @@ namespace LibGit2Sharp
             refs = new ReferenceCollection(this);
             branches = new BranchCollection(this);
             tags = new TagCollection(this);
-            info = new Lazy<RepositoryInformation>(() => new RepositoryInformation(this, isBare));
-            config = new Lazy<Configuration>(() => new Configuration(this));
-            remotes = new Lazy<RemoteCollection>(() => new RemoteCollection(this));
+            info = new LibGit2Sharp.Core.Lazy<RepositoryInformation>(() => new RepositoryInformation(this, isBare));
+            config = new LibGit2Sharp.Core.Lazy<Configuration>(() => new Configuration(this));
+            remotes = new LibGit2Sharp.Core.Lazy<RemoteCollection>(() => new RemoteCollection(this));
         }
 
         internal RepositorySafeHandle Handle

--- a/LibGit2Sharp/TagAnnotation.cs
+++ b/LibGit2Sharp/TagAnnotation.cs
@@ -9,7 +9,7 @@ namespace LibGit2Sharp
     /// </summary>
     public class TagAnnotation : GitObject
     {
-        private Lazy<GitObject> targetBuilder;
+        private LibGit2Sharp.Core.Lazy<GitObject> targetBuilder;
 
         internal TagAnnotation(ObjectId id)
             : base(id)
@@ -49,7 +49,7 @@ namespace LibGit2Sharp
                            Message = NativeMethods.git_tag_message(obj).MarshallAsString(),
                            Name = NativeMethods.git_tag_name(obj).MarshallAsString(),
                            Tagger = new Signature(NativeMethods.git_tag_tagger(obj)),
-                           targetBuilder = new Lazy<GitObject>(() => repo.Lookup<GitObject>(new ObjectId(oid)))
+                           targetBuilder = new LibGit2Sharp.Core.Lazy<GitObject>(() => repo.Lookup<GitObject>(new ObjectId(oid)))
                        };
         }
     }

--- a/LibGit2Sharp/TreeEntry.cs
+++ b/LibGit2Sharp/TreeEntry.cs
@@ -11,7 +11,7 @@ namespace LibGit2Sharp
     {
         private readonly ObjectId parentTreeId;
         private readonly Repository repo;
-        private readonly Lazy<GitObject> target;
+        private readonly LibGit2Sharp.Core.Lazy<GitObject> target;
         private readonly ObjectId targetOid;
 
         private static readonly LambdaEqualityHelper<TreeEntry> equalityHelper =
@@ -24,7 +24,7 @@ namespace LibGit2Sharp
             IntPtr gitTreeEntryId = NativeMethods.git_tree_entry_id(obj);
             targetOid = new ObjectId((GitOid)Marshal.PtrToStructure(gitTreeEntryId, typeof(GitOid)));
             Type = NativeMethods.git_tree_entry_type(obj);
-            target = new Lazy<GitObject>(RetreiveTreeEntryTarget);
+            target = new LibGit2Sharp.Core.Lazy<GitObject>(RetreiveTreeEntryTarget);
 
             Attributes = NativeMethods.git_tree_entry_attributes(obj);
             Name = NativeMethods.git_tree_entry_name(obj).MarshallAsString();


### PR DESCRIPTION
Hi @ALL,

I made some changes to be able to build the library on an Ubuntu 11.10 system using mono.

Most of the changes affected the Core.Lazy object.
Mono has a Lazy class in the System namespace so there were some naming conflicts.

I tested it on WinXP and VisualStudio on the same branch.
All tests and builds were not affected. (As far as I can see..., please review!)

If you are not interested in this changes... Simply close this pull request ;-)
