### PR TITLE
Fixed Index.Remove() 

### DIFF
--- a/LibGit2Sharp.Tests/IndexFixture.cs
+++ b/LibGit2Sharp.Tests/IndexFixture.cs
@@ -479,7 +479,7 @@ namespace LibGit2Sharp.Tests
         }
 
         [TestCase("deleted_staged_file.txt")]
-        [TestCase("deleted_unstaged_file.txt")]
+        [TestCase("modified_unstaged_file.txt")]
         [TestCase("shadowcopy_of_an_unseen_ghost.txt")]
         public void RemovingAInvalidFileThrows(string filepath)
         {

--- a/LibGit2Sharp/Index.cs
+++ b/LibGit2Sharp/Index.cs
@@ -335,7 +335,7 @@ namespace LibGit2Sharp
                     throw new NotImplementedException();
                 }
 
-                if (!keyValuePair.Value.HasAny(new[] { FileStatus.Missing, FileStatus.Nonexistent, FileStatus.Removed, FileStatus.Untracked }))
+                if (!keyValuePair.Value.HasAny(new[] { FileStatus.Nonexistent, FileStatus.Removed, FileStatus.Modified, FileStatus.Untracked }))
                 {
                     continue;
                 }
@@ -347,7 +347,11 @@ namespace LibGit2Sharp
             foreach (KeyValuePair<string, FileStatus> keyValuePair in batch)
             {
                 RemoveFromIndex(keyValuePair.Key);
-                File.Delete(Path.Combine(wd, keyValuePair.Key));
+
+                if (File.Exists(Path.Combine(wd, keyValuePair.Key)))
+                {
+                    File.Delete(Path.Combine(wd, keyValuePair.Key));
+                }
             }
 
             UpdatePhysicalIndex();


### PR DESCRIPTION
The following changes have been made:
- Modified files can no longer be removed (prevent loss of uncommited changes)
- Files with FileStatus Missing can be removed
- Updated test `RemovingAInvalidFileThrows` 

Please review the changed TestCase parameters.
I want to make sure they are correct. Thanks.
