### PR TITLE
Blob Quickie

### DIFF
--- a/LibGit2Sharp/Blob.cs
+++ b/LibGit2Sharp/Blob.cs
@@ -23,7 +23,7 @@ namespace LibGit2Sharp
         /// <summary>
         ///   Gets the size in bytes of the contents of a blob
         /// </summary>
-        public int Size { get; set; }
+        public int Size { get; protected set; }
 
         public byte[] Content
         {


### PR DESCRIPTION
`Blob.Size` setter is public but shouldn't be.
