### PR TITLE
Enable thread affinity for life of Repository

### DIFF
--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -679,7 +679,7 @@ namespace LibGit2Sharp.Core
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(FilePathMarshaler))] FilePath filepath);
 
         internal delegate int status_callback(
-            IntPtr statuspath,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(FilePathMarshaler))] FilePath statuspath,
             uint statusflags,
             IntPtr payload);
 

--- a/LibGit2Sharp/RepositoryStatus.cs
+++ b/LibGit2Sharp/RepositoryStatus.cs
@@ -54,9 +54,8 @@ namespace LibGit2Sharp
             isDirty = statusEntries.Any(entry => entry.State != FileStatus.Ignored);
         }
 
-        private int StateChanged(IntPtr filePathPtr, uint state, IntPtr payload)
+        private int StateChanged(FilePath filePath, uint state, IntPtr payload)
         {
-            var filePath = FilePathMarshaler.FromNative(filePathPtr);
             var gitStatus = (FileStatus)state;
             statusEntries.Add(new StatusEntry(filePath.Native, gitStatus));
 


### PR DESCRIPTION
See libgit2/libgit2#624 and https://github.com/libgit2/libgit2/issues/624#issuecomment-7815470

One caveat: [`Thread.BeginThreadAffinity()`](http://msdn.microsoft.com/en-us/library/system.threading.thread.beginthreadaffinity.aspx) is decorated with [`SecurityCriticalAttribute`](http://msdn.microsoft.com/en-us/library/system.security.securitycriticalattribute.aspx):

> Requires full trust for the immediate caller. This member cannot be used by partially trusted or transparent code.
