### PR TITLE
Expose libgit2 fetch functionality.

### DIFF
--- a/LibGit2Sharp.Tests/BranchFixture.cs
+++ b/LibGit2Sharp.Tests/BranchFixture.cs
@@ -221,6 +221,19 @@ namespace LibGit2Sharp.Tests
         }
 
         [Fact]
+        public void CanResolveTrackedRemote()
+        {
+            using (var repo = new Repository(StandardTestRepoPath))
+            {
+                Branch master = repo.Branches["master"];
+                Assert.Equal(repo.Remotes["origin"], master.ResolveTrackedRemote());
+
+                Branch test = repo.Branches["test"];
+                Assert.Null(test);
+            }
+        }
+
+        [Fact]
         public void CanLookupABranchByItsCanonicalName()
         {
             using (var repo = new Repository(BareTestRepoPath))

--- a/LibGit2Sharp/Branch.cs
+++ b/LibGit2Sharp/Branch.cs
@@ -136,9 +136,31 @@ namespace LibGit2Sharp
             get { return repo.Commits.QueryBy(new Filter { Since = this }); }
         }
 
+        /// <summary>
+        ///   Gets the <see cref="Remote"/> tracking this branch
+        /// </summary>
+        /// <returns>The <see cref="Remote"/> tracking this branch if one exists, otherwise returns null.</returns>
+        public virtual Remote ResolveTrackedRemote()
+        {
+            if (IsTracking)
+            {
+                string trackedRemoteName = ResolveTrackedRemoteName();
+                if (string.IsNullOrEmpty(trackedRemoteName))
+                {
+                    return null;
+                }
+
+                return repo.Remotes[trackedRemoteName];
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         private Branch ResolveTrackedBranch()
         {
-            var trackedRemote = repo.Config.Get<string>("branch", Name, "remote", null);
+            string trackedRemote = ResolveTrackedRemoteName();
             if (trackedRemote == null)
             {
                 return null;
@@ -152,6 +174,11 @@ namespace LibGit2Sharp
 
             var remoteRefName = ResolveTrackedReference(trackedRemote, trackedRefName);
             return repo.Branches[remoteRefName];
+        }
+
+        private string ResolveTrackedRemoteName()
+        {
+            return repo.Config.Get<string>("branch", Name, "remote", null) as string;
         }
 
         private static string ResolveTrackedReference(string trackedRemote, string trackedRefName)

--- a/LibGit2Sharp/Core/GitDirection.cs
+++ b/LibGit2Sharp/Core/GitDirection.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace LibGit2Sharp.Core
+{
+    internal enum GitDirection
+    {
+        Fetch = 0,
+        Push = 1
+    }
+}

--- a/LibGit2Sharp/Core/GitIndexerStats.cs
+++ b/LibGit2Sharp/Core/GitIndexerStats.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace LibGit2Sharp.Core
+{
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct GitIndexerStats
+    {
+        public uint total;
+        public uint processed;
+    }
+}

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -568,6 +568,18 @@ namespace LibGit2Sharp.Core
         public static extern string git_remote_url(RemoteSafeHandle remote);
 
         [DllImport(libgit2)]
+        public static extern int git_remote_connect(RemoteSafeHandle remote, GitDirection direction);
+
+        [DllImport(libgit2)]
+        public static extern void git_remote_disconnect(RemoteSafeHandle remote);
+
+        [DllImport(libgit2)]
+        public static extern int git_remote_download(RemoteSafeHandle remote, ref long bytes, ref GitIndexerStats stats);
+
+        [DllImport(libgit2)]
+        public static extern int git_remote_update_tips(RemoteSafeHandle remote, IntPtr cb);
+
+        [DllImport(libgit2)]
         public static extern int git_remote_save(RemoteSafeHandle remote);
 
         [DllImport(libgit2)]

--- a/LibGit2Sharp/FetchProgress.cs
+++ b/LibGit2Sharp/FetchProgress.cs
@@ -1,0 +1,43 @@
+﻿using LibGit2Sharp.Core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace LibGit2Sharp
+{
+    /// <summary>
+    ///   Contains data regarding fetch progress.
+    /// </summary>
+    public class FetchProgress : IndexerStats
+    {
+        /// <summary>
+        ///   Fetch progress constructor.
+        /// </summary>
+        public FetchProgress()
+        { }
+
+        /// <summary>
+        ///   Bytes received.
+        /// </summary>
+        public long Bytes
+        {
+            get
+            {
+                return bytes;
+            }
+        }
+
+        internal override void Reset()
+        {
+            base.Reset();
+            bytes = 0;
+        }
+
+        #region Fields
+
+        internal long bytes;
+
+        #endregion
+    }
+}

--- a/LibGit2Sharp/IndexerStats.cs
+++ b/LibGit2Sharp/IndexerStats.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace LibGit2Sharp.Core
+{
+    /// <summary>
+    /// Wrapper around git_indexer_stats
+    /// </summary>
+    public class IndexerStats
+    {
+        /// <summary>
+        ///   Constructor
+        /// </summary>
+        public IndexerStats()
+        {
+            indexerStats = new GitIndexerStats();
+        }
+        /// <summary>
+        ///   Total number of objects
+        /// </summary>
+        public long TotalObjectCount
+        {
+            get
+            {
+                return indexerStats.total;
+            }
+        }
+
+        /// <summary>
+        ///   Number of objects processed.
+        /// </summary>
+        public long ProcessedObjectCount
+        {
+            get
+            {
+                return indexerStats.processed;
+            }
+        }
+
+        /// <summary>
+        ///   Reset internal data
+        /// </summary>
+        internal virtual void Reset()
+        {
+            indexerStats.processed = 0;
+            indexerStats.total = 0;
+        }
+
+        #region Fields
+
+        internal GitIndexerStats indexerStats;
+
+        #endregion
+    }
+}

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -66,8 +66,10 @@
     <Compile Include="CommitLog.cs" />
     <Compile Include="Configuration.cs" />
     <Compile Include="ContentChanges.cs" />
+    <Compile Include="Core\GitIndexerStats.cs" />
     <Compile Include="TagCollectionExtensions.cs" />
     <Compile Include="Core\Compat\Environment.cs" />
+    <Compile Include="FetchProgress.cs" />
     <Compile Include="Core\FilePath.cs" />
     <Compile Include="Core\FilePathExtensions.cs" />
     <Compile Include="Core\FilePathMarshaler.cs" />
@@ -79,6 +81,7 @@
     <Compile Include="Core\GitBranchType.cs" />
     <Compile Include="Core\GitDiff.cs" />
     <Compile Include="Core\GitDiffExtensions.cs" />
+    <Compile Include="Core\GitDirection.cs" />
     <Compile Include="Core\GitError.cs" />
     <Compile Include="Core\GitErrorCategory.cs" />
     <Compile Include="Core\GitNoteData.cs" />
@@ -93,6 +96,7 @@
     <Compile Include="Core\Handles\OidSafeHandle.cs" />
     <Compile Include="Core\Handles\TreeBuilderSafeHandle.cs" />
     <Compile Include="Core\Handles\TreeEntrySafeHandle_Owned.cs" />
+    <Compile Include="IndexerStats.cs" />
     <Compile Include="Core\ReferenceExtensions.cs" />
     <Compile Include="Core\Handles\ReferenceSafeHandle.cs" />
     <Compile Include="Core\Handles\SignatureSafeHandle.cs" />

--- a/LibGit2Sharp/RemoteCollection.cs
+++ b/LibGit2Sharp/RemoteCollection.cs
@@ -55,7 +55,7 @@ namespace LibGit2Sharp
         {
             using (RemoteSafeHandle handle = LoadRemote(name, false))
             {
-                return Remote.CreateFromPtr(handle);
+                return Remote.CreateFromPtr(repository, handle);
             }
         }
 
@@ -100,7 +100,7 @@ namespace LibGit2Sharp
 
             using (handle)
             {
-                return Remote.CreateFromPtr(handle);
+                return Remote.CreateFromPtr(repository, handle);
             }
         }
 
@@ -142,7 +142,7 @@ namespace LibGit2Sharp
                 res = NativeMethods.git_remote_save(handle);
                 Ensure.Success(res);
 
-                return Remote.CreateFromPtr(handle);
+                return Remote.CreateFromPtr(repository, handle);
             }
         }
 


### PR DESCRIPTION
This pull request implements the basics needed to expose fetch through Libgit2Sharp.

I see there is issue #65 indicating that there might already be some other work done on fetch, and that the code is being polished, but this was over 4 months ago and I have not seen it in the main branch. 

I did not implement the callback on git_remote_update_tips, as this function seems to be changing in the latest version of libgit2 (possibly why fetch has not made it into the main branch on LibGit2Sharp?).

Thanks,
Jameson 
