### PR TITLE
Fix IsTracking Property for DetachedHead branches

### DIFF
--- a/LibGit2Sharp.Tests/BranchFixture.cs
+++ b/LibGit2Sharp.Tests/BranchFixture.cs
@@ -580,5 +580,21 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(br2.Tip, newTest.Tip);
             }
         }
+
+        [Fact]
+        public void DetachedHeadIsNotATrackingBranch()
+        {
+            TemporaryCloneOfTestRepo path = BuildTemporaryCloneOfTestRepo(StandardTestRepoWorkingDirPath);
+            using (var repo = new Repository(path.RepositoryPath))
+            {
+                repo.Reset(ResetOptions.Hard);
+                repo.RemoveUntrackedFiles();
+
+                string headSha = repo.Head.Tip.Sha;
+                repo.Checkout(headSha);
+
+                Assert.False(repo.Head.IsTracking);
+            }
+        }
     }
 }

--- a/LibGit2Sharp/DetachedHead.cs
+++ b/LibGit2Sharp/DetachedHead.cs
@@ -11,5 +11,16 @@
         {
             return branchName;
         }
+
+        /// <summary>
+        ///   Detached Head cannot be a tracking branch.
+        /// </summary>
+        public override bool IsTracking
+        {
+            get
+            {
+                return false;
+            }
+        }
     }
 }


### PR DESCRIPTION
Accessing the IsTracking property (and any property that accessing IsTracking internally) throws an exception. This fix is to have the DetachedHead always return false for IsTracking.

Here is the failure before the fix:

```
LibGit2Sharp.Tests.BranchFixture.DetachedHeadIsNotATrackingBranch [FAIL]
LibGit2Sharp.LibGit2SharpException : An error was raised by libgit2. Category = Reference (-12). The given reference name '(no branch)' is not valid
```

Stack Trace:

```
libgit2sharp\LibGit2Sharp\Core\Ensure.cs(85,0): at LibGit2Sharp.Core.Ensure.Success(Int32 result, Boolean allowPositiveResult)
libgit2sharp\LibGit2Sharp\Core\Proxy.cs(1020,0): at LibGit2Sharp.Core.Proxy.git_reference_lookup(RepositorySafeHandle repo, String name, Boolean shouldThrowIfNotFound)
libgit2sharp\LibGit2Sharp\ReferenceCollection.cs(227,0): at LibGit2Sharp.ReferenceCollection.RetrieveReferencePtr(String referenceName, Boolean shouldThrowIfNotFound)
libgit2sharp\LibGit2Sharp\Branch.cs(204,0): at LibGit2Sharp.Branch.ResolveTrackedBranch()
libgit2sharp\LibGit2Sharp\Core\Compat\Lazy.cs(45,0): at LibGit2Sharp.Core.Compat.Lazy`1.Evaluate()
libgit2sharp\LibGit2Sharp\Core\Compat\Lazy.cs(34,0): at LibGit2Sharp.Core.Compat.Lazy`1.get_Value()
libgit2sharp\LibGit2Sharp\Branch.cs(88,0): at LibGit2Sharp.Branch.get_TrackedBranch()
libgit2sharp\LibGit2Sharp\Branch.cs(96,0): at LibGit2Sharp.Branch.get_IsTracking()
libgit2sharp\LibGit2Sharp.Tests\BranchFixture.cs(596,0): at LibGit2Sharp.Tests.BranchFixture.DetachedHeadIsNotATrackingBranch()
```
