### PR TITLE
Fix TrackedBranch property on DetachedHead branches

### DIFF
--- a/LibGit2Sharp.Tests/BranchFixture.cs
+++ b/LibGit2Sharp.Tests/BranchFixture.cs
@@ -594,6 +594,7 @@ namespace LibGit2Sharp.Tests
                 repo.Checkout(headSha);
 
                 Assert.False(repo.Head.IsTracking);
+                Assert.Null(repo.Head.TrackedBranch);
             }
         }
     }

--- a/LibGit2Sharp/DetachedHead.cs
+++ b/LibGit2Sharp/DetachedHead.cs
@@ -13,14 +13,11 @@
         }
 
         /// <summary>
-        ///   Determines if this local branch is connected to a remote one.
+        ///   Gets the remote branch which is connected to this local one, or null if there is none.
         /// </summary>
-        public override bool IsTracking
+        public override Branch TrackedBranch
         {
-            get
-            {
-                return false;
-            }
+            get { return null; }
         }
     }
 }


### PR DESCRIPTION
Follow-up to #266 - same error when accessing `TrackedBranch`

```
Test 'LibGit2Sharp.Tests.BranchFixture.DetachedHeadIsNotATrackingBranch' failed: LibGit2Sharp.LibGit2SharpException : An error was raised by libgit2. Category = Reference (-12).
The given reference name '(no branch)' is not valid
    Core\Ensure.cs(85,0): at LibGit2Sharp.Core.Ensure.Success(Int32 result, Boolean allowPositiveResult)
    Core\Proxy.cs(1065,0): at LibGit2Sharp.Core.Proxy.git_reference_lookup(RepositorySafeHandle repo, String name, Boolean shouldThrowIfNotFound)
    ReferenceCollection.cs(227,0): at LibGit2Sharp.ReferenceCollection.RetrieveReferencePtr(String referenceName, Boolean shouldThrowIfNotFound)
    Branch.cs(211,0): at LibGit2Sharp.Branch.ResolveTrackedBranch()
    Core\Compat\Lazy.cs(45,0): at LibGit2Sharp.Core.Compat.Lazy`1.Evaluate()
    Core\Compat\Lazy.cs(34,0): at LibGit2Sharp.Core.Compat.Lazy`1.get_Value()
    Branch.cs(88,0): at LibGit2Sharp.Branch.get_TrackedBranch()
    BranchFixture.cs(597,0): at LibGit2Sharp.Tests.BranchFixture.DetachedHeadIsNotATrackingBranch()
```
