### PR TITLE
Clone

### DIFF
--- a/LibGit2Sharp.Tests/RepositoryFixture.cs
+++ b/LibGit2Sharp.Tests/RepositoryFixture.cs
@@ -4,12 +4,14 @@ using System.IO;
 using System.Linq;
 using LibGit2Sharp.Tests.TestHelpers;
 using Xunit;
+using Xunit.Extensions;
 
 namespace LibGit2Sharp.Tests
 {
     public class RepositoryFixture : BaseFixture
     {
         private const string commitSha = "8496071c1b46c854b31185ea97743be6a8774479";
+        private const string TestRepoUrl = "git://github.com/libgit2/TestGitRepository";
 
         [Fact]
         public void CanCreateBareRepo()
@@ -463,6 +465,73 @@ namespace LibGit2Sharp.Tests
 
                 repo.Refs.Add("HEAD", branchName, true);
                 Assert.False(repo.Info.IsHeadOrphaned);
+            }
+        }
+
+        [Theory]
+        [InlineData("http://github.com/libgit2/TestGitRepository")]
+        [InlineData("https://github.com/libgit2/TestGitRepository")]
+        [InlineData("git://github.com/libgit2/TestGitRepository")]
+        //[InlineData("git@github.com:libgit2/TestGitRepository")]
+        public void CanClone(string url)
+        {
+            var scd = BuildSelfCleaningDirectory();
+            using (Repository repo = Repository.Clone(url, scd.RootedDirectoryPath))
+            {
+                string dir = repo.Info.Path;
+                Assert.True(Path.IsPathRooted(dir));
+                Assert.True(Directory.Exists(dir));
+
+                Assert.NotNull(repo.Info.WorkingDirectory);
+                Assert.Equal(Path.Combine(scd.RootedDirectoryPath, ".git" + Path.DirectorySeparatorChar), repo.Info.Path);
+                Assert.False(repo.Info.IsBare);
+
+                Assert.True(File.Exists(Path.Combine(scd.RootedDirectoryPath, "master.txt")));
+                Assert.Equal(repo.Head.Name, "master");
+                Assert.Equal(repo.Head.Tip.Id.ToString(), "49322bb17d3acc9146f98c97d078513228bbf3c0");
+            }
+        }
+
+        [Theory]
+        [InlineData("http://github.com/libgit2/TestGitRepository")]
+        [InlineData("https://github.com/libgit2/TestGitRepository")]
+        [InlineData("git://github.com/libgit2/TestGitRepository")]
+        //[InlineData("git@github.com:libgit2/TestGitRepository")]
+        public void CanCloneBarely(string url)
+        {
+            var scd = BuildSelfCleaningDirectory();
+            using (Repository repo = Repository.Clone(url, scd.RootedDirectoryPath, bare:true))
+            {
+                string dir = repo.Info.Path;
+                Assert.True(Path.IsPathRooted(dir));
+                Assert.True(Directory.Exists(dir));
+
+                Assert.Null(repo.Info.WorkingDirectory);
+                Assert.Equal(scd.RootedDirectoryPath + Path.DirectorySeparatorChar, repo.Info.Path);
+                Assert.True(repo.Info.IsBare);
+            }
+        }
+
+        [Fact]
+        public void WontCheckoutIfAskedNotTo()
+        {
+            var scd = BuildSelfCleaningDirectory();
+            using (Repository repo = Repository.Clone(TestRepoUrl, scd.RootedDirectoryPath, checkout:false))
+            {
+                Assert.False(File.Exists(Path.Combine(scd.RootedDirectoryPath, "master.txt")));
+            }
+        }
+
+        [Fact]
+        public void CallsTransferProgress()
+        {
+            bool wasCalled = false;
+
+            var scd = BuildSelfCleaningDirectory();
+            using (Repository repo = Repository.Clone(TestRepoUrl, scd.RootedDirectoryPath, 
+                onTransferProgress: (_) => wasCalled = true))
+            {
+                Assert.True(wasCalled);
             }
         }
     }

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -155,6 +155,23 @@ namespace LibGit2Sharp.Core
             GitCheckoutOpts opts);
 
         [DllImport(libgit2)]
+        internal static extern int git_clone(
+            out RepositorySafeHandle repo,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(Utf8Marshaler))] string origin_url,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(FilePathMarshaler))] FilePath workdir_path,
+            git_transfer_progress_callback transfer_callback,
+            IntPtr transfer_payload,
+            GitCheckoutOpts checkout_opts);
+
+        [DllImport(libgit2)]
+        internal static extern int git_clone_bare(
+            out RepositorySafeHandle repo,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(Utf8Marshaler))] string url,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(FilePathMarshaler))] FilePath destination,
+            git_transfer_progress_callback transfer_callback,
+            IntPtr transfer_payload);
+
+        [DllImport(libgit2)]
         internal static extern IntPtr git_commit_author(GitObjectSafeHandle commit);
 
         [DllImport(libgit2)]

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -190,6 +190,39 @@ namespace LibGit2Sharp.Core
 
         #endregion
 
+        #region git_clone_
+
+        public static RepositorySafeHandle git_clone(
+            string url,
+            string workdir,
+            NativeMethods.git_transfer_progress_callback transfer_cb,
+            GitCheckoutOpts checkoutOptions)
+        {
+            using (ThreadAffinity())
+            {
+                RepositorySafeHandle repo;
+                int res = NativeMethods.git_clone(out repo, url, workdir, transfer_cb, IntPtr.Zero, checkoutOptions);
+                Ensure.Success(res);
+                return repo;
+            }
+        }
+
+        public static RepositorySafeHandle git_clone_bare(
+            string url,
+            string workdir,
+            NativeMethods.git_transfer_progress_callback transfer_cb)
+        {
+            using (ThreadAffinity())
+            {
+                RepositorySafeHandle repo;
+                int res = NativeMethods.git_clone_bare(out repo, url, workdir, transfer_cb, IntPtr.Zero);
+                Ensure.Success(res);
+                return repo;
+            }
+        }
+
+        #endregion
+
         #region git_commit_
 
         public static Signature git_commit_author(GitObjectSafeHandle obj)


### PR DESCRIPTION
This adds `Repository.Clone`, building on the just-merged checkout code.

Things this should be merged _after_:
- ~~#233 (Checkout)~~
- ~~#238 (Fetch update)~~

It relies on types that are most naturally merged with them. I'll rebase once they're merged into vNext.
### UPDATE

The two PRs mentioned have been merged. Any objections?
