### PR TITLE
Exposed git_blob_create_frombuffer as ObjectDatabase.CreateBlob(byte[] buffer, long length)

### DIFF
--- a/LibGit2Sharp.Tests/ObjectDatabaseFixture.cs
+++ b/LibGit2Sharp.Tests/ObjectDatabaseFixture.cs
@@ -1,4 +1,6 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
+using System.Linq;
 using LibGit2Sharp.Tests.TestHelpers;
 using Xunit;
 using Xunit.Extensions;
@@ -44,6 +46,82 @@ namespace LibGit2Sharp.Tests
                 var fetchedBlob = repo.Lookup<Blob>(blob.Id);
                 Assert.Equal(blob, fetchedBlob);
             }
+        }
+
+        [Fact]
+        public void CanCreateABlobFromAByteArray()
+        {
+            TemporaryCloneOfTestRepo scd = BuildTemporaryCloneOfTestRepo(StandardTestRepoWorkingDirPath);
+
+            using (var repo = new Repository(scd.DirectoryPath))
+            {
+                byte[] content = new byte[] {65, 66, 67, 68};
+                Blob blob = repo.ObjectDatabase.CreateBlob(content, 3);
+                Assert.Equal(3, blob.Size);
+
+                Assert.NotNull(blob);
+                Assert.Equal("48b83b862ebc57bd3f7c34ed47262f4b402935af", blob.Sha);
+
+                /*  check to make sure it is indeed stored in the repository. */
+                var fetchedBlob = repo.Lookup<Blob>(blob.Id);
+                Assert.Equal(content.Take(3), fetchedBlob.Content);
+                Assert.Equal(blob, fetchedBlob);
+            }
+        }
+
+        [Fact]
+        public void CanCreateABlobFromAnEmptyByteArray()
+        {
+            TemporaryCloneOfTestRepo scd = BuildTemporaryCloneOfTestRepo(StandardTestRepoWorkingDirPath);
+
+            using (var repo = new Repository(scd.DirectoryPath))
+            {
+                byte[] content = new byte[0];
+                Blob blob = repo.ObjectDatabase.CreateBlob(content, 0);
+                Assert.Equal(0, blob.Size);
+
+                Assert.NotNull(blob);
+                Assert.Equal("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391", blob.Sha);
+
+                /*  check to make sure it is indeed stored in the repository. */
+                var fetchedBlob = repo.Lookup<Blob>(blob.Id);
+                Assert.Empty(fetchedBlob.Content);
+                Assert.Equal(blob, fetchedBlob);
+            }
+        }
+
+        [Fact]
+        public void CreateABlobFromAByteArrayThrowsIfArrayNull()
+        {
+            TemporaryCloneOfTestRepo scd = BuildTemporaryCloneOfTestRepo(StandardTestRepoWorkingDirPath);
+
+            using (var repo = new Repository(scd.DirectoryPath))
+            {
+                Assert.Throws<ArgumentNullException>(() => repo.ObjectDatabase.CreateBlob(null, 3));
+            }
+        }
+
+        [Fact]
+        public void CreateABlobFromAByteArrayThrowsIfLengthSmallerThanZero()
+        {
+            TemporaryCloneOfTestRepo scd = BuildTemporaryCloneOfTestRepo(StandardTestRepoWorkingDirPath);
+
+            using (var repo = new Repository(scd.DirectoryPath))
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => repo.ObjectDatabase.CreateBlob(new byte[] {1, 2, 3, 4}, -2));
+            }
+        }
+
+        [Fact]
+        public void CreateABlobFromAByteArrayThrowsIfLengthIsInvalid()
+        {
+            TemporaryCloneOfTestRepo scd = BuildTemporaryCloneOfTestRepo(StandardTestRepoWorkingDirPath);
+
+            using (var repo = new Repository(scd.DirectoryPath))
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => repo.ObjectDatabase.CreateBlob(new byte[] { 1, 2 }, 3));
+            }
+            
         }
 
         [Fact]

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -68,6 +68,13 @@ namespace LibGit2Sharp.Core
         public static extern GitErrorSafeHandle giterr_last();
 
         [DllImport(libgit2)]
+        public static extern int git_blob_create_frombuffer(
+            ref GitOid oid,
+            RepositorySafeHandle repo,
+            byte[] buffer,
+            UIntPtr len);
+
+        [DllImport(libgit2)]
         public static extern int git_blob_create_fromdisk(
             ref GitOid oid,
             RepositorySafeHandle repo,

--- a/LibGit2Sharp/ObjectDatabase.cs
+++ b/LibGit2Sharp/ObjectDatabase.cs
@@ -37,6 +37,23 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
+        ///  Inserts a <see cref="Blob"/> into the object database, created from the first <paramref name="length"/> bytes of <paramref name="buffer"/>.
+        /// </summary>
+        /// <param name="buffer">The <see cref="byte"/> array containing the data to insert.</param>
+        /// <param name="length">The number of bytes from <paramref name="buffer"/> to insert.</param>
+        /// <returns>The created <see cref="Blob"/>.</returns>
+        public Blob CreateBlob(byte[] buffer, long length)
+        {
+            Ensure.ArgumentNotNull(buffer, "buffer");
+            if (length < 0 || length > buffer.LongLength)
+                throw new ArgumentOutOfRangeException("length", "Value has to be greater or equal to zero and smaller than or equal to the length of the buffer.");
+
+            var oid = new GitOid();
+            Ensure.Success(NativeMethods.git_blob_create_frombuffer(ref oid, repo.Handle, buffer, new UIntPtr((ulong)length)));
+            return repo.Lookup<Blob>(new ObjectId(oid));
+        }
+
+        /// <summary>
         ///   Inserts a <see cref="Blob"/> into the object database, created from the content of a file.
         /// </summary>
         /// <param name="path">Path to the file to create the blob from.</param>


### PR DESCRIPTION
Added a single overload to CreateBlob taking a byte[] and a length enabling blob-creation from in-memory objects. 
I'm all for adding an overload that takes a Stream as well (as discussed), but for now this will at least expose the basic functionality required to create blobs from memory.
