### PR TITLE
Preserve non-ASCII characters in commit messages

### DIFF
--- a/LibGit2Sharp.Tests/ObjectDatabaseFixture.cs
+++ b/LibGit2Sharp.Tests/ObjectDatabaseFixture.cs
@@ -264,12 +264,13 @@ namespace LibGit2Sharp.Tests
 
                 Tree tree = repo.ObjectDatabase.CreateTree(td);
 
-                Commit commit = repo.ObjectDatabase.CreateCommit("message", DummySignature, DummySignature, tree, new[] { repo.Head.Tip });
+                Commit commit = repo.ObjectDatabase.CreateCommit("Ü message", DummySignature, DummySignature, tree, new[] { repo.Head.Tip });
 
                 Branch newHead = repo.Head;
 
                 Assert.Equal(head, newHead);
                 Assert.Equal(commit, repo.Lookup<Commit>(commit.Sha));
+                Assert.Equal("Ü message\n", commit.Message);
             }
         }
     }

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -373,8 +373,8 @@ namespace LibGit2Sharp.Core
         [DllImport(libgit2)]
         public static extern int git_message_prettify(
             byte[] message_out, // NB: This is more properly a StringBuilder, but it's UTF8
-            int buffer_size, 
-            string message,
+            int buffer_size,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(Utf8Marshaler))] string message,
             bool strip_comments);
 
         [DllImport(libgit2)]


### PR DESCRIPTION
We weren't converting the commit message to UTF-8 before asking libgit2
to prettify it.
