### PR TITLE
Switch submodule to use HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libgit2"]
 	path = libgit2
-	url = http://github.com/libgit2/libgit2.git
+	url = https://github.com/libgit2/libgit2.git


### PR DESCRIPTION
When I added libgit2sharp as a submodule, I would prefer to use anonymous read-only access for the initial clone for the libgit2 submodule
