### PR TITLE
Add some `DebuggerDisplay` love

### DIFF
--- a/LibGit2Sharp/BranchCollection.cs
+++ b/LibGit2Sharp/BranchCollection.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using LibGit2Sharp.Core;
@@ -11,6 +12,7 @@ namespace LibGit2Sharp
     /// <summary>
     ///   The collection of Branches in a <see cref = "Repository" />
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class BranchCollection : IEnumerable<Branch>
     {
         internal readonly Repository repo;
@@ -191,6 +193,11 @@ namespace LibGit2Sharp
             return referenceName == "HEAD" ||
                 referenceName.StartsWith("refs/heads/", StringComparison.Ordinal) ||
                 referenceName.StartsWith("refs/remotes/", StringComparison.Ordinal);
+        }
+
+        private string DebuggerDisplay
+        {
+            get { return string.Format("Count = {0}", this.Count()); }
         }
     }
 }

--- a/LibGit2Sharp/Changes.cs
+++ b/LibGit2Sharp/Changes.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text;
 
 namespace LibGit2Sharp
@@ -5,6 +6,7 @@ namespace LibGit2Sharp
     /// <summary>
     ///   Base class for changes.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public abstract class Changes
     {
         private readonly StringBuilder patchBuilder = new StringBuilder();
@@ -36,5 +38,10 @@ namespace LibGit2Sharp
         ///   Determines if at least one side of the comparison holds binary content.
         /// </summary>
         public virtual bool IsBinaryComparison { get; protected set; }
+
+        private string DebuggerDisplay
+        {
+            get { return string.Format(@"{{+{0}, -{1}}}", LinesAdded, LinesDeleted); }
+        }
     }
 }

--- a/LibGit2Sharp/ConfigurationEntry.cs
+++ b/LibGit2Sharp/ConfigurationEntry.cs
@@ -1,8 +1,11 @@
-﻿namespace LibGit2Sharp
+﻿using System.Diagnostics;
+
+namespace LibGit2Sharp
 {
     /// <summary>
     /// An enumerated configuration entry.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class ConfigurationEntry
     {
         /// <summary>
@@ -32,6 +35,11 @@
             Key = key;
             Value = value;
             Level = level;
+        }
+
+        private string DebuggerDisplay
+        {
+            get { return string.Format("{0} = \"{1}\"", Key, Value); }
         }
     }
 }

--- a/LibGit2Sharp/GitObject.cs
+++ b/LibGit2Sharp/GitObject.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Globalization;
 using LibGit2Sharp.Core;
 
@@ -7,6 +8,7 @@ namespace LibGit2Sharp
     /// <summary>
     ///   A GitObject
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public abstract class GitObject : IEquatable<GitObject>
     {
         internal static GitObjectTypeMap TypeToTypeMap =
@@ -123,6 +125,11 @@ namespace LibGit2Sharp
         public static bool operator !=(GitObject left, GitObject right)
         {
             return !Equals(left, right);
+        }
+
+        private string DebuggerDisplay
+        {
+            get { return Id.ToString(7); }
         }
     }
 }

--- a/LibGit2Sharp/Index.cs
+++ b/LibGit2Sharp/Index.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -14,6 +15,7 @@ namespace LibGit2Sharp
     ///   The Index is a staging area between the Working directory and the Repository.
     ///   It's used to prepare and aggregate the changes that will be part of the next commit.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class Index : IEnumerable<IndexEntry>
     {
         private readonly IndexSafeHandle handle;
@@ -498,6 +500,11 @@ namespace LibGit2Sharp
 
             Proxy.git_index_add(handle, indexEntry);
             Marshal.FreeHGlobal(indexEntry.Path);
+        }
+
+        private string DebuggerDisplay
+        {
+            get { return string.Format("Count = {0}", Count); }
         }
     }
 }

--- a/LibGit2Sharp/IndexEntry.cs
+++ b/LibGit2Sharp/IndexEntry.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using LibGit2Sharp.Core;
 using LibGit2Sharp.Core.Handles;
 
