### PR TITLE
Expose and use giterr_set_str for ODB backends

### DIFF
--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -69,6 +69,14 @@ namespace LibGit2Sharp.Core
         internal static extern GitErrorSafeHandle giterr_last();
 
         [DllImport(libgit2)]
+        internal static extern void giterr_set_str(
+            GitErrorCategory error_class,
+            string errorString);
+
+        [DllImport(libgit2)]
+        internal static extern void giterr_set_oom();
+
+        [DllImport(libgit2)]
         internal static extern int git_blob_create_fromdisk(
             ref GitOid oid,
             RepositorySafeHandle repo,

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -11,6 +11,27 @@ namespace LibGit2Sharp.Core
 {
     internal class Proxy
     {
+        #region giterr_
+
+        public static void giterr_set_str(GitErrorCategory error_class, Exception exception)
+        {
+            if (exception is OutOfMemoryException)
+            {
+                NativeMethods.giterr_set_oom();
+            }
+            else
+            {
+                NativeMethods.giterr_set_str(error_class, exception.Message);
+            }
+        }
+
+        public static void giterr_set_str(GitErrorCategory error_class, String errorString)
+        {
+            NativeMethods.giterr_set_str(error_class, errorString);
+        }
+
+        #endregion
+
         #region git_blob_
 
         public static ObjectId git_blob_create_fromchunks(RepositorySafeHandle repo, FilePath hintpath, NativeMethods.source_callback fileCallback)

--- a/LibGit2Sharp/OdbBackend.cs
+++ b/LibGit2Sharp/OdbBackend.cs
@@ -228,9 +228,9 @@ namespace LibGit2Sharp
 
                         return toReturn;
                     }
-                    catch
+                    catch (Exception ex)
                     {
-                        // TODO: Set a rich error message for libgit2
+                        Proxy.giterr_set_str(GitErrorCategory.Odb, ex);
                     }
                     finally
                     {
@@ -295,9 +295,9 @@ namespace LibGit2Sharp
 
                         return toReturn;
                     }
-                    catch
+                    catch (Exception ex)
                     {
-                        // TODO: Set a rich error message for libgit2
+                        Proxy.giterr_set_str(GitErrorCategory.Odb, ex);
                     }
                     finally
                     {
@@ -339,9 +339,9 @@ namespace LibGit2Sharp
 
                         return toReturn;
                     }
-                    catch
+                    catch (Exception ex)
                     {
-                        // TODO: Set a rich error message for libgit2
+                        Proxy.giterr_set_str(GitErrorCategory.Odb, ex);
                     }
                 }
 
@@ -376,9 +376,9 @@ namespace LibGit2Sharp
                             return toReturn;
                         }
                     }
-                    catch
+                    catch (Exception ex)
                     {
-                        // TODO: Set a rich error message for libgit2
+                        Proxy.giterr_set_str(GitErrorCategory.Odb, ex);
                     }
                 }
 
@@ -411,9 +411,9 @@ namespace LibGit2Sharp
 
                         return toReturn;
                     }
-                    catch
+                    catch (Exception ex)
                     {
-                        // TODO: Set a rich error message for libgit2
+                        Proxy.giterr_set_str(GitErrorCategory.Odb, ex);
                     }
                 }
 
@@ -444,9 +444,9 @@ namespace LibGit2Sharp
 
                         return toReturn;
                     }
-                    catch
+                    catch (Exception ex)
                     {
-                        // TODO: Set a rich error message for libgit2
+                        Proxy.giterr_set_str(GitErrorCategory.Odb, ex);
                     }
                 }
 
@@ -465,9 +465,9 @@ namespace LibGit2Sharp
                     {
                         return odbBackend.Exists(oid.Id);
                     }
-                    catch
+                    catch (Exception ex)
                     {
-                        // TODO: Set a rich error message for libgit2
+                        Proxy.giterr_set_str(GitErrorCategory.Odb, ex);
                     }
                 }
 
@@ -487,9 +487,9 @@ namespace LibGit2Sharp
                     {
                         return odbBackend.Foreach(new ForeachState(cb, data).ManagedCallback);
                     }
-                    catch
+                    catch (Exception ex)
                     {
-                        // TODO: Set a rich error message for libgit2
+                        Proxy.giterr_set_str(GitErrorCategory.Odb, ex);
                     }
                 }
 
@@ -508,9 +508,9 @@ namespace LibGit2Sharp
                     {
                         odbBackend.Dispose();
                     }
-                    catch
+                    catch (Exception ex)
                     {
-                        // TODO: Set a rich error message for libgit2
+                        Proxy.giterr_set_str(GitErrorCategory.Odb, ex);
                     }
                 }
             }

--- a/LibGit2Sharp/OdbBackendStream.cs
+++ b/LibGit2Sharp/OdbBackendStream.cs
@@ -150,7 +150,14 @@ namespace LibGit2Sharp
                 {
                     using (UnmanagedMemoryStream memoryStream = new UnmanagedMemoryStream((byte*)buffer, 0, (long)len.ToUInt64(), FileAccess.ReadWrite))
                     {
-                        return odbBackendStream.Read(memoryStream, (long)len.ToUInt64());
+                        try
+                        {
+                            return odbBackendStream.Read(memoryStream, (long)len.ToUInt64());
+                        }
+                        catch (Exception ex)
+                        {
+                            Proxy.giterr_set_str(GitErrorCategory.Odb, ex);
+                        }
                     }
                 }
 
@@ -171,7 +178,14 @@ namespace LibGit2Sharp
 
                     using (UnmanagedMemoryStream dataStream = new UnmanagedMemoryStream((byte*)buffer, length))
                     {
-                        return odbBackendStream.Write(dataStream, length);
+                        try
+                        {
+                            return odbBackendStream.Write(dataStream, length);
+                        }
+                        catch (Exception ex)
+                        {
+                            Proxy.giterr_set_str(GitErrorCategory.Odb, ex);
+                        }
                     }
                 }
 
@@ -190,14 +204,21 @@ namespace LibGit2Sharp
                 {
                     byte[] computedObjectId;
 
-                    int toReturn = odbBackendStream.FinalizeWrite(out computedObjectId);
-
-                    if (0 == toReturn)
+                    try
                     {
-                        oid_p.Id = computedObjectId;
-                    }
+                        int toReturn = odbBackendStream.FinalizeWrite(out computedObjectId);
 
-                    return toReturn;
+                        if (0 == toReturn)
+                        {
+                            oid_p.Id = computedObjectId;
+                        }
+
+                        return toReturn;
+                    }
+                    catch (Exception ex)
+                    {
+                        Proxy.giterr_set_str(GitErrorCategory.Odb, ex);
+                    }
                 }
 
                 return (int)GitErrorCode.Error;
@@ -210,7 +231,14 @@ namespace LibGit2Sharp
 
                 if (odbBackendStream != null)
                 {
-                    odbBackendStream.Dispose();
+                    try
+                    {
+                        odbBackendStream.Dispose();
+                    }
+                    catch (Exception ex)
+                    {
+                        Proxy.giterr_set_str(GitErrorCategory.Odb, ex);
+                    }
                 }
             }
         }


### PR DESCRIPTION
@nulltoken Thanks for bringing libgit2sharp up to date with libgit2 again. This change adds the managed -> native error marshaling that we talked about previously. Anything you think is missing or incorrect? Thanks!
