### PR TITLE
Skip fetch-related tests when a proxy exists

### DIFF
--- a/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
+++ b/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
@@ -90,6 +90,7 @@
     <Compile Include="TagFixture.cs" />
     <Compile Include="TestHelpers\DirectoryHelper.cs" />
     <Compile Include="TestHelpers\ExpectedFetchState.cs" />
+    <Compile Include="TestHelpers\SkippableTheoryAttribute.cs" />
     <Compile Include="TestHelpers\TestRemoteInfo.cs" />
     <Compile Include="TestHelpers\IPostTestDirectoryRemover.cs" />
     <Compile Include="TestHelpers\SelfCleaningDirectory.cs" />

--- a/LibGit2Sharp.Tests/RemoteFixture.cs
+++ b/LibGit2Sharp.Tests/RemoteFixture.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using LibGit2Sharp.Tests.TestHelpers;
 using Xunit;
 using Xunit.Extensions;
@@ -110,12 +111,15 @@ namespace LibGit2Sharp.Tests
             }
         }
 
-        [Theory]
-        [InlineData("http://github.com/libgit2/TestGitRepository")]
+        [SkippableTheory]
+        [InlineData("http://localhost")]
         [InlineData("https://github.com/libgit2/TestGitRepository")]
         [InlineData("git://github.com/libgit2/TestGitRepository.git")]
         public void CanFetchAllTagsIntoAnEmptyRepository(string url)
         {
+            InconclusiveIf(() => WebRequest.DefaultWebProxy.GetProxy(new Uri(url)).AbsoluteUri != url,
+                "libgit2 does not support proxyfied connections yet.");
+
             string remoteName = "testRemote";
 
             var scd = BuildSelfCleaningDirectory();

--- a/LibGit2Sharp.Tests/TestHelpers/SkippableTheoryAttribute.cs
+++ b/LibGit2Sharp.Tests/TestHelpers/SkippableTheoryAttribute.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using System.Linq;
+using Xunit.Extensions;
+using Xunit.Sdk;
+
+namespace LibGit2Sharp.Tests.TestHelpers
+{
+    internal class SkippableTheoryAttribute : TheoryAttribute
+    {
+        protected override IEnumerable<ITestCommand> EnumerateTestCommands(IMethodInfo method)
+        {
+            IEnumerable<ITestCommand> commands = base.EnumerateTestCommands(method);
+            return commands.Select(c => new SkippableTestCommand(method, (TheoryCommand)c)).Cast<ITestCommand>();
+        }
+
+        class SkippableTestCommand : TheoryCommand
+        {
+            private readonly TheoryCommand internalCommand;
+
+            public SkippableTestCommand(IMethodInfo method, TheoryCommand internalCommand)
+                : base(method, null)
+            {
+                this.internalCommand = internalCommand;
+            }
+
+            public override MethodResult Execute(object testClass)
+            {
+                try
+                {
+                    return internalCommand.Execute(testClass);
+                }
+                catch (SkipException e)
+                {
+                    return new SkipResult(testMethod, DisplayName, e.Reason);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Libgit2 does not support proxies (yet), which makes libgit2sharp a bit painful to test on a computer which uses proxies (you have to wait for ~15 tests to timeout).
