### PR TITLE
Add meaningful message when an external process prevents tests cleanup

### DIFF
--- a/LibGit2Sharp.Tests/TestHelpers/DirectoryHelper.cs
+++ b/LibGit2Sharp.Tests/TestHelpers/DirectoryHelper.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 
 namespace LibGit2Sharp.Tests.TestHelpers
 {
@@ -46,7 +47,19 @@ namespace LibGit2Sharp.Tests.TestHelpers
             }
 
             File.SetAttributes(directoryPath, FileAttributes.Normal);
-            Directory.Delete(directoryPath, false);
+            try
+            {
+                Directory.Delete(directoryPath, false);
+            } 
+            catch (IOException ex)
+            {
+                throw new IOException(string.Format("{0}The directory '{1}' could not be deleted!" +
+                                                    "{0}Most of the time, this is due to an external process accessing the files in the temporary repositories created during the test runs, and keeping a handle on the directory, thus preventing the deletion of those files." +
+                                                    "{0}Known and common causes include:" +
+                                                    "{0}- Windows Search Indexer (go to the Indexing Options, in the Windows Control Panel, and exclude the bin folder of LibGit2Sharp.Tests)" +
+                                                    "{0}- Antivirus (exclude the bin folder of LibGit2Sharp.Tests from the paths scanned by your real-time antivirus){0}", 
+                    Environment.NewLine, Path.GetFullPath(directoryPath)), ex);
+            }
         }
     }
 }


### PR DESCRIPTION
Following #141, and the talk that we had on dahlbyk@d430855, I added a more meaningful exception message.
