### PR TITLE
Add the streaming indexer to the bindings

### DIFF
--- a/LibGit2Sharp.Tests/IndexerFixture.cs
+++ b/LibGit2Sharp.Tests/IndexerFixture.cs
@@ -1,0 +1,48 @@
+using System;
+using System.IO;
+using LibGit2Sharp.Advanced;
+using LibGit2Sharp.Tests.TestHelpers;
+using Xunit;
+
+namespace LibGit2Sharp.Tests
+{
+    public class IndexerFixture : BaseFixture
+    {
+        [Fact]
+        public void CanIndexFromAFilePath()
+        {
+            TransferProgress copiedProgress = default(TransferProgress);
+            using (var repo = new Repository(SandboxStandardTestRepoGitDir()))
+            {
+                var path = Path.Combine(repo.Info.Path, "objects/pack/pack-a81e489679b7d3418f9ab594bda8ceb37dd4c695.pack");
+                using (var indexer = new Indexer(repo.Info.WorkingDirectory, 438 /* 0666 */,
+                    onProgress: (p) => {
+                        copiedProgress = p;
+                        return true;
+                    }))
+                {
+                    indexer.Index(path);
+                    Assert.Equal(1628, indexer.Progress.TotalObjects);
+                    Assert.Equal(indexer.Progress.TotalObjects, copiedProgress.TotalObjects);
+                }
+            }
+        }
+
+        [Fact]
+        public void CanIndexFromAStream()
+        {
+            using (var repo = new Repository(SandboxStandardTestRepoGitDir()))
+            {
+                var path = Path.Combine(repo.Info.Path, "objects/pack/pack-a81e489679b7d3418f9ab594bda8ceb37dd4c695.pack");
+                using (var indexer = new Indexer(repo.Info.WorkingDirectory, 438 /* 0666 */))
+                using (var stream = new FileStream(path, FileMode.Open, FileAccess.Read))
+                {
+                    indexer.Index(stream);
+                    Assert.Equal(1628, indexer.Progress.TotalObjects);
+                }
+            }
+        }
+
+    }
+}
+

--- a/LibGit2Sharp.Tests/IndexerFixture.cs
+++ b/LibGit2Sharp.Tests/IndexerFixture.cs
@@ -14,17 +14,18 @@ namespace LibGit2Sharp.Tests
             TransferProgress copiedProgress = default(TransferProgress);
             using (var repo = new Repository(SandboxStandardTestRepoGitDir()))
             {
+                var expectedId = new ObjectId("a81e489679b7d3418f9ab594bda8ceb37dd4c695");
                 var path = Path.Combine(repo.Info.Path, "objects/pack/pack-a81e489679b7d3418f9ab594bda8ceb37dd4c695.pack");
-                using (var indexer = new Indexer(repo.Info.WorkingDirectory, 438 /* 0666 */,
+                TransferProgress progress;
+                var packId = Indexer.Index(out progress, path, repo.Info.WorkingDirectory, 438 /* 0666 */,
                     onProgress: (p) => {
                         copiedProgress = p;
                         return true;
-                    }))
-                {
-                    indexer.Index(path);
-                    Assert.Equal(1628, indexer.Progress.TotalObjects);
-                    Assert.Equal(indexer.Progress.TotalObjects, copiedProgress.TotalObjects);
-                }
+                    });
+
+                Assert.Equal(expectedId, packId);
+                Assert.Equal(1628, progress.TotalObjects);
+                Assert.Equal(1628, copiedProgress.TotalObjects);
             }
         }
 
@@ -33,12 +34,14 @@ namespace LibGit2Sharp.Tests
         {
             using (var repo = new Repository(SandboxStandardTestRepoGitDir()))
             {
+                var expectedId = new ObjectId("a81e489679b7d3418f9ab594bda8ceb37dd4c695");
                 var path = Path.Combine(repo.Info.Path, "objects/pack/pack-a81e489679b7d3418f9ab594bda8ceb37dd4c695.pack");
-                using (var indexer = new Indexer(repo.Info.WorkingDirectory, 438 /* 0666 */))
+                TransferProgress progress;
                 using (var stream = new FileStream(path, FileMode.Open, FileAccess.Read))
                 {
-                    indexer.Index(stream);
-                    Assert.Equal(1628, indexer.Progress.TotalObjects);
+                    var packId = Indexer.Index(out progress, stream, repo.Info.WorkingDirectory, 438 /* 0666 */);
+                    Assert.Equal(expectedId, packId);
+                    Assert.Equal(1628, progress.TotalObjects);
                 }
             }
         }

