### PR TITLE
Ref slash prefix workaround (empty branches collection)

### DIFF
--- a/LibGit2Sharp.Tests/BranchFixture.cs
+++ b/LibGit2Sharp.Tests/BranchFixture.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Linq;
 using LibGit2Sharp.Tests.TestHelpers;
 using NUnit.Framework;
@@ -164,6 +165,20 @@ namespace LibGit2Sharp.Tests
                 CollectionAssert.AreEqual(expectedBranches, repo.Branches.Select(b => b.Name).ToArray());
 
                 repo.Branches.Count().ShouldEqual(5);
+            }
+        }
+
+        [Test]
+        public void CanListAllBranchesWhenGivenWorkingDir()
+        {
+            TemporaryCloneOfTestRepo path = BuildTemporaryCloneOfTestRepo(StandardTestRepoWorkingDirPath);
+            using (var repo = new Repository(path.DirectoryPath))
+            {
+                var expectedWdBranches = new[] { "master", "origin/HEAD", "origin/br2", "origin/master", "origin/packed-test", "origin/test" };
+
+                CollectionAssert.AreEqual(expectedWdBranches, repo.Branches.Select(b => b.Name).ToArray());
+
+                repo.Branches.Count().ShouldEqual(6);
             }
         }
 


### PR DESCRIPTION
When libgit2 is passed a path to a working directory instead of a git directory the names returned from git_reference_listall (and perhaps other similar methods) will apparently be prefixed with a slash such that instead of refs/heads/master it'll return /refs/heads/master.

I'm at fault for not reading the constructor documentation for Repository which does say that you should give it the path to the .git-directory, not the working directory. But since it worked for the trivial stuff I was doing I didn't notice it until I tried retrieving all branches and repo.Branches was empty. Digging into the code I saw that LibGit2Sharp calls [git_reference_listall](https://github.com/libgit2/libgit2/blob/20c50b9e16c19bbbf7cf38bb4bd3177596bce61b/src/refs.c#L1553-1580) (through [Libgit2UnsafeHelper.ListAllReferenceNames](https://github.com/libgit2/libgit2sharp/blob/e32dba45b0edc7283833d2daad19a5ccc6a6452c/LibGit2Sharp/Core/Libgit2UnsafeHelper.cs#L8-15)) and then filters the output using the [LooksLikeABranchName](https://github.com/libgit2/libgit2sharp/blob/5ae0c34d1a8af43e124466352bf33ead5f128f56/LibGit2Sharp/BranchCollection.cs#L144-147) predicate.

When I called [ListAllReferenceNames](https://github.com/libgit2/libgit2sharp/blob/e32dba45b0edc7283833d2daad19a5ccc6a6452c/LibGit2Sharp/Core/Libgit2UnsafeHelper.cs#L8-15) myself I saw that it was returning the refs with a slash prefixed (/refs/heads/...) and then noticed that it was only doing so when I opened a repository with the path to a working directory instead of a git directory.

Perhaps I shouldn't try to load a repo witha working directory at all but since libgit2 seems to support it (see https://github.com/libgit2/libgit2/blob/development/src/repository.c#L164-171) I thought I should at least open an issue.

My workaround does more or less exactly what libgit2 does, it checks for the presence of a .git-directory under the path given to the constructor and if it exists it replaces the path provided with the path to the .git-directory before passing it on to libgit2.
