### PR TITLE
Support for custom, managed ODB backends

### DIFF
--- a/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
+++ b/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
@@ -67,6 +67,7 @@
     <Compile Include="DiffTreeToTargetFixture.cs" />
     <Compile Include="DiffWorkdirToIndexFixture.cs" />
     <Compile Include="ObjectDatabaseFixture.cs" />
+    <Compile Include="OdbBackendFixture.cs" />
     <Compile Include="DiffTreeToTreeFixture.cs" />
     <Compile Include="RepositoryOptionsFixture.cs" />
     <Compile Include="ResetHeadFixture.cs" />

--- a/LibGit2Sharp.Tests/OdbBackendFixture.cs
+++ b/LibGit2Sharp.Tests/OdbBackendFixture.cs
@@ -1,0 +1,396 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Cryptography;
+using LibGit2Sharp.Tests.TestHelpers;
+using Xunit;
+
+namespace LibGit2Sharp.Tests
+{
+    public class OdbBackendFixture : BaseFixture
+    {
+        [Fact]
+        public void SimpleOdbBackendFixtureTest()
+        {
+            SelfCleaningDirectory scd = new SelfCleaningDirectory(this);
+
+            Repository.Init(scd.RootedDirectoryPath);
+
+            using (Repository repository = new Repository(scd.RootedDirectoryPath))
+            {
+                repository.ObjectDatabase.AddBackend(new MockOdbBackend(), priority: 5);
+
+                String filePath = Path.Combine(scd.RootedDirectoryPath, "file.txt");
+                String fileContents = "Hello!";
+
+                // Exercises read, write, writestream, exists
+                File.WriteAllText(filePath, fileContents);
+                repository.Index.Stage(filePath);
+
+                Signature signature = new Signature("SimpleOdbBackendFixtureTest", "user@example.com", DateTimeOffset.Now);
+                repository.Commit(String.Empty, signature, signature);
+
+                // Exercises read
+                Blob blob = repository.Lookup(new ObjectId("69342c5c39e5ae5f0077aecc32c0f81811fb8193")) as Blob;
+
+                Assert.NotNull(blob);
+                Assert.True(fileContents.Length == blob.Size);
+            }
+        }
+
+        #region MockOdbBackend
+
+        private class MockOdbBackend : OdbBackend
+        {
+            public MockOdbBackend()
+            {
+            }
+
+            protected override OdbBackend.OdbBackendOperations SupportedOperations
+            {
+                get
+                {
+                    return OdbBackendOperations.Read |
+                        OdbBackendOperations.ReadPrefix |
+                        OdbBackendOperations.Write |
+                        OdbBackendOperations.WriteStream |
+                        OdbBackendOperations.Exists;
+                }
+            }
+
+            public override int Read(byte[] oid, out Stream data, out GitObjectType objectType)
+            {
+                data = null;
+                objectType = GitObjectType.Bad;
+
+                MockGitObject gitObject;
+
+                if (m_objectIdToContent.TryGetValue(oid, out gitObject))
+                {
+                    data = Allocate(gitObject.Data.LongLength);
+                    data.Write(gitObject.Data, 0, gitObject.Data.Length);
+
+                    objectType = gitObject.ObjectType;
+
+                    return GIT_OK;
+                }
+
+                return GIT_ENOTFOUND;
+            }
+
+            public override int ReadPrefix(byte[] shortOid, out byte[] oid, out Stream data, out GitObjectType objectType)
+            {
+                oid = null;
+                data = null;
+                objectType = GitObjectType.Bad;
+
+                MockGitObject gitObjectAlreadyFound = null;
+
+                foreach (MockGitObject gitObject in m_objectIdToContent.Values)
+                {
+                    bool match = true;
+
+                    for (int i = 0; i < shortOid.Length; i++)
+                    {
+                        if (gitObject.ObjectId[i] != shortOid[i])
+                        {
+                            match = false;
+                            break;
+                        }
+                    }
+
+                    if (!match)
+                    {
+                        continue;
+                    }
+
+                    if (null != gitObjectAlreadyFound)
+                    {
+                        return GIT_EAMBIGUOUS;
+                    }
+
+                    gitObjectAlreadyFound = gitObject;
+                }
+
+                if (null != gitObjectAlreadyFound)
+                {
+                    oid = gitObjectAlreadyFound.ObjectId;
+                    objectType = gitObjectAlreadyFound.ObjectType;
+
+                    data = Allocate(gitObjectAlreadyFound.Data.LongLength);
+                    data.Write(gitObjectAlreadyFound.Data, 0, gitObjectAlreadyFound.Data.Length);
+
+                    return GIT_OK;
+                }
+
+                return GIT_ENOTFOUND;
+            }
+
+            public override int Write(byte[] oid, Stream dataStream, long length, GitObjectType objectType, out byte[] finalOid)
+            {
+                using (SHA1CryptoServiceProvider sha1 = new SHA1CryptoServiceProvider())
+                {
+                    finalOid = sha1.ComputeHash(dataStream);
+
+                    dataStream.Seek(0, SeekOrigin.Begin);
+                }
+
+                if (m_objectIdToContent.ContainsKey(finalOid))
+                {
+                    return GIT_EEXISTS;
+                }
+
+                if (length > (long)int.MaxValue)
+                {
+                    return GIT_ERROR;
+                }
+
+                byte[] buffer = new byte[length];
+                int bytesRead = dataStream.Read(buffer, 0, (int)length);
+
+                if (bytesRead != (int)length)
+                {
+                    return GIT_ERROR;
+                }
+
+                m_objectIdToContent.Add(finalOid, new MockGitObject(finalOid, objectType, buffer));
+
+                return GIT_OK;
+            }
+
+            public override int WriteStream(long length, GitObjectType objectType, out OdbBackendStream stream)
+            {
+                stream = new MockOdbBackendStream(this, objectType, length);
+
+                return GIT_OK;
+            }
+
+            public override bool Exists(byte[] oid)
+            {
+                return m_objectIdToContent.ContainsKey(oid);
+            }
+
+            private Dictionary<byte[], MockGitObject> m_objectIdToContent = new Dictionary<byte[], MockGitObject>(MockGitObjectComparer.Instance);
+
+            private const int GIT_OK = 0;
+            private const int GIT_ERROR = -1;
+            private const int GIT_ENOTFOUND = -3;
+            private const int GIT_EEXISTS = -4;
+            private const int GIT_EAMBIGUOUS = -5;
+
+            #region Unimplemented
+
+            public override int ReadHeader(byte[] oid, out int length, out GitObjectType objectType)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override int ReadStream(byte[] oid, out OdbBackendStream stream)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override int Foreach(OdbBackend.ForeachCallback callback)
+            {
+                throw new NotImplementedException();
+            }
+
+            #endregion
+
+            #region MockOdbBackendStream
+
+            private class MockOdbBackendStream : OdbBackendStream
+            {
+                public MockOdbBackendStream(MockOdbBackend backend, GitObjectType objectType, long length)
+                    : base(backend)
+                {
+                    m_type = objectType;
+                    m_length = length;
+                    m_hash = new SHA1CryptoServiceProvider();
+                }
+
+                protected override void Dispose()
+                {
+                    ((IDisposable)m_hash).Dispose();
+
+                    base.Dispose();
+                }
+
+                public override bool CanRead
+                {
+                    get
+                    {
+                        return false;
+                    }
+                }
+
+                public override bool CanWrite
+                {
+                    get
+                    {
+                        return true;
+                    }
+                }
+
+                public override int Write(Stream dataStream, long length)
+                {
+                    if (null == m_buffer)
+                    {
+                        m_buffer = new byte[length];
+
+                        if (length > (long)int.MaxValue)
+                            return GIT_ERROR;
+
+                        int bytesRead = dataStream.Read(m_buffer, 0, (int)length);
+
+                        if (bytesRead != (int)length)
+                            return GIT_ERROR;
+
+                        m_hash.TransformBlock(m_buffer, 0, (int)length, null, 0);
+                    }
+                    else
+                    {
+                        long newLength = m_buffer.LongLength + length;
+
+                        if (newLength > (long)int.MaxValue)
+                            return GIT_ERROR;
+
+                        byte[] newBuffer = new byte[newLength];
+                        Array.Copy(m_buffer, newBuffer, m_buffer.Length);
+
+                        int bytesRead = dataStream.Read(newBuffer, m_buffer.Length, (int)length);
+
+                        if (bytesRead != (int)length)
+                            return GIT_ERROR;
+
+                        m_hash.TransformBlock(newBuffer, m_buffer.Length, (int)length, null, 0);
+
+                        m_buffer = newBuffer;
+                    }
+
+                    return GIT_OK;
+                }
+
+                public override int FinalizeWrite(out byte[] oid)
+                {
+                    m_hash.TransformFinalBlock(m_buffer, 0, 0);
+                    oid = m_hash.Hash;
+
+                    if (m_buffer.Length != (int)m_length)
+                    {
+                        return GIT_ERROR;
+                    }
+
+                    MockOdbBackend backend = (MockOdbBackend)this.Backend;
+
+                    if (!backend.m_objectIdToContent.ContainsKey(oid))
+                    {
+                        backend.m_objectIdToContent.Add(oid, new MockGitObject(oid, m_type, m_buffer));
+                    }
+
+                    return GIT_OK;
+                }
+
+                private byte[] m_buffer;
+
+                private readonly GitObjectType m_type;
+                private readonly long m_length;
+                private readonly HashAlgorithm m_hash;
+
+                #region Unimplemented
+
+                public override int Read(Stream dataStream, long length)
+                {
+                    throw new NotImplementedException();
+                }
+
+                #endregion
+            }
+
+            #endregion
+
+            #region MockGitObject
+
+            private class MockGitObject
+            {
+                public MockGitObject(byte[] objectId, GitObjectType objectType, byte[] data)
+                {
+                    if (objectId.Length != 20)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    this.ObjectId = objectId;
+                    this.ObjectType = objectType;
+                    this.Data = data;
+                }
+
+                public byte[] ObjectId;
+                public GitObjectType ObjectType;
+                public byte[] Data;
+
+                public int Length
+                {
+                    get
+                    {
+                        return this.Data.Length;
+                    }
+                }
+            }
+
+            #endregion
+
+            #region MockGitObjectComparer
+
+            private class MockGitObjectComparer : IEqualityComparer<byte[]>
+            {
+                public bool Equals(byte[] x, byte[] y)
+                {
+                    for (int i = 0; i < 20; i++)
+                    {
+                        if (x[i] != y[i])
+                        {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                }
+
+                public int GetHashCode(byte[] obj)
+                {
+                    int toReturn = 0;
+
+                    for (int i = 0; i < obj.Length / 4; i++)
+                    {
+                        toReturn ^= (int)obj[4 * i] << 24 +
+                                    (int)obj[4 * i + 1] << 16 +
+                                    (int)obj[4 * i + 2] << 8 +
+                                    (int)obj[4 * i + 3];
+                    }
+
+                    return toReturn;
+                }
+
+                public static MockGitObjectComparer Instance
+                {
+                    get
+                    {
+                        if (null == s_instance)
+                        {
+                            s_instance = new MockGitObjectComparer();
+                        }
+
+                        return s_instance;
+                    }
+                }
+
+                private static MockGitObjectComparer s_instance;
+            }
+
+            #endregion
+        }
+
+        #endregion
+    }
+}

--- a/LibGit2Sharp/Core/GitOdbBackend.cs
+++ b/LibGit2Sharp/Core/GitOdbBackend.cs
@@ -1,0 +1,184 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace LibGit2Sharp.Core
+{
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct GitOdbBackend
+    {
+        static GitOdbBackend()
+        {
+            GCHandleOffset = Marshal.OffsetOf(typeof(GitOdbBackend), "GCHandle").ToInt32();
+        }
+
+#pragma warning disable 169
+
+        /// <summary>
+        /// This field is populated by libgit2 at backend addition time, and exists for its
+        /// use only. From this side of the interop, it is unreferenced.
+        /// </summary>
+        private IntPtr Odb;
+
+#pragma warning restore 169
+
+        public read_callback Read;
+        public read_prefix_callback ReadPrefix;
+        public read_header_callback ReadHeader;
+        public write_callback Write;
+        public writestream_callback WriteStream;
+        public readstream_callback ReadStream;
+        public exists_callback Exists;
+        public foreach_callback Foreach;
+        public free_callback Free;
+
+        /* The libgit2 structure definition ends here. Subsequent fields are for libgit2sharp bookkeeping. */
+
+        public IntPtr GCHandle;
+
+        /* The following static fields are not part of the structure definition. */
+
+        public static int GCHandleOffset;
+
+        /// <summary>
+        /// The backend is passed an OID. From that data the backend is expected to return a pointer to the
+        /// data for that object, the size of the data, and the type of the object.
+        /// </summary>
+        /// <param name="buffer_p">[out] If the call is successful, the backend will write the address of a buffer containing the object contents here.</param>
+        /// <param name="len_p">[out] If the call is successful, the backend will write the length of the buffer containing the object contents here.</param>
+        /// <param name="type_p">[out] If the call is successful, the backend will write the type of the object here.</param>
+        /// <param name="backend">[in] A pointer to the backend which is being asked to perform the task.</param>
+        /// <param name="oid">[in] The OID which the backend is being asked to look up.</param>
+        /// <returns>0 if successful; an error code otherwise.</returns>
+        public delegate int read_callback(
+            out IntPtr buffer_p,
+            out UIntPtr len_p,
+            out GitObjectType type_p,
+            IntPtr backend,
+            ref GitOid oid);
+
+        /// <summary>
+        /// The backend is passed a short OID and the number of characters in that short OID.
+        /// From that data the backend is expected to return the full OID (in out_oid), a pointer
+        /// to the data (in buffer_p), the size of the buffer returned in buffer_p (in len_p),
+        /// and the object type (in type_p). The short OID might not be long enough to resolve
+        /// to just one object. In that case the backend should return GIT_EAMBIGUOUS.
+        /// </summary>
+        /// <param name="out_oid">[out] If the call is successful, the backend will write the full OID if the object here.</param>
+        /// <param name="buffer_p">[out] If the call is successful, the backend will write the address of a buffer containing the object contents here.</param>
+        /// <param name="len_p">[out] If the call is successful, the backend will write the length of the buffer containing the object contents here.</param>
+        /// <param name="type_p">[out] If the call is successful, the backend will write the type of the object here.</param>
+        /// <param name="backend">[in] A pointer to the backend which is being asked to perform the task.</param>
+        /// <param name="short_oid">[in] The short-form OID which the backend is being asked to look up.</param>
+        /// <param name="len">[in] The length of the short-form OID (short_oid).</param>
+        /// <returns>0 if successful; an error code otherwise.</returns>
+        public delegate int read_prefix_callback(
+            out GitOid out_oid,
+            out IntPtr buffer_p,
+            out UIntPtr len_p,
+            out GitObjectType type_p,
+            IntPtr backend,
+            ref GitOid short_oid,
+            uint len);
+
+        /// <summary>
+        /// The backend is passed an OID. From that data the backend is expected to return the size of the
+        /// data for that OID, and the type of that OID.
+        /// </summary>
+        /// <param name="len_p">[out] If the call is successful, the backend will write the length of the data for the OID here.</param>
+        /// <param name="type_p">[out] If the call is successful, the backend will write the type of the object here.</param>
+        /// <param name="backend">[in] A pointer to the backend which is being asked to perform the task.</param>
+        /// <param name="oid">[in] The OID which the backend is being asked to look up.</param>
+        /// <returns>0 if successful; an error code otherwise.</returns>
+        public delegate int read_header_callback(
+            out UIntPtr len_p,
+            out GitObjectType type_p,
+            IntPtr backend,
+            ref GitOid oid);
+
+        /// <summary>
+        /// The backend is passed an OID, the type of the object, and its contents. The backend is asked to write
+        /// that data to the backing store.
+        /// </summary>
+        /// <param name="oid">[in] The OID which the backend is being asked to write.</param>
+        /// <param name="backend">[in] A pointer to the backend which is being asked to perform the task.</param>
+        /// <param name="data">[in] A pointer to the data for this object.</param>
+        /// <param name="len">[in] The length of the buffer pointed to by data.</param>
+        /// <param name="type">[in] The type of the object.</param>
+        /// <returns>0 if successful; an error code otherwise.</returns>
+        public delegate int write_callback(
+            ref GitOid oid,
+            IntPtr backend,
+            IntPtr data,
+            UIntPtr len,
+            GitObjectType type);
+
+        /// <summary>
+        /// The backend is passed an OID, the type of the object, and the length of its contents. The backend is
+        /// asked to return a stream object which the caller can use to write the contents of the object to the
+        /// backing store.
+        /// </summary>
+        /// <param name="stream_out">[out] The stream object which the caller will use to write the contents for this object.</param>
+        /// <param name="backend">[in] A pointer to the backend which is being asked to perform the task.</param>
+        /// <param name="length">[in] The length of the object's contents.</param>
+        /// <param name="type">[in] The type of the object being written.</param>
+        /// <returns>0 if successful; an error code otherwise.</returns>
+        public delegate int writestream_callback(
+            out IntPtr stream_out,
+            IntPtr backend,
+            UIntPtr length,
+            GitObjectType type);
+
+        /// <summary>
+        /// The backend is passed an OID. The backend is asked to return a stream object which the caller can use
+        /// to read the contents of this object from the backing store.
+        /// </summary>
+        /// <param name="stream_out">[out] The stream object which the caller will use to read the contents of this object.</param>
+        /// <param name="backend">[in] A pointer to the backend which is being asked to perform the task.</param>
+        /// <param name="oid">[in] The object ID that the caller is requesting.</param>
+        /// <returns>0 if successful; an error code otherwise.</returns>
+        public delegate int readstream_callback(
+            out IntPtr stream_out,
+            IntPtr backend,
+            ref GitOid oid);
+
+        /// <summary>
+        /// The backend is passed an OID. The backend is asked to return a value that indicates whether or not
+        /// the object exists in the backing store.
+        /// </summary>
+        /// <param name="backend">[in] A pointer to the backend which is being asked to perform the task.</param>
+        /// <param name="oid">[in] The object ID that the caller is requesting.</param>
+        /// <returns>True if the object exists; false otherwise</returns>
+        public delegate bool exists_callback(
+            IntPtr backend,
+            ref GitOid oid);
+
+        /// <summary>
+        /// The backend is passed a callback function and a void* to pass through to the callback. The backend is
+        /// asked to iterate through all objects in the backing store, invoking the callback for each item.
+        /// </summary>
+        /// <param name="backend">[in] A pointer to the backend which is being asked to perform the task.</param>
+        /// <param name="cb">[in] The callback function to invoke.</param>
+        /// <param name="data">[in] An arbitrary parameter to pass through to the callback</param>
+        public delegate int foreach_callback(
+            IntPtr backend,
+            foreach_callback_callback cb,
+            IntPtr data);
+
+        /// <summary>
+        /// The owner of this backend is finished with it. The backend is asked to clean up and shut down.
+        /// </summary>
+        /// <param name="backend">[in] A pointer to the backend which is being freed.</param>
+        public delegate void free_callback(
+            IntPtr backend);
+
+        /// <summary>
+        /// A callback for the backend's implementation of foreach.
+        /// </summary>
+        /// <param name="oid">The oid of each object in the backing store.</param>
+        /// <param name="data">The arbitrary parameter given to foreach_callback.</param>
+        /// <returns>A non-negative result indicates the enumeration should continue. Otherwise, the enumeration should stop.</returns>
+        public delegate int foreach_callback_callback(
+            ref GitOid oid,
+            IntPtr data);
+    }
+}

--- a/LibGit2Sharp/Core/GitOdbBackendStream.cs
+++ b/LibGit2Sharp/Core/GitOdbBackendStream.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace LibGit2Sharp.Core
+{
+    [Flags]
+    internal enum GitOdbBackendStreamMode
+    {
+        Read = 2,
+        Write = 4
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal class GitOdbBackendStream
+    {
+        static GitOdbBackendStream()
+        {
+            GCHandleOffset = Marshal.OffsetOf(typeof(GitOdbBackendStream), "GCHandle").ToInt32();
+        }
+
+        public IntPtr Backend;
+        public GitOdbBackendStreamMode Mode;
+
+        public read_callback Read;
+        public write_callback Write;
+        public finalize_write_callback FinalizeWrite;
+        public free_callback Free;
+
+        /* The libgit2 structure definition ends here. Subsequent fields are for libgit2sharp bookkeeping. */
+
+        public IntPtr GCHandle;
+
+        /* The following static fields are not part of the structure definition. */
+
+        public static int GCHandleOffset;
+
+        public delegate int read_callback(
+            IntPtr stream,
+            IntPtr buffer,
+            UIntPtr len);
+
+        public delegate int write_callback(
+            IntPtr stream,
+            IntPtr buffer,
+            UIntPtr len);
+
+        public delegate int finalize_write_callback(
+            out GitOid oid_p,
+            IntPtr stream);
+
+        public delegate void free_callback(
+            IntPtr stream);
+    }
+}

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -432,6 +432,12 @@ namespace LibGit2Sharp.Core
             IntPtr payload);
 
         [DllImport(libgit2)]
+        internal static extern int git_odb_add_backend(ObjectDatabaseSafeHandle odb, IntPtr backend, int priority);
+
+        [DllImport(libgit2)]
+        internal static extern IntPtr git_odb_backend_malloc(IntPtr backend, UIntPtr len);
+
+        [DllImport(libgit2)]
         internal static extern int git_odb_exists(ObjectDatabaseSafeHandle odb, ref GitOid id);
 
         [DllImport(libgit2)]

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -793,6 +793,26 @@ namespace LibGit2Sharp.Core
 
         #region git_odb_
 
+        public static void git_odb_add_backend(ObjectDatabaseSafeHandle odb, IntPtr backend, int priority)
+        {
+            Ensure.Success(NativeMethods.git_odb_add_backend(odb, backend, priority));
+        }
+
+        public static IntPtr git_odb_backend_malloc(IntPtr backend, UIntPtr len)
+        {
+            IntPtr toReturn = NativeMethods.git_odb_backend_malloc(backend, len);
+
+            if (IntPtr.Zero == toReturn)
+            {
+                throw new LibGit2SharpException(String.Format(CultureInfo.InvariantCulture,
+                                                              "Unable to allocate {0} bytes; out of memory",
+                                                              len.ToString()),
+                                                GitErrorCode.Error, GitErrorCategory.NoMemory);
+            }
+
+            return toReturn;
+        }
+
         public static bool git_odb_exists(ObjectDatabaseSafeHandle odb, ObjectId id)
         {
             GitOid oid = id.Oid;

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -86,6 +86,8 @@
     <Compile Include="Core\GitErrorCategory.cs" />
     <Compile Include="Core\GitNoteData.cs" />
     <Compile Include="Core\GitObjectExtensions.cs" />
+    <Compile Include="Core\GitOdbBackend.cs" />
+    <Compile Include="Core\GitOdbBackendStream.cs" />
     <Compile Include="Core\Handles\GitErrorSafeHandle.cs" />
     <Compile Include="Core\Handles\NoteSafeHandle.cs" />
     <Compile Include="Core\Handles\ObjectDatabaseSafeHandle.cs" />
@@ -147,6 +149,8 @@
     <Compile Include="Core\LookUpOptions.cs" />
     <Compile Include="Mode.cs" />
     <Compile Include="ObjectDatabase.cs" />
+    <Compile Include="OdbBackend.cs" />
+    <Compile Include="OdbBackendStream.cs" />
     <Compile Include="ReferenceWrapper.cs" />
     <Compile Include="ObjectId.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/LibGit2Sharp/ObjectDatabase.cs
+++ b/LibGit2Sharp/ObjectDatabase.cs
@@ -66,6 +66,19 @@ namespace LibGit2Sharp
             return repo.Lookup<Blob>(id);
         }
 
+        /// <summary>
+        ///   Adds the provided backend to the object database with the specified priority.
+        /// </summary>
+        /// <param name="backend">The backend to add</param>
+        /// <param name="priority">The priority at which libgit2 should consult this backend (higher values are consulted first)</param>
+        public virtual void AddBackend(OdbBackend backend, int priority)
+        {
+            Ensure.ArgumentNotNull(backend, "backend");
+            Ensure.ArgumentConformsTo<int>(priority, s => s > 0, "priority");
+
+            Proxy.git_odb_add_backend(this.handle, backend.GitOdbBackendPointer, priority);
+        }
+
         private class Processor
         {
             private readonly BinaryReader _reader;

--- a/LibGit2Sharp/OdbBackend.cs
+++ b/LibGit2Sharp/OdbBackend.cs
@@ -1,0 +1,589 @@
+﻿using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using LibGit2Sharp.Core;
+
+namespace LibGit2Sharp
+{
+    /// <summary>
+    ///   Base class for all custom managed backends for the libgit2 object database (ODB).
+    /// </summary>
+    public abstract class OdbBackend
+    {
+        /// <summary>
+        ///   Invoked by libgit2 when this backend is no longer needed.
+        /// </summary>
+        protected virtual void Dispose()
+        {
+            if (IntPtr.Zero != nativeBackendPointer)
+            {
+                GCHandle.FromIntPtr(Marshal.ReadIntPtr(nativeBackendPointer, GitOdbBackend.GCHandleOffset)).Free();
+                Marshal.FreeHGlobal(nativeBackendPointer);
+                nativeBackendPointer = IntPtr.Zero;
+            }
+        }
+
+        /// <summary>
+        ///   In your subclass, override this member to provide the list of actions your backend supports.
+        /// </summary>
+        protected abstract OdbBackendOperations SupportedOperations
+        {
+            get;
+        }
+
+        /// <summary>
+        ///   Call this method from your implementations of Read and ReadPrefix to allocate a buffer in
+        ///   which to return the object's data.
+        /// </summary>
+        /// <param name="bytes">Number of bytes to allocate</param>
+        /// <returns>An Stream for you to write to and then return. Do not dispose this object before returning it.</returns>
+        protected unsafe Stream Allocate(long bytes)
+        {
+            if (bytes < 0 ||
+                (UIntPtr.Size == sizeof(int) && bytes > int.MaxValue))
+            {
+                throw new ArgumentOutOfRangeException("bytes");
+            }
+
+            IntPtr buffer = Proxy.git_odb_backend_malloc(this.GitOdbBackendPointer, new UIntPtr((ulong)bytes));
+
+            return new UnmanagedMemoryStream((byte*)buffer, 0, bytes, FileAccess.ReadWrite);
+        }
+
+        /// <summary>
+        ///   Requests that this backend read an object.
+        /// </summary>
+        public abstract int Read(byte[] oid,
+            out Stream data,
+            out GitObjectType objectType);
+
+        /// <summary>
+        ///   Requests that this backend read an object. The object ID may not be complete (may be a prefix).
+        /// </summary>
+        public abstract int ReadPrefix(byte[] shortOid,
+            out byte[] oid,
+            out Stream data,
+            out GitObjectType objectType);
+
+        /// <summary>
+        ///   Requests that this backend read an object's header (length and object type) but not its contents.
+        /// </summary>
+        public abstract int ReadHeader(byte[] oid,
+            out int length,
+            out GitObjectType objectType);
+
+        /// <summary>
+        ///   Requests that this backend write an object to the backing store. The backend may need to compute the object ID
+        ///   and return it to the caller.
+        /// </summary>
+        public abstract int Write(byte[] oid,
+            Stream dataStream,
+            long length,
+            GitObjectType objectType,
+            out byte[] finalOid);
+
+        /// <summary>
+        ///   Requests that this backend read an object. Returns a stream so that the caller can read the data in chunks.
+        /// </summary>
+        public abstract int ReadStream(byte[] oid,
+            out OdbBackendStream stream);
+
+        /// <summary>
+        ///   Requests that this backend write an object to the backing store. Returns a stream so that the caller can write
+        ///   the data in chunks.
+        /// </summary>
+        public abstract int WriteStream(long length,
+            GitObjectType objectType,
+            out OdbBackendStream stream);
+
+        /// <summary>
+        ///   Requests that this backend check if an object ID exists.
+        /// </summary>
+        public abstract bool Exists(byte[] oid);
+
+        /// <summary>
+        ///   Requests that this backend enumerate all items in the backing store.
+        /// </summary>
+        public abstract int Foreach(ForeachCallback callback);
+
+        /// <summary>
+        ///   The signature of the callback method provided to the Foreach method.
+        /// </summary>
+        /// <param name="oid">The object ID of the object in the backing store.</param>
+        /// <returns>A non-negative result indicates the enumeration should continue. Otherwise, the enumeration should stop.</returns>
+        public delegate int ForeachCallback(byte[] oid);
+
+        private IntPtr nativeBackendPointer;
+
+        internal IntPtr GitOdbBackendPointer
+        {
+            get
+            {
+                if (IntPtr.Zero == nativeBackendPointer)
+                {
+                    var nativeBackend = new GitOdbBackend();
+
+                    // The "free" entry point is always provided.
+                    nativeBackend.Free = BackendEntryPoints.FreeCallback;
+
+                    var supportedOperations = this.SupportedOperations;
+
+                    if ((supportedOperations & OdbBackendOperations.Read) != 0)
+                    {
+                        nativeBackend.Read = BackendEntryPoints.ReadCallback;
+                    }
+
+                    if ((supportedOperations & OdbBackendOperations.ReadPrefix) != 0)
+                    {
+                        nativeBackend.ReadPrefix = BackendEntryPoints.ReadPrefixCallback;
+                    }
+
+                    if ((supportedOperations & OdbBackendOperations.ReadHeader) != 0)
+                    {
+                        nativeBackend.ReadHeader = BackendEntryPoints.ReadHeaderCallback;
+                    }
+
+                    if ((supportedOperations & OdbBackendOperations.Write) != 0)
+                    {
+                        nativeBackend.Write = BackendEntryPoints.WriteCallback;
+                    }
+
+                    if ((supportedOperations & OdbBackendOperations.WriteStream) != 0)
+                    {
+                        nativeBackend.WriteStream = BackendEntryPoints.WriteStreamCallback;
+                    }
+
+                    if ((supportedOperations & OdbBackendOperations.Exists) != 0)
+                    {
+                        nativeBackend.Exists = BackendEntryPoints.ExistsCallback;
+                    }
+
+                    if ((supportedOperations & OdbBackendOperations.Foreach) != 0)
+                    {
+                        nativeBackend.Foreach = BackendEntryPoints.ForeachCallback;
+                    }
+
+                    nativeBackend.GCHandle = GCHandle.ToIntPtr(GCHandle.Alloc(this));
+                    nativeBackendPointer = Marshal.AllocHGlobal(Marshal.SizeOf(nativeBackend));
+                    Marshal.StructureToPtr(nativeBackend, nativeBackendPointer, false);
+                }
+
+                return nativeBackendPointer;
+            }
+        }
+
+        private static class BackendEntryPoints
+        {
+            // Because our GitOdbBackend structure exists on the managed heap only for a short time (to be marshaled
+            // to native memory with StructureToPtr), we need to bind to static delegates. If at construction time
+            // we were to bind to the methods directly, that's the same as newing up a fresh delegate every time.
+            // Those delegates won't be rooted in the object graph and can be collected as soon as StructureToPtr finishes.
+            public static GitOdbBackend.read_callback ReadCallback = new GitOdbBackend.read_callback(Read);
+            public static GitOdbBackend.read_prefix_callback ReadPrefixCallback = new GitOdbBackend.read_prefix_callback(ReadPrefix);
+            public static GitOdbBackend.read_header_callback ReadHeaderCallback = new GitOdbBackend.read_header_callback(ReadHeader);
+            public static GitOdbBackend.write_callback WriteCallback = new GitOdbBackend.write_callback(Write);
+            public static GitOdbBackend.writestream_callback WriteStreamCallback = new GitOdbBackend.writestream_callback(WriteStream);
+            public static GitOdbBackend.exists_callback ExistsCallback = new GitOdbBackend.exists_callback(Exists);
+            public static GitOdbBackend.foreach_callback ForeachCallback = new GitOdbBackend.foreach_callback(Foreach);
+            public static GitOdbBackend.free_callback FreeCallback = new GitOdbBackend.free_callback(Free);
+
+            private unsafe static int Read(
+                out IntPtr buffer_p,
+                out UIntPtr len_p,
+                out GitObjectType type_p,
+                IntPtr backend,
+                ref GitOid oid)
+            {
+                buffer_p = IntPtr.Zero;
+                len_p = UIntPtr.Zero;
+                type_p = GitObjectType.Bad;
+
+                OdbBackend odbBackend = GCHandle.FromIntPtr(Marshal.ReadIntPtr(backend, GitOdbBackend.GCHandleOffset)).Target as OdbBackend;
+
+                if (odbBackend != null)
+                {
+                    Stream dataStream = null;
+                    GitObjectType objectType;
+
+                    try
+                    {
+                        int toReturn = odbBackend.Read(oid.Id, out dataStream, out objectType);
+
+                        if (0 == toReturn)
+                        {
+                            // Caller is expected to give us back a stream created with the Allocate() method.
+                            UnmanagedMemoryStream memoryStream = dataStream as UnmanagedMemoryStream;
+
+                            if (null == memoryStream)
+                            {
+                                return (int)GitErrorCode.Error;
+                            }
+
+                            len_p = new UIntPtr((ulong)memoryStream.Capacity);
+                            type_p = objectType;
+
+                            memoryStream.Seek(0, SeekOrigin.Begin);
+                            buffer_p = new IntPtr(memoryStream.PositionPointer);
+                        }
+
+                        return toReturn;
+                    }
+                    catch
+                    {
+                        // TODO: Set a rich error message for libgit2
+                    }
+                    finally
+                    {
+                        if (null != dataStream)
+                        {
+                            dataStream.Dispose();
+                        }
+                    }
+                }
+
+                return (int)GitErrorCode.Error;
+            }
+
+            private unsafe static int ReadPrefix(
+                out GitOid out_oid,
+                out IntPtr buffer_p,
+                out UIntPtr len_p,
+                out GitObjectType type_p,
+                IntPtr backend,
+                ref GitOid short_oid,
+                uint len)
+            {
+                out_oid = default(GitOid);
+                buffer_p = IntPtr.Zero;
+                len_p = UIntPtr.Zero;
+                type_p = GitObjectType.Bad;
+
+                OdbBackend odbBackend = GCHandle.FromIntPtr(Marshal.ReadIntPtr(backend, GitOdbBackend.GCHandleOffset)).Target as OdbBackend;
+
+                if (odbBackend != null)
+                {
+                    byte[] oid;
+                    Stream dataStream = null;
+                    GitObjectType objectType;
+
+                    try
+                    {
+                        // The length of short_oid is described in characters (40 per full ID) vs. bytes (20)
+                        // which is what we care about.
+                        byte[] shortOidArray = new byte[len >> 1];
+                        Array.Copy(short_oid.Id, shortOidArray, shortOidArray.Length);
+
+                        int toReturn = odbBackend.ReadPrefix(shortOidArray, out oid, out dataStream, out objectType);
+
+                        if (0 == toReturn)
+                        {
+                            // Caller is expected to give us back a stream created with the Allocate() method.
+                            UnmanagedMemoryStream memoryStream = dataStream as UnmanagedMemoryStream;
+
+                            if (null == memoryStream)
+                            {
+                                return (int)GitErrorCode.Error;
+                            }
+
+                            out_oid.Id = oid;
+                            len_p = new UIntPtr((ulong)memoryStream.Capacity);
+                            type_p = objectType;
+
+                            memoryStream.Seek(0, SeekOrigin.Begin);
+                            buffer_p = new IntPtr(memoryStream.PositionPointer);
+                        }
+
+                        return toReturn;
+                    }
+                    catch
+                    {
+                        // TODO: Set a rich error message for libgit2
+                    }
+                    finally
+                    {
+                        if (null != dataStream)
+                        {
+                            dataStream.Dispose();
+                        }
+                    }
+                }
+
+                return (int)GitErrorCode.Error;
+            }
+
+            private static int ReadHeader(
+                out UIntPtr len_p,
+                out GitObjectType type_p,
+                IntPtr backend,
+                ref GitOid oid)
+            {
+                len_p = UIntPtr.Zero;
+                type_p = GitObjectType.Bad;
+
+                OdbBackend odbBackend = GCHandle.FromIntPtr(Marshal.ReadIntPtr(backend, GitOdbBackend.GCHandleOffset)).Target as OdbBackend;
+
+                if (odbBackend != null)
+                {
+                    int length;
+                    GitObjectType objectType;
+
+                    try
+                    {
+                        int toReturn = odbBackend.ReadHeader(oid.Id, out length, out objectType);
+
+                        if (0 == toReturn)
+                        {
+                            len_p = new UIntPtr((uint)length);
+                            type_p = objectType;
+                        }
+
+                        return toReturn;
+                    }
+                    catch
+                    {
+                        // TODO: Set a rich error message for libgit2
+                    }
+                }
+
+                return (int)GitErrorCode.Error;
+            }
+
+            private static unsafe int Write(
+                ref GitOid oid,
+                IntPtr backend,
+                IntPtr data,
+                UIntPtr len,
+                GitObjectType type)
+            {
+                OdbBackend odbBackend = GCHandle.FromIntPtr(Marshal.ReadIntPtr(backend, GitOdbBackend.GCHandleOffset)).Target as OdbBackend;
+
+                if (odbBackend != null &&
+                    len.ToUInt64() < (ulong)long.MaxValue)
+                {
+                    try
+                    {
+                        using (UnmanagedMemoryStream stream = new UnmanagedMemoryStream((byte*)data, (long)len.ToUInt64()))
+                        {
+                            byte[] finalOid;
+
+                            int toReturn = odbBackend.Write(oid.Id, stream, (long)len.ToUInt64(), type, out finalOid);
+
+                            if (0 == toReturn)
+                            {
+                                oid.Id = finalOid;
+                            }
+
+                            return toReturn;
+                        }
+                    }
+                    catch
+                    {
+                        // TODO: Set a rich error message for libgit2
+                    }
+                }
+
+                return (int)GitErrorCode.Error;
+            }
+
+            private static int WriteStream(
+                out IntPtr stream_out,
+                IntPtr backend,
+                UIntPtr length,
+                GitObjectType type)
+            {
+                stream_out = IntPtr.Zero;
+
+                OdbBackend odbBackend = GCHandle.FromIntPtr(Marshal.ReadIntPtr(backend, GitOdbBackend.GCHandleOffset)).Target as OdbBackend;
+
+                if (odbBackend != null &&
+                    length.ToUInt64() < (ulong)long.MaxValue)
+                {
+                    OdbBackendStream stream;
+
+                    try
+                    {
+                        int toReturn = odbBackend.WriteStream((long)length.ToUInt64(), type, out stream);
+
+                        if (0 == toReturn)
+                        {
+                            stream_out = stream.GitOdbBackendStreamPointer;
+                        }
+
+                        return toReturn;
+                    }
+                    catch
+                    {
+                        // TODO: Set a rich error message for libgit2
+                    }
+                }
+
+                return (int)GitErrorCode.Error;
+            }
+
+            private static int ReadStream(
+                out IntPtr stream_out,
+                IntPtr backend,
+                ref GitOid oid)
+            {
+                stream_out = IntPtr.Zero;
+
+                OdbBackend odbBackend = GCHandle.FromIntPtr(Marshal.ReadIntPtr(backend, GitOdbBackend.GCHandleOffset)).Target as OdbBackend;
+
+                if (odbBackend != null)
+                {
+                    OdbBackendStream stream;
+
+                    try
+                    {
+                        int toReturn = odbBackend.ReadStream(oid.Id, out stream);
+
+                        if (0 == toReturn)
+                        {
+                            stream_out = stream.GitOdbBackendStreamPointer;
+                        }
+
+                        return toReturn;
+                    }
+                    catch
+                    {
+                        // TODO: Set a rich error message for libgit2
+                    }
+                }
+
+                return (int)GitErrorCode.Error;
+            }
+
+            private static bool Exists(
+                IntPtr backend,
+                ref GitOid oid)
+            {
+                OdbBackend odbBackend = GCHandle.FromIntPtr(Marshal.ReadIntPtr(backend, GitOdbBackend.GCHandleOffset)).Target as OdbBackend;
+
+                if (odbBackend != null)
+                {
+                    try
+                    {
+                        return odbBackend.Exists(oid.Id);
+                    }
+                    catch
+                    {
+                        // TODO: Set a rich error message for libgit2
+                    }
+                }
+
+                return false;
+            }
+
+            private static int Foreach(
+                IntPtr backend,
+                GitOdbBackend.foreach_callback_callback cb,
+                IntPtr data)
+            {
+                OdbBackend odbBackend = GCHandle.FromIntPtr(Marshal.ReadIntPtr(backend, GitOdbBackend.GCHandleOffset)).Target as OdbBackend;
+
+                if (odbBackend != null)
+                {
+                    try
+                    {
+                        return odbBackend.Foreach(new ForeachState(cb, data).ManagedCallback);
+                    }
+                    catch
+                    {
+                        // TODO: Set a rich error message for libgit2
+                    }
+                }
+
+                return (int)GitErrorCode.Error;
+            }
+
+            private static void Free(
+                IntPtr backend)
+            {
+                GCHandle gcHandle = GCHandle.FromIntPtr(Marshal.ReadIntPtr(backend, GitOdbBackend.GCHandleOffset));
+                OdbBackend odbBackend = gcHandle.Target as OdbBackend;
+
+                if (odbBackend != null)
+                {
+                    try
+                    {
+                        odbBackend.Dispose();
+                    }
+                    catch
+                    {
+                        // TODO: Set a rich error message for libgit2
+                    }
+                }
+            }
+
+            private class ForeachState
+            {
+                public ForeachState(GitOdbBackend.foreach_callback_callback cb, IntPtr data)
+                {
+                    this.cb = cb;
+                    this.data = data;
+                    this.ManagedCallback = CallbackMethod;
+                }
+
+                private int CallbackMethod(byte[] oid)
+                {
+                    GitOid gitOid = new GitOid();
+                    gitOid.Id = oid;
+
+                    return cb(ref gitOid, data);
+                }
+
+                public ForeachCallback ManagedCallback;
+
+                private GitOdbBackend.foreach_callback_callback cb;
+                private IntPtr data;                
+            }
+        }
+
+        /// <summary>
+        ///   Flags used by subclasses of OdbBackend to indicate which operations they support.
+        /// </summary>
+        [Flags]
+        protected enum OdbBackendOperations
+        {
+            /// <summary>
+            ///   This OdbBackend declares that it supports the Read method.
+            /// </summary>
+            Read = 1,
+
+            /// <summary>
+            ///   This OdbBackend declares that it supports the ReadPrefix method.
+            /// </summary>
+            ReadPrefix = 2,
+
+            /// <summary>
+            ///   This OdbBackend declares that it supports the ReadHeader method.
+            /// </summary>
+            ReadHeader = 4,
+
+            /// <summary>
+            ///   This OdbBackend declares that it supports the Write method.
+            /// </summary>
+            Write = 8,
+
+            /// <summary>
+            ///   This OdbBackend declares that it supports the ReadStream method.
+            /// </summary>
+            ReadStream = 16,
+
+            /// <summary>
+            ///   This OdbBackend declares that it supports the WriteStream method.
+            /// </summary>
+            WriteStream = 32,
+
+            /// <summary>
+            ///   This OdbBackend declares that it supports the Exists method.
+            /// </summary>
+            Exists = 64,
+
+            /// <summary>
+            ///   This OdbBackend declares that it supports the Foreach method.
+            /// </summary>
+            Foreach = 128,
+        }
+    }
+}

--- a/LibGit2Sharp/OdbBackendStream.cs
+++ b/LibGit2Sharp/OdbBackendStream.cs
@@ -1,0 +1,218 @@
+﻿using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using LibGit2Sharp.Core;
+
+namespace LibGit2Sharp
+{
+    /// <summary>
+    ///   When an OdbBackend implements the WriteStream or ReadStream methods, it returns an OdbBackendStream to libgit2.
+    ///   Libgit2 then uses the OdbBackendStream to read or write from the backend in a streaming fashion.
+    /// </summary>
+    public abstract class OdbBackendStream
+    {
+        /// <summary>
+        /// This is to quiet the MetaFixture.TypesInLibGit2SharpMustBeExtensibleInATestingContext test.
+        /// Do not use this constructor.
+        /// </summary>
+        protected internal OdbBackendStream()
+        {
+            throw new InvalidOperationException();
+        }
+
+        /// <summary>
+        /// Base constructor for OdbBackendStream. Make sure that your derived class calls this base constructor.
+        /// </summary>
+        /// <param name="backend">The backend to which this backend stream is attached.</param>
+        protected OdbBackendStream(OdbBackend backend)
+        {
+            this.backend = backend;
+        }
+
+        /// <summary>
+        ///   Invoked by libgit2 when this stream is no longer needed.
+        /// </summary>
+        protected virtual void Dispose()
+        {
+            if (IntPtr.Zero != nativeBackendStreamPointer)
+            {
+                GCHandle.FromIntPtr(Marshal.ReadIntPtr(nativeBackendStreamPointer, GitOdbBackendStream.GCHandleOffset)).Free();
+                Marshal.FreeHGlobal(nativeBackendStreamPointer);
+                nativeBackendStreamPointer = IntPtr.Zero;
+            }
+        }
+
+        /// <summary>
+        ///   If true, then it is legal to call the Read method.
+        /// </summary>
+        public abstract bool CanRead
+        {
+            get;
+        }
+
+        /// <summary>
+        ///   If true, then it is legal to call the Write and FinalizeWrite methods.
+        /// </summary>
+        public abstract bool CanWrite
+        {
+            get;
+        }
+
+        /// <summary>
+        ///   Requests that the stream write the next length bytes of the stream to the provided Stream object.
+        /// </summary>
+        public abstract int Read(
+            Stream dataStream,
+            long length);
+
+        /// <summary>
+        ///   Requests that the stream write the first length bytes of the provided Stream object to the stream.
+        /// </summary>
+        public abstract int Write(
+            Stream dataStream,
+            long length);
+
+        /// <summary>
+        ///   After all bytes have been written to the stream, the object ID can be retrieved by calling FinalizeWrite.
+        /// </summary>
+        public abstract int FinalizeWrite(
+            out byte[] oid);
+
+        /// <summary>
+        ///   The backend object this stream was created by.
+        /// </summary>
+        public virtual OdbBackend Backend
+        {
+            get
+            {
+                return this.backend;
+            }
+        }
+
+        private OdbBackend backend;
+        private IntPtr nativeBackendStreamPointer;
+
+        internal IntPtr GitOdbBackendStreamPointer
+        {
+            get
+            {
+                if (IntPtr.Zero == nativeBackendStreamPointer)
+                {
+                    var nativeBackendStream = new GitOdbBackendStream();
+
+                    nativeBackendStream.Backend = this.backend.GitOdbBackendPointer;
+                    nativeBackendStream.Free = BackendStreamEntryPoints.FreeCallback;
+
+                    if (CanRead)
+                    {
+                        nativeBackendStream.Read = BackendStreamEntryPoints.ReadCallback;
+
+                        nativeBackendStream.Mode |= GitOdbBackendStreamMode.Read;
+                    }
+
+                    if (CanWrite)
+                    {
+                        nativeBackendStream.Write = BackendStreamEntryPoints.WriteCallback;
+                        nativeBackendStream.FinalizeWrite = BackendStreamEntryPoints.FinalizeWriteCallback;
+
+                        nativeBackendStream.Mode |= GitOdbBackendStreamMode.Write;
+                    }
+
+                    nativeBackendStream.GCHandle = GCHandle.ToIntPtr(GCHandle.Alloc(this));
+                    nativeBackendStreamPointer = Marshal.AllocHGlobal(Marshal.SizeOf(nativeBackendStream));
+                    Marshal.StructureToPtr(nativeBackendStream, nativeBackendStreamPointer, false);
+                }
+
+                return nativeBackendStreamPointer;
+            }
+        }
+
+        private static class BackendStreamEntryPoints
+        {
+            // Because our GitOdbBackendStream structure exists on the managed heap only for a short time (to be marshaled
+            // to native memory with StructureToPtr), we need to bind to static delegates. If at construction time
+            // we were to bind to the methods directly, that's the same as newing up a fresh delegate every time.
+            // Those delegates won't be rooted in the object graph and can be collected as soon as StructureToPtr finishes.
+            public static GitOdbBackendStream.read_callback ReadCallback = new GitOdbBackendStream.read_callback(Read);
+            public static GitOdbBackendStream.write_callback WriteCallback = new GitOdbBackendStream.write_callback(Write);
+            public static GitOdbBackendStream.finalize_write_callback FinalizeWriteCallback = new GitOdbBackendStream.finalize_write_callback(FinalizeWrite);
+            public static GitOdbBackendStream.free_callback FreeCallback = new GitOdbBackendStream.free_callback(Free);
+
+            private unsafe static int Read(
+                IntPtr stream,
+                IntPtr buffer,
+                UIntPtr len)
+            {
+                OdbBackendStream odbBackendStream = GCHandle.FromIntPtr(Marshal.ReadIntPtr(stream, GitOdbBackendStream.GCHandleOffset)).Target as OdbBackendStream;
+
+                if (odbBackendStream != null &&
+                    len.ToUInt64() < (ulong)long.MaxValue)
+                {
+                    using (UnmanagedMemoryStream memoryStream = new UnmanagedMemoryStream((byte*)buffer, 0, (long)len.ToUInt64(), FileAccess.ReadWrite))
+                    {
+                        return odbBackendStream.Read(memoryStream, (long)len.ToUInt64());
+                    }
+                }
+
+                return (int)GitErrorCode.Error;
+            }
+
+            private static unsafe int Write(
+                IntPtr stream,
+                IntPtr buffer,
+                UIntPtr len)
+            {
+                OdbBackendStream odbBackendStream = GCHandle.FromIntPtr(Marshal.ReadIntPtr(stream, GitOdbBackendStream.GCHandleOffset)).Target as OdbBackendStream;
+
+                if (odbBackendStream != null &&
+                    len.ToUInt64() < (ulong)long.MaxValue)
+                {
+                    long length = (long)len.ToUInt64();
+
+                    using (UnmanagedMemoryStream dataStream = new UnmanagedMemoryStream((byte*)buffer, length))
+                    {
+                        return odbBackendStream.Write(dataStream, length);
+                    }
+                }
+
+                return (int)GitErrorCode.Error;
+            }
+
+            private static int FinalizeWrite(
+                out GitOid oid_p,
+                IntPtr stream)
+            {
+                oid_p = default(GitOid);
+
+                OdbBackendStream odbBackendStream = GCHandle.FromIntPtr(Marshal.ReadIntPtr(stream, GitOdbBackendStream.GCHandleOffset)).Target as OdbBackendStream;
+
+                if (odbBackendStream != null)
+                {
+                    byte[] computedObjectId;
+
+                    int toReturn = odbBackendStream.FinalizeWrite(out computedObjectId);
+
+                    if (0 == toReturn)
+                    {
+                        oid_p.Id = computedObjectId;
+                    }
+
+                    return toReturn;
+                }
+
+                return (int)GitErrorCode.Error;
+            }
+
+            private static void Free(
+                IntPtr stream)
+            {
+                OdbBackendStream odbBackendStream = GCHandle.FromIntPtr(Marshal.ReadIntPtr(stream, GitOdbBackendStream.GCHandleOffset)).Target as OdbBackendStream;
+
+                if (odbBackendStream != null)
+                {
+                    odbBackendStream.Dispose();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds interop for an ODB backend to be implemented in C#.

The author of the backend derives their backend from the abstract class `OdbBackend` (and `OdbBackendStream` if they are supporting streaming reads or writes). The author declares, through the `SupportedOperations` property, which operations their backend supports.

The backend is added at runtime to the object database by calling `ObjectDatabase.AddBackend` and passing a reference to the backend and a priority.

This pull request includes a test that exercises most of the backend functionality.

Some of the interop in this change is not for the faint of heart :-)