@@ -7,6 +8,7 @@ namespace LibGit2Sharp
     /// <summary>
     ///   A reference to a <see cref = "Blob" /> known by the <see cref = "Index" />.
     /// </summary>
+    [DebuggerDisplayAttribute("{DebuggerDisplay,nq}")]
     public class IndexEntry : IEquatable<IndexEntry>
     {
         private static readonly LambdaEqualityHelper<IndexEntry> equalityHelper =
@@ -107,6 +109,11 @@ namespace LibGit2Sharp
         public static bool operator !=(IndexEntry left, IndexEntry right)
         {
             return !Equals(left, right);
+        }
+
+        private string DebuggerDisplay
+        {
+            get { return string.Format("{0} => \"{1}\"", Path, Id.ToString(7)); }
         }
     }
 }

--- a/LibGit2Sharp/Note.cs
+++ b/LibGit2Sharp/Note.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using LibGit2Sharp.Core;
 using LibGit2Sharp.Core.Handles;
 
@@ -7,6 +8,7 @@ namespace LibGit2Sharp
     /// <summary>
     ///   A note, attached to a given <see cref = "GitObject"/>.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class Note : IEquatable<Note>
     {
         /// <summary>
@@ -104,6 +106,15 @@ namespace LibGit2Sharp
         public static bool operator !=(Note left, Note right)
         {
             return !Equals(left, right);
+        }
+
+        private string DebuggerDisplay
+        {
+            get
+            {
+                return string.Format("Target \"{0}\", Namespace \"{1}\": {2}",
+                    TargetObjectId.ToString(7), Namespace, Message);
+            }
         }
     }
 }

--- a/LibGit2Sharp/NoteCollection.cs
+++ b/LibGit2Sharp/NoteCollection.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using LibGit2Sharp.Core;
 using LibGit2Sharp.Core.Compat;
@@ -11,6 +12,7 @@ namespace LibGit2Sharp
     /// <summary>
     ///   A collection of <see cref = "Note"/> exposed in the <see cref = "Repository"/>.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class NoteCollection : IEnumerable<Note>
     {
         private readonly Repository repo;
@@ -225,6 +227,11 @@ namespace LibGit2Sharp
         public virtual void Delete(ObjectId targetId, Signature author, Signature committer, string @namespace)
         {
             Remove(targetId, author, committer, @namespace);
+        }
+
+        private string DebuggerDisplay
+        {
+            get { return string.Format("Count = {0}", this.Count()); }
         }
     }
 }

--- a/LibGit2Sharp/Reference.cs
+++ b/LibGit2Sharp/Reference.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Globalization;
 using LibGit2Sharp.Core;
 using LibGit2Sharp.Core.Compat;
@@ -9,6 +10,7 @@ namespace LibGit2Sharp
     /// <summary>
     ///   A Reference to another git object
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public abstract class Reference : IEquatable<Reference>
     {
         private static readonly LambdaEqualityHelper<Reference> equalityHelper =
@@ -132,6 +134,11 @@ namespace LibGit2Sharp
         public override string ToString()
         {
             return CanonicalName;
+        }
+
+        private string DebuggerDisplay
+        {
+            get { return string.Format("{0} => \"{1}\"", CanonicalName, TargetIdentifier); }
         }
     }
 }

--- a/LibGit2Sharp/ReferenceCollection.cs
+++ b/LibGit2Sharp/ReferenceCollection.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using LibGit2Sharp.Core;
 using LibGit2Sharp.Core.Handles;
@@ -10,6 +11,7 @@ namespace LibGit2Sharp
     /// <summary>
     ///   The Collection of references in a <see cref = "Repository" />
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class ReferenceCollection : IEnumerable<Reference>
     {
         internal readonly Repository repo;
@@ -256,6 +258,11 @@ namespace LibGit2Sharp
         public virtual bool IsValidName(string canonicalName)
         {
             return Proxy.git_reference_is_valid_name(canonicalName);
+        }
+
+        private string DebuggerDisplay
+        {
+            get { return string.Format("Count = {0}", this.Count()); }
         }
     }
 }

