### PR TITLE
Made DetachedHead public

### DIFF
--- a/LibGit2Sharp/DetachedHead.cs
+++ b/LibGit2Sharp/DetachedHead.cs
@@ -1,7 +1,10 @@
 ﻿namespace LibGit2Sharp
 {
-    internal class DetachedHead : Branch
+    public class DetachedHead : Branch
     {
+        protected DetachedHead()
+        { }
+        
         internal DetachedHead(Repository repo, Reference reference)
             : base(repo, reference, "(no branch)")
         {


### PR DESCRIPTION
We need to be able to determine whether the current "branch" is a detached
head. But we can't compare it if the type is internal.

For example,

```
if (someBranch is DetachedHead) {...}
```

This commit makes it public and mockable.