--- a/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
+++ b/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
@@ -122,6 +122,7 @@
     <Compile Include="TreeDefinitionFixture.cs" />
     <Compile Include="TreeFixture.cs" />
     <Compile Include="UnstageFixture.cs" />
+    <Compile Include="IndexerFixture.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\LibGit2Sharp\LibGit2Sharp.csproj">

--- a/LibGit2Sharp/Advanced/Indexer.cs
+++ b/LibGit2Sharp/Advanced/Indexer.cs
@@ -1,0 +1,101 @@
+using System;
+using System.IO;
+using LibGit2Sharp.Core;
+using LibGit2Sharp.Handlers;
+using LibGit2Sharp.Core.Handles;
+
+namespace LibGit2Sharp.Advanced
+{
+    public class Indexer : IDisposable
+    {
+
+        readonly IndexerSafeHandle handle;
+        readonly TransferProgressHandler callback;
+
+        GitTransferProgress progress;
+        byte[] buffer;
+
+        /// <summary>
+        /// The indexing progress
+        /// </summary>
+        /// <value>The progres information for the current operation.</value>
+        public TransferProgress Progress
+        {
+            get
+            {
+                return new TransferProgress(progress);
+            }
+        }
+
+        public Indexer(string prefix, uint mode, ObjectDatabase odb = null, TransferProgressHandler onProgress = null)
+        {
+            /* The runtime won't let us pass null as a SafeHandle, wo create a "dummy" one to represent NULL */
+            ObjectDatabaseSafeHandle odbHandle = odb != null ? odb.Handle : new ObjectDatabaseSafeHandle();
+            callback = onProgress;
+            handle = Proxy.git_indexer_new(prefix, odbHandle, mode, GitDownloadTransferProgressHandler);
+            progress = new GitTransferProgress();
+        }
+
+        /// <summary>
+        /// Index the packfile at the specified path. This function runs synchronously and should usually be run
+        /// in a background thread.
+        /// </summary>
+        /// <param name="path">The packfile's path</param>
+        public ObjectId Index(string path)
+        {
+            using (var fs = new FileStream(path, FileMode.Open, FileAccess.Read))
+            {
+                return Index(fs);
+            }
+        }
+
+        /// <summary>
+        /// Index the packfile from the specified stream. This function runs synchronously and should usually be run
+        /// in a background thread.
+        /// </summary>
+        /// <param name="stream">The stream from which to read the packfile data</param>
+        public ObjectId Index(Stream stream)
+        {
+            buffer = new byte[65536];
+            int read;
+
+            do
+            {
+                read = stream.Read(buffer, 0, buffer.Length);
+                Proxy.git_indexer_append(handle, buffer, (UIntPtr)read, ref progress);
+            } while (read > 0);
+
+            Proxy.git_indexer_commit(handle, ref progress);
+
+            return Proxy.git_indexer_hash(handle);
+        }
+
+        // This comes from RemoteCallbacks
+        /// <summary>
+        /// The delegate with the signature that matches the native git_transfer_progress_callback function's signature.
+        /// </summary>
+        /// <param name="progress"><see cref="GitTransferProgress"/> structure containing progress information.</param>
+        /// <param name="payload">Payload data.</param>
+        /// <returns>the result of the wrapped <see cref="TransferProgressHandler"/></returns>
+        int GitDownloadTransferProgressHandler(ref GitTransferProgress progress, IntPtr payload)
+        {
+            bool shouldContinue = true;
+
+            if (callback != null)
+            {
+                shouldContinue = callback(new TransferProgress(progress));
+            }
+
+            return Proxy.ConvertResultToCancelFlag(shouldContinue);
+        }
+
+        #region IDisposable implementation
+
+        public void Dispose()
+        {
+            handle.SafeDispose();
+        }
+
+        #endregion
+    }
+}

--- a/LibGit2Sharp/Core/Handles/IndexerSafeHandle.cs
+++ b/LibGit2Sharp/Core/Handles/IndexerSafeHandle.cs
@@ -1,0 +1,13 @@
+using System;
+namespace LibGit2Sharp.Core.Handles
+{
+    internal class IndexerSafeHandle : SafeHandleBase
+    {
+        protected override bool ReleaseHandleImpl()
+        {
+            Proxy.git_indexer_free(handle);
+            return true;
+        }
+    }
+}
+

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -1578,6 +1578,27 @@ namespace LibGit2Sharp.Core
 
         [DllImport(libgit2)]
         internal static extern int git_cherrypick(RepositorySafeHandle repo, GitObjectSafeHandle commit, GitCherryPickOptions options);
