### PR TITLE
Use FilePath in TreeChanges

### DIFF
--- a/LibGit2Sharp.Tests/DiffTreeToTreeFixture.cs
+++ b/LibGit2Sharp.Tests/DiffTreeToTreeFixture.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.IO;
+using System.Linq;
 using System.Text;
 using LibGit2Sharp.Tests.TestHelpers;
 using Xunit;
@@ -7,6 +8,8 @@ namespace LibGit2Sharp.Tests
 {
     public class DiffTreeToTreeFixture : BaseFixture
     {
+        private static readonly string subBranchfilePath = Path.Combine("1", "branch_file.txt");
+
         [Fact]
         public void ComparingATreeAgainstItselfReturnsNoDifference()
         {
@@ -87,7 +90,7 @@ namespace LibGit2Sharp.Tests
                 Assert.NotNull(changes);
 
                 Assert.Equal(1, changes.Count());
-                Assert.Equal("1/branch_file.txt", changes.Added.Single().Path);
+                Assert.Equal(subBranchfilePath, changes.Added.Single().Path);
             }
         }
 
@@ -120,7 +123,7 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(1, changes.Deleted.Count());
 
                 Assert.Equal("readme.txt", changes.Deleted.Single().Path);
-                Assert.Equal(new[] { "1.txt", "1/branch_file.txt", "README", "branch_file.txt", "deleted_staged_file.txt", "deleted_unstaged_file.txt", "modified_staged_file.txt", "modified_unstaged_file.txt", "new.txt" },
+                Assert.Equal(new[] { "1.txt", subBranchfilePath, "README", "branch_file.txt", "deleted_staged_file.txt", "deleted_unstaged_file.txt", "modified_staged_file.txt", "modified_unstaged_file.txt", "new.txt" },
                              changes.Added.Select(x => x.Path));
 
                 Assert.Equal(9, changes.LinesAdded);

--- a/LibGit2Sharp/TreeChanges.cs
+++ b/LibGit2Sharp/TreeChanges.cs
@@ -41,8 +41,8 @@ namespace LibGit2Sharp
 
         private int PrintCallBack(IntPtr data, GitDiffDelta delta, GitDiffRange range, GitDiffLineOrigin lineorigin, IntPtr content, uint contentlen)
         {
-            var formattedoutput = Utf8Marshaler.FromNative(content, contentlen);
-            var currentFilePath = Utf8Marshaler.FromNative(delta.NewFile.Path);
+            string formattedoutput = Utf8Marshaler.FromNative(content, contentlen);
+            FilePath currentFilePath = FilePathMarshaler.FromNative(delta.NewFile.Path);
 
             AddLineChange(currentFilePath, lineorigin);
 
@@ -51,13 +51,13 @@ namespace LibGit2Sharp
                 AddFileChange(delta);
             }
 
-            changes[currentFilePath].AppendToPatch(formattedoutput);
+            changes[currentFilePath.Native].AppendToPatch(formattedoutput);
             fullPatchBuilder.Append(formattedoutput);
 
             return 0;
         }
 
-        private void AddLineChange(string currentFilePath, GitDiffLineOrigin lineOrigin)
+        private void AddLineChange(FilePath currentFilePath, GitDiffLineOrigin lineOrigin)
         {
             switch (lineOrigin)
             {
@@ -71,22 +71,22 @@ namespace LibGit2Sharp
             }
         }
 
-        private void IncrementLinesDeleted(string filePath)
+        private void IncrementLinesDeleted(FilePath filePath)
         {
             linesDeleted++;
-            this[filePath].LinesDeleted++;
+            this[filePath.Native].LinesDeleted++;
         }
 
-        private void IncrementLinesAdded(string filePath)
+        private void IncrementLinesAdded(FilePath filePath)
         {
             linesAdded++;
-            this[filePath].LinesAdded++;
+            this[filePath.Native].LinesAdded++;
         }
 
         private void AddFileChange(GitDiffDelta delta)
         {
-            var newFilePath = Utf8Marshaler.FromNative(delta.NewFile.Path);
-            var oldFilePath = Utf8Marshaler.FromNative(delta.OldFile.Path);
+            var newFilePath = FilePathMarshaler.FromNative(delta.NewFile.Path);
+            var oldFilePath = FilePathMarshaler.FromNative(delta.OldFile.Path);
             var newMode = (Mode)delta.NewFile.Mode;
             var oldMode = (Mode)delta.OldFile.Mode;
             var newOid = new ObjectId(delta.NewFile.Oid);

--- a/LibGit2Sharp/TreeEntryChanges.cs
+++ b/LibGit2Sharp/TreeEntryChanges.cs
@@ -1,3 +1,5 @@
+using LibGit2Sharp.Core;
+
 namespace LibGit2Sharp
 {
     /// <summary>
@@ -5,13 +7,13 @@ namespace LibGit2Sharp
     /// </summary>
     public class TreeEntryChanges : Changes
     {
-        internal TreeEntryChanges(string path, Mode mode, ObjectId oid, ChangeKind status, string oldPath, Mode oldMode, ObjectId oldOid, bool isBinaryComparison)
+        internal TreeEntryChanges(FilePath path, Mode mode, ObjectId oid, ChangeKind status, FilePath oldPath, Mode oldMode, ObjectId oldOid, bool isBinaryComparison)
         {
-            Path = path;
+            Path = path.Native;
             Mode = mode;
             Oid = oid;
             Status = status;
-            OldPath = oldPath;
+            OldPath = oldPath.Native;
             OldMode = oldMode;
             OldOid = oldOid;
             IsBinaryComparison = isBinaryComparison;


### PR DESCRIPTION
Under the hood, `TreeChanges` should leverage `FilePath` for all paths.
