### PR TITLE
Add support for unborn branches

### DIFF
--- a/LibGit2Sharp.Tests/BranchFixture.cs
+++ b/LibGit2Sharp.Tests/BranchFixture.cs
@@ -280,6 +280,44 @@ namespace LibGit2Sharp.Tests
             }
         }
 
+        public void CanGetInformationFromUnbornBranch()
+        {
+            SelfCleaningDirectory scd = BuildSelfCleaningDirectory();
+            using (var repo = Repository.Init(scd.DirectoryPath, true))
+            {
+                var head = repo.Head;
+
+                Assert.Equal("refs/heads/master", head.CanonicalName);
+                Assert.Equal(0, head.Commits.Count());
+                Assert.True(head.IsCurrentRepositoryHead);
+                Assert.False(head.IsRemote);
+                Assert.Equal("master", head.Name);
+                Assert.Null(head.Tip);
+                Assert.Null(head["huh?"]);
+
+                Assert.Null(head.AheadBy);
+                Assert.Null(head.BehindBy);
+                Assert.False(head.IsTracking);
+                Assert.Null(head.TrackedBranch);
+            }
+        }
+
+        [Fact]
+        public void CanGetTrackingInformationFromBranchSharingNoHistoryWithItsTrackedBranch()
+        {
+            TemporaryCloneOfTestRepo path = BuildTemporaryCloneOfTestRepo(StandardTestRepoWorkingDirPath);
+            using (var repo = new Repository(path.RepositoryPath))
+            {
+                Branch master = repo.Branches["master"];
+                repo.Refs.UpdateTarget("refs/remotes/origin/master", "origin/test");
+
+                Assert.True(master.IsTracking);
+                Assert.Null(master.AheadBy);
+                Assert.Null(master.BehindBy);
+                Assert.NotNull(master.TrackedBranch);
+            }
+        }
+
         [Fact]
         public void TrackingInformationIsEmptyForNonTrackingBranch()
         {
@@ -288,8 +326,8 @@ namespace LibGit2Sharp.Tests
                 Branch branch = repo.Branches["test"];
                 Assert.False(branch.IsTracking);
                 Assert.Null(branch.TrackedBranch);
-                Assert.Equal(0, branch.AheadBy);
-                Assert.Equal(0, branch.BehindBy);
+                Assert.Null(branch.AheadBy);
+                Assert.Null(branch.BehindBy);
             }
         }
 

--- a/LibGit2Sharp/Branch.cs
+++ b/LibGit2Sharp/Branch.cs
@@ -80,7 +80,7 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
-        ///   Gets the remote branch which is connected to this local one.
+        ///   Gets the remote branch which is connected to this local one, or null if there is none.
         /// </summary>
         public virtual Branch TrackedBranch
         {
@@ -95,20 +95,43 @@ namespace LibGit2Sharp
             get { return TrackedBranch != null; }
         }
 
+        private bool ExistsPathToTrackedBranch()
+        {
+            if (!IsTracking)
+            {
+                return false;
+            }
+
+            if (repo.Commits.FindCommonAncestor(Tip, TrackedBranch.Tip) == null)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
         /// <summary>
         ///   Gets the number of commits, starting from the <see cref="Tip"/>, that have been performed on this local branch and aren't known from the remote one.
+        ///   <para>
+        ///     This property will return null if there is no remote branch linked to this local branch, or if the remote branch and the local branch do
+        ///     not share a common ancestor.
+        ///   </para>
         /// </summary>
-        public virtual int AheadBy
+        public virtual int? AheadBy
         {
-            get { return IsTracking ? repo.Commits.QueryBy(new Filter { Since = Tip, Until = TrackedBranch }).Count() : 0; }
+            get { return ExistsPathToTrackedBranch() ? repo.Commits.QueryBy(new Filter { Since = Tip, Until = TrackedBranch }).Count() : (int?)null; }
         }
 
         /// <summary>
         ///   Gets the number of commits that exist in the remote branch, on top of <see cref="Tip"/>, and aren't known from the local one.
+        ///   <para>
+        ///     This property will return null if there is no remote branch linked to this local branch, or if the remote branch and the local branch do
+        ///     not share a common ancestor.
+        ///   </para>
         /// </summary>
-        public virtual int BehindBy
+        public virtual int? BehindBy
         {
-            get { return IsTracking ? repo.Commits.QueryBy(new Filter { Since = TrackedBranch, Until = Tip }).Count() : 0; }
+            get { return ExistsPathToTrackedBranch() ? repo.Commits.QueryBy(new Filter { Since = TrackedBranch, Until = Tip }).Count() : (int?)null; }
         }
 
         /// <summary>
@@ -140,16 +163,23 @@ namespace LibGit2Sharp
 
         private Branch ResolveTrackedBranch()
         {
-            using (ReferenceSafeHandle branchPtr = repo.Refs.RetrieveReferencePtr(CanonicalName))
-            using (ReferenceSafeHandle referencePtr = Proxy.git_branch_tracking(branchPtr))
+            using (ReferenceSafeHandle branchPtr = repo.Refs.RetrieveReferencePtr(CanonicalName, false))
             {
-                if (referencePtr == null)
+                if (branchPtr == null)
                 {
                     return null;
                 }
 
-                var reference = Reference.BuildFromPtr<Reference>(referencePtr, repo);
-                return repo.Branches[reference.CanonicalName];
+                using (ReferenceSafeHandle referencePtr = Proxy.git_branch_tracking(branchPtr))
+                {
+                    if (referencePtr == null)
+                    {
+                        return null;
+                    }
+
+                    var reference = Reference.BuildFromPtr<Reference>(referencePtr, repo);
+                    return repo.Branches[reference.CanonicalName];
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #216

Here is the state for all cases:
- Unborn branch: `null/false/null/null`
- Local branch with no tracked branch: `null/false/null/null`.
- Local branch with a tracked branch, but which does not share history with it: `something/true/null/null`.

Thoughts for the future: with git.git, a local branch can have more than one tracked branch. 
This does not seem to be yet supported by libgit2: `git_branch_tracking` can only be used to get one reference.

However, when it is supported, it means that AheadBy/BehindBy surely won't be properties of the Branch anymore. One idea could be to have a `IEnumerable<TrackingInformation>` in Branch, which would contain this information (and the information linked to each TrackedBranch).

Also, it seems that git.git differentiates between AheadBy/BehindBy (for when we are on the same timeline with the tracked branch) and Different (for when the local and remote have diverged, or do not even share the same history).
