### PR TITLE
Exposed git_merge_base as CommitCollection.GetMergeBase(...)

### DIFF
--- a/LibGit2Sharp/CommitCollection.cs
+++ b/LibGit2Sharp/CommitCollection.cs
@@ -125,6 +125,61 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
+        /// Find as good common ancestors as possible for a merge given two <see cref="Commit"/>.
+        /// </summary>
+        /// <param name="first">The first <see cref="Commit"/> for which to find the common ancestor.</param>
+        /// <param name="second">The second <see cref="Commit"/> for which to find the common ancestor.</param>
+        /// <returns>The common ancestor or null if none found.</returns>
+        public Commit FindCommonAncestor(Commit first, Commit second)
+        {
+            Ensure.ArgumentNotNull(first, "first");
+            Ensure.ArgumentNotNull(second, "second");
+            GitOid ret;
+            using (var osw1 = new ObjectSafeWrapper(first.Id, this.repo))
+            using (var osw2 = new ObjectSafeWrapper(second.Id, this.repo))
+            {
+                int result = NativeMethods.git_merge_base(out ret, this.repo.Handle, osw1.ObjectPtr, osw2.ObjectPtr);
+                if (result == (int)GitErrorCode.GIT_ENOTFOUND)
+                    return null;
+
+                Ensure.Success(result);
+                return this.repo.Lookup<Commit>(new ObjectId(ret));
+            }
+        }
+
+        /// <summary>
+        /// Find as good common ancestors as possible for a merge given two or more <see cref="Commit"/>.
+        /// </summary>
+        /// <param name="commits">The <see cref="Commit"/> for which to find the common ancestor.</param>
+        /// <returns>The common ancestor or null if none found.</returns>
+        public Commit FindCommonAncestor(IEnumerable<Commit> commits)
+        {
+            Ensure.ArgumentNotNull(commits, "commits");
+            Commit ret = null;
+            int count = 0;
+            foreach (var commit in commits)
+            {
+                if (commit == null)
+                    throw new ArgumentException("Enumerable contains null at position: " + count.ToString(CultureInfo.InvariantCulture), "commits");
+
+                count++;
+
+                if (ret == null)
+                    ret = commit;
+                else
+                {
+                    ret = this.FindCommonAncestor(ret, commit);
+                    if (ret == null)
+                        break;
+                }
+            }
+            if (count < 2)
+                throw new ArgumentException("The enumerable must contains at least two commits.", "commits");
+
+            return ret;
+        }
+
+        /// <summary>
         ///   Stores the content of the <see cref = "Repository.Index" /> as a new <see cref = "Commit" /> into the repository.
         ///   The tip of the <see cref = "Repository.Head"/> will be used as the parent of this new Commit.
         ///   Once the commit is created, the <see cref = "Repository.Head"/> will move forward to point at it.

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -327,6 +327,13 @@ namespace LibGit2Sharp.Core
         public static extern int git_index_write(IndexSafeHandle index);
 
         [DllImport(libgit2)]
+        public static extern int git_merge_base(
+            out GitOid mergeBase,
+            RepositorySafeHandle repo,
+            GitObjectSafeHandle one,
+            GitObjectSafeHandle two);
+
+        [DllImport(libgit2)]
         public static extern int git_odb_exists(ObjectDatabaseSafeHandle odb, ref GitOid id);
 
         [DllImport(libgit2)]

--- a/LibGit2Sharp/IQueryableCommitCollection.cs
+++ b/LibGit2Sharp/IQueryableCommitCollection.cs
@@ -1,4 +1,6 @@
-﻿namespace LibGit2Sharp
+﻿using System.Collections.Generic;
+
+namespace LibGit2Sharp
 {
     public interface IQueryableCommitCollection : ICommitCollection //TODO: Find a name that's more explicit than IQueryableCommitCollection
     {
@@ -20,5 +22,21 @@
         /// <param name = "amendPreviousCommit">True to amend the current <see cref = "Commit"/> pointed at by <see cref = "Repository.Head"/>, false otherwise.</param>
         /// <returns>The generated <see cref = "Commit" />.</returns>
         Commit Create(string message, Signature author, Signature committer, bool amendPreviousCommit);
+
+
+        /// <summary>
+        /// Find as good common ancestors as possible for a merge given two <see cref="Commit"/>.
+        /// </summary>
+        /// <param name="first">The first <see cref="Commit"/> for which to find the common ancestor.</param>
+        /// <param name="second">The second <see cref="Commit"/> for which to find the common ancestor.</param>
+        /// <returns>The common ancestor or null if none found.</returns>
+        Commit FindCommonAncestor(Commit first, Commit second);
+
+        /// <summary>
+        /// Find as good common ancestors as possible for a merge given two or more <see cref="Commit"/>.
+        /// </summary>
+        /// <param name="commits">The <see cref="Commit"/> for which to find the common ancestor.</param>
+        /// <returns>The common ancestor or null if none found.</returns>
+        Commit FindCommonAncestor(IEnumerable<Commit> commits);
     }
 }


### PR DESCRIPTION
Take two, now that @nulltoken updated the libgit2 version.

Contains three overloads:

``` csharp
Commit GetMergeBase(Commit first, Commit second);
Commit GetMergeBase(IEnumerable<Commit> commits);
Commit GetMergeBase(Commit first, Commit second, params Commit[] rest);
```
