### PR TITLE
Setting a remote named "origin" doesn't save it properly.

### DIFF
--- a/LibGit2Sharp.Tests/RepositoryFixture.cs
+++ b/LibGit2Sharp.Tests/RepositoryFixture.cs
@@ -348,5 +348,32 @@ namespace LibGit2Sharp.Tests
 
             File.Delete(path);
         }
+
+        [Test]
+        public void CanSetARemote()
+        {
+            SelfCleaningDirectory scd = BuildSelfCleaningDirectory();
+            using (var repo = Repository.Init(scd.DirectoryPath, true))
+            {
+                repo.Config.Set("remote.origin.url", "http://example.com");
+
+                repo.Config.Get<string>("remote", "origin", "url", null).ShouldEqual("http://example.com");
+                repo.Remotes["origin"].ShouldEqual("http://example.com");
+            }
+        }
+
+        [Test]
+        public void SettingARemoteSavesIt()
+        {
+            SelfCleaningDirectory scd = BuildSelfCleaningDirectory();
+            using (var repo = Repository.Init(scd.DirectoryPath, true))
+            {
+                repo.Config.Set("remote.origin.url", "http://example.com");
+
+                var newRepo = new Repository(repo.Info.Path);
+                newRepo.Config.Get<string>("remote", "origin", "url", null).ShouldEqual("http://example.com");
+                newRepo.Remotes["origin"].ShouldEqual("http://example.com");
+            }
+        }
     }
 }


### PR DESCRIPTION
Please take a look at the two unit tests I added. I think they should pass, but they fail. The problem seems to be that setting the origin url doesn't allow you to retrieve the setting you just saved.

If you create a new instance of repository pointing to the same directory, you can retrieve it via the `Configuration` property of `Repository`.

However, in all cases, `repository.Remotes["origin"]` returns null.
