### PR TITLE
Enumerate config values

### DIFF
--- a/LibGit2Sharp.Tests/ConfigurationFixture.cs
+++ b/LibGit2Sharp.Tests/ConfigurationFixture.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using System.Text;
 using LibGit2Sharp.Tests.TestHelpers;
 using Xunit;
@@ -154,6 +155,29 @@ namespace LibGit2Sharp.Tests
             {
                 Assert.Equal("+refs/heads/*:refs/remotes/origin/*", repo.Config.Get<string>("remote.origin.fetch", null));
                 Assert.Equal("+refs/heads/*:refs/remotes/origin/*", repo.Config.Get<string>("remote", "origin", "fetch", null));
+            }
+        }
+
+        [SkippableFact]
+        public void CanEnumerateGlobalConfig()
+        {
+            using (var repo = new Repository(StandardTestRepoPath))
+            {
+                InconclusiveIf(() => !repo.Config.HasGlobalConfig, "No Git global configuration available");
+                var entry = repo.Config.FirstOrDefault(e => e.Key == "user.name");
+                Assert.NotNull(entry);
+                Assert.NotNull(entry.Value);
+            }
+        }
+
+        [Fact]
+        public void CanEnumerateLocalConfig()
+        {
+            using (var repo = new Repository(StandardTestRepoPath))
+            {
+                var entry = repo.Config.FirstOrDefault(e => e.Key == "core.ignorecase");
+                Assert.NotNull(entry);
+                Assert.Equal("true", entry.Value);
             }
         }
 

--- a/LibGit2Sharp/Configuration.cs
+++ b/LibGit2Sharp/Configuration.cs
@@ -10,7 +10,7 @@ namespace LibGit2Sharp
     /// <summary>
     ///   Provides access to configuration variables for a repository.
     /// </summary>
-    public class Configuration : IDisposable
+    public class Configuration : IDisposable, IEnumerable<ConfigurationEntry>
     {
         private readonly FilePath globalConfigPath;
         private readonly FilePath systemConfigPath;
@@ -406,5 +406,22 @@ namespace LibGit2Sharp
             { typeof(bool), GetUpdater<bool>(Proxy.git_config_set_bool) },
             { typeof(string), GetUpdater<string>(Proxy.git_config_set_string) },
         };
+
+        IEnumerator<ConfigurationEntry> IEnumerable<ConfigurationEntry>.GetEnumerator()
+        {
+            var values = new List<ConfigurationEntry>();
+            Proxy.git_config_foreach(LocalHandle, (namePtr, valuePtr, _) => {
+                var name = Utf8Marshaler.FromNative(namePtr);
+                var value = Utf8Marshaler.FromNative(valuePtr);
+                values.Add(new ConfigurationEntry(name, value));
+                return 0;
+            });
+            return values.GetEnumerator();
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return ((IEnumerable<ConfigurationEntry>)this).GetEnumerator();
+        }
     }
 }

--- a/LibGit2Sharp/ConfigurationEntry.cs
+++ b/LibGit2Sharp/ConfigurationEntry.cs
@@ -1,0 +1,29 @@
+﻿namespace LibGit2Sharp
+{
+    /// <summary>
+    /// An enumerated configuration entry.
+    /// </summary>
+    public class ConfigurationEntry
+    {
+        /// <summary>
+        /// The option name.
+        /// </summary>
+        public string Key { get; private set; }
+
+        /// <summary>
+        /// The option value.
+        /// </summary>
+        public string Value { get; private set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConfigurationEntry"/> class with a given key and value
+        /// </summary>
+        /// <param name="key">The option name</param>
+        /// <param name="value">The option value, as a string</param>
+        public ConfigurationEntry(string key, string value)
+        {
+            Key = key;
+            Value = value;
+        }
+    }
+}

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -242,6 +242,17 @@ namespace LibGit2Sharp.Core
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(Utf8Marshaler))] string name,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(Utf8Marshaler))] string value);
 
+        internal delegate int config_foreach_callback(
+            IntPtr var_name,
+            IntPtr value,
+            IntPtr payload);
+
+        [DllImport(libgit2)]
+        internal static extern int git_config_foreach(
+            ConfigurationSafeHandle cfg,
+            config_foreach_callback callback,
+            IntPtr payload);
+
         [DllImport(libgit2)]
         internal static extern void git_diff_list_free(IntPtr diff);
 

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -379,6 +379,17 @@ namespace LibGit2Sharp.Core
             }
         }
 
+        public static void git_config_foreach(
+            ConfigurationSafeHandle config,
+            NativeMethods.config_foreach_callback callback)
+        {
+            using (ThreadAffinity())
+            {
+                int res = NativeMethods.git_config_foreach(config, callback, IntPtr.Zero);
+                Ensure.Success(res);
+            }
+        }
+
         #endregion
 
         #region git_diff_

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Commit.cs" />
     <Compile Include="CommitLog.cs" />
     <Compile Include="Configuration.cs" />
+    <Compile Include="ConfigurationEntry.cs" />
     <Compile Include="ContentChanges.cs" />
     <Compile Include="Core\Proxy.cs" />
     <Compile Include="TagCollectionExtensions.cs" />


### PR DESCRIPTION
I'd like to be able to enumerate config values for a repository, similar to `git config --list`. I'm thinking this would be a clean API:

``` c#
using(var repo = new Repository(/*...*/))
{
  foreach(var config in repo.Config)
  {
    Console.WriteLine(config.Key + "=" + config.Value);
  }
}
```

... supported by something like this:

``` c#
public class Configuration : IDisposable, IEnumerable<ConfigurationEntry>
{
  // ...
  public class ConfigurationEntry
  {
    public string Key { get; }
    public string Value { get; }
  }
}
```

I'd like to have this so that I can replace [git-tfs's config-reading code](https://github.com/git-tfs/git-tfs/blob/7675359d79b51c043d29e63d18f80fe24bc39841/GitTfs/Core/GitRepository.cs#L98).