--- a/LibGit2Sharp/ReferenceWrapper.cs
+++ b/LibGit2Sharp/ReferenceWrapper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using LibGit2Sharp.Core;
 using LibGit2Sharp.Core.Compat;
 
@@ -8,6 +9,7 @@ namespace LibGit2Sharp
     ///   A base class for things that wrap a <see cref = "Reference" /> (branch, tag, etc).
     /// </summary>
     /// <typeparam name="TObject">The type of the referenced Git object.</typeparam>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public abstract class ReferenceWrapper<TObject> : IEquatable<ReferenceWrapper<TObject>> where TObject : GitObject
     {
         /// <summary>
@@ -147,6 +149,15 @@ namespace LibGit2Sharp
         public static bool operator !=(ReferenceWrapper<TObject> left, ReferenceWrapper<TObject> right)
         {
             return !Equals(left, right);
+        }
+
+        private string DebuggerDisplay
+        {
+            get
+            {
+                return string.Format("{0} => \"{1}\"", CanonicalName,
+                    (TargetObject != null) ? TargetObject.Id.ToString(7) : "?");
+            }
         }
     }
 }

--- a/LibGit2Sharp/Remote.cs
+++ b/LibGit2Sharp/Remote.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using LibGit2Sharp.Core;
 using LibGit2Sharp.Core.Handles;
 using LibGit2Sharp.Handlers;
@@ -8,6 +9,7 @@ namespace LibGit2Sharp
     /// <summary>
     ///   A remote repository whose branches are tracked.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class Remote : IEquatable<Remote>
     {
         private static readonly LambdaEqualityHelper<Remote> equalityHelper =
@@ -145,6 +147,11 @@ namespace LibGit2Sharp
         public static bool operator !=(Remote left, Remote right)
         {
             return !Equals(left, right);
+        }
+
+        private string DebuggerDisplay
+        {
+            get { return string.Format("{0} => {1}", Name, Url); }
         }
     }
 }

--- a/LibGit2Sharp/RemoteCollection.cs
+++ b/LibGit2Sharp/RemoteCollection.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using LibGit2Sharp.Core;
 using LibGit2Sharp.Core.Handles;
@@ -10,6 +11,7 @@ namespace LibGit2Sharp
     /// <summary>
     ///   The collection of <see cref = "Remote" /> in a <see cref = "Repository" />
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class RemoteCollection : IEnumerable<Remote>
     {
         private readonly Repository repository;
@@ -130,6 +132,11 @@ namespace LibGit2Sharp
         public virtual Remote Create(string name, string url, string fetchRefSpec)
         {
             return Add(name, url);
+        }
+
+        private string DebuggerDisplay
+        {
+            get { return string.Format("Count = {0}", this.Count()); }
         }
     }
 }

--- a/LibGit2Sharp/Repository.cs
+++ b/LibGit2Sharp/Repository.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -15,6 +16,7 @@ namespace LibGit2Sharp
     /// <summary>
     ///   A Repository is the primary interface into a git repository
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class Repository : IRepository
     {
         private readonly BranchCollection branches;
@@ -658,6 +660,16 @@ namespace LibGit2Sharp
             using (var sr = new StreamReader(assembly.GetManifestResourceStream(name)))
             {
                 return sr.ReadLine();
+            }
+        }
+
+        private string DebuggerDisplay
+        {
+            get
+            {
+                return string.Format("{0} = \"{1}\"",
+                    Info.IsBare ? "Gitdir" : "Workdir",
+                    Info.IsBare ? Info.Path : Info.WorkingDirectory);
             }
         }
     }

--- a/LibGit2Sharp/SymbolicReference.cs
+++ b/LibGit2Sharp/SymbolicReference.cs
@@ -1,8 +1,11 @@
-﻿namespace LibGit2Sharp
+﻿using System.Diagnostics;
+
+namespace LibGit2Sharp
 {
     /// <summary>
     ///   A SymbolicReference is a reference that points to another reference
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class SymbolicReference : Reference
     {
         /// <summary>
@@ -17,6 +20,17 @@
         public override DirectReference ResolveToDirectReference()
         {
             return (Target == null) ? null : Target.ResolveToDirectReference();
+        }
+
+        private string DebuggerDisplay
+        {
+            get
+            {
+                var directReference = ResolveToDirectReference();
+                return string.Format("{0} => {1} => \"{2}\"",
+                    CanonicalName, TargetIdentifier,
+                    (directReference != null) ? directReference.TargetIdentifier : "?");
+            }
         }
     }
 }