+
+        [DllImport(libgit2)]
+        public static extern int git_indexer_new(
+            out IndexerSafeHandle handle,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath prefix,
+            uint mode,
+            ObjectDatabaseSafeHandle odbHandle,
+            git_transfer_progress_callback progress_callback,
+            IntPtr payload);
+
+        [DllImport(libgit2)]
+        public static extern int git_indexer_append(IndexerSafeHandle idx, byte[] data, UIntPtr size, ref GitTransferProgress progress);
+
+        [DllImport(libgit2)]
+        public static extern int git_indexer_commit(IndexerSafeHandle idx, ref GitTransferProgress progress);
+
+        [DllImport(libgit2)]
+        public static extern OidSafeHandle git_indexer_hash(IndexerSafeHandle idx);
+
+        [DllImport(libgit2)]
+        public static extern void git_indexer_free(IntPtr idx);
     }
 }
 // ReSharper restore InconsistentNaming

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -1086,6 +1086,52 @@ namespace LibGit2Sharp.Core
 
         #endregion
 
+        #region git_indexer_
+
+        public static IndexerSafeHandle git_indexer_new(FilePath prefix, ObjectDatabaseSafeHandle odbHandle, uint mode,
+                                                        NativeMethods.git_transfer_progress_callback progressCallback)
+        {
+            using (ThreadAffinity())
+            {
+                IndexerSafeHandle handle;
+
+                int res = NativeMethods.git_indexer_new(out handle, prefix, mode, odbHandle, progressCallback, IntPtr.Zero);
+                Ensure.ZeroResult(res);
+
+                return handle;
+            }
+        }
+
+        public static void git_indexer_append(IndexerSafeHandle handle, byte[] data, UIntPtr length, ref GitTransferProgress progress)
+        {
+            using (ThreadAffinity())
+            {
+                int res = NativeMethods.git_indexer_append(handle, data, length, ref progress);
+                Ensure.ZeroResult(res);
+            }
+        }
+
+        public static void git_indexer_commit(IndexerSafeHandle handle, ref GitTransferProgress progress)
+        {
+            using (ThreadAffinity())
+            {
+                int res = NativeMethods.git_indexer_commit(handle, ref progress);
+                Ensure.ZeroResult(res);
+            }
+        }
+
+        public static ObjectId git_indexer_hash(IndexerSafeHandle handle)
+        {
+            return NativeMethods.git_indexer_hash(handle).MarshalAsObjectId();
+        }
+
+        public static void git_indexer_free(IntPtr handle)
+        {
+            NativeMethods.git_indexer_free(handle);
+        }
+
+        #endregion
+
         #region git_merge_
 
         public static IndexSafeHandle git_merge_trees(RepositorySafeHandle repo, GitObjectSafeHandle ancestorTree, GitObjectSafeHandle ourTree, GitObjectSafeHandle theirTree)

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -340,6 +340,8 @@
     <Compile Include="Core\RawContentStream.cs" />
     <Compile Include="Core\Handles\OdbStreamSafeHandle.cs" />
     <Compile Include="SupportedCredentialTypes.cs" />
+    <Compile Include="Core\Handles\IndexerSafeHandle.cs" />
+    <Compile Include="Advanced\Indexer.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="CustomDictionary.xml" />

--- a/LibGit2Sharp/ObjectDatabase.cs
+++ b/LibGit2Sharp/ObjectDatabase.cs
@@ -60,6 +60,11 @@ namespace LibGit2Sharp
 
         #endregion
 
+        internal ObjectDatabaseSafeHandle Handle
+        {
+            get { return handle; }
+        }
+
         /// <summary>
         /// Determines if the given object can be found in the object database.
         /// </summary>


### PR DESCRIPTION
There are a few things that I'm not so sure about, style-wise.

Firstly, the indexer's stats are actually `unsigned int` in C, but if I try to put that in the struct, I get a warning that it's not CLS complaint, so it it may not work. @nulltoken, do you have any insights into this?

Secondly, I transform the stats into the C# variant after each add, which could be too much work, if the stats are looked up less often. I thought about doing it on demand, but that would mean locking and I worry that it would mean even more work.

Thirdly, is there some extablished convention whereby I can make clear that you shouldn't call `Indexer.Hash()` before the indexer is done?