--- a/LibGit2Sharp/TagCollection.cs
+++ b/LibGit2Sharp/TagCollection.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using LibGit2Sharp.Core;
 
@@ -9,6 +10,7 @@ namespace LibGit2Sharp
     /// <summary>
     ///   The collection of <see cref = "Tag" />s in a <see cref = "Repository" />
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class TagCollection : IEnumerable<Tag>
     {
         internal readonly Repository repo;
@@ -179,6 +181,11 @@ namespace LibGit2Sharp
             }
 
             return name.Substring(refsTagsPrefix.Length);
+        }
+
+        private string DebuggerDisplay
+        {
+            get { return string.Format("Count = {0}", this.Count()); }
         }
     }
 }

--- a/LibGit2Sharp/Tree.cs
+++ b/LibGit2Sharp/Tree.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using LibGit2Sharp.Core;
 using LibGit2Sharp.Core.Handles;
@@ -9,6 +10,7 @@ namespace LibGit2Sharp
     /// <summary>
     ///   A container which references a list of other <see cref="Tree"/>s and <see cref="Blob"/>s.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class Tree : GitObject, IEnumerable<TreeEntry>
     {
         private readonly FilePath path;
@@ -126,5 +128,10 @@ namespace LibGit2Sharp
         }
 
         #endregion
+
+        private string DebuggerDisplay
+        {
+            get { return string.Format("{0}, Count = {1}", Id.ToString(7), Count); }
+        }
     }
 }

--- a/LibGit2Sharp/TreeChanges.cs
+++ b/LibGit2Sharp/TreeChanges.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 using System.Text;
 using LibGit2Sharp.Core;
 using LibGit2Sharp.Core.Handles;
@@ -11,6 +13,7 @@ namespace LibGit2Sharp
     ///   Holds the result of a diff between two trees.
     ///   <para>Changes at the granularity of the file can be obtained through the different sub-collections <see cref="Added"/>, <see cref="Deleted"/> and <see cref="Modified"/>.</para>
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class TreeChanges : IEnumerable<TreeEntryChanges>
     {
         private readonly IDictionary<FilePath, TreeEntryChanges> changes = new Dictionary<FilePath, TreeEntryChanges>();
@@ -184,6 +187,15 @@ namespace LibGit2Sharp
         public virtual string Patch
         {
             get { return fullPatchBuilder.ToString(); }
+        }
+
+        private string DebuggerDisplay
+        {
+            get
+            {
+                return string.Format("Added: {0}, Deleted: {1}, Modified: {2}",
+                    Added.Count(), Deleted.Count(), Modified.Count());
+            }
         }
     }
 }

--- a/LibGit2Sharp/TreeEntryChanges.cs
+++ b/LibGit2Sharp/TreeEntryChanges.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using LibGit2Sharp.Core;
 
 namespace LibGit2Sharp
@@ -5,6 +6,7 @@ namespace LibGit2Sharp
     /// <summary>
     ///   Holds the changes between two versions of a tree entry.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class TreeEntryChanges : Changes
     {
         /// <summary>
@@ -59,5 +61,14 @@ namespace LibGit2Sharp
         ///   The old content hash.
         /// </summary>
         public virtual ObjectId OldOid { get; private set; }
+
+        private string DebuggerDisplay
+        {
+            get
+            {
+                return string.Format("Path = {0}, File {1}",
+                    !string.IsNullOrEmpty(Path) ? Path : OldPath, Status);
+            }
+        }
     }
 }


### PR DESCRIPTION
I followed implementation best practices as described at http://blogs.msdn.com/b/jaredpar/archive/2011/03/18/debuggerdisplay-attribute-best-practices.aspx

Also added a Meta test to make sure the same implementation is used everywhere when using `[DebuggerDisplay]`.
