### PR TITLE
Initial push implementation.

### DIFF
--- a/LibGit2Sharp/Core/Handles/PushSafeHandle.cs
+++ b/LibGit2Sharp/Core/Handles/PushSafeHandle.cs
@@ -1,0 +1,11 @@
+﻿namespace LibGit2Sharp.Core.Handles
+{
+    internal class PushSafeHandle : SafeHandleBase
+    {
+        protected override bool ReleaseHandle()
+        {
+            Proxy.git_push_free(handle);
+            return true;
+        }
+    }
+}

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -564,6 +564,37 @@ namespace LibGit2Sharp.Core
         internal static extern GitObjectType git_object_type(GitObjectSafeHandle obj);
 
         [DllImport(libgit2)]
+        internal static extern int git_push_new(out PushSafeHandle push, RemoteSafeHandle remote);
+
+        [DllImport(libgit2)]
+        internal static extern int git_push_add_refspec(
+            PushSafeHandle push,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(Utf8Marshaler))] string pushRefSpec);
+
+        [DllImport(libgit2)]
+        internal static extern int git_push_finish(PushSafeHandle push);
+
+        [DllImport(libgit2)]
+        internal static extern void git_push_free(IntPtr push);
+
+        [DllImport(libgit2)]
+        internal static extern int git_push_status_foreach(
+            PushSafeHandle push,
+            push_status_foreach_cb status_cb,
+            IntPtr data);
+
+        internal delegate int push_status_foreach_cb(
+            IntPtr reference,
+            IntPtr msg,
+            IntPtr data);
+
+        [DllImport(libgit2)]
+        internal static extern int git_push_unpack_ok(PushSafeHandle push);
+
+        [DllImport(libgit2)]
+        internal static extern int git_push_update_tips(PushSafeHandle push);
+
+        [DllImport(libgit2)]
         internal static extern int git_reference_create(
             out ReferenceSafeHandle reference,
             RepositorySafeHandle repo,

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -1044,6 +1044,68 @@ namespace LibGit2Sharp.Core
 
         #endregion
 
+        #region git_push_
+
+        public static void git_push_add_refspec(PushSafeHandle push, string pushRefSpec)
+        {
+            using (ThreadAffinity())
+            {
+                int res = NativeMethods.git_push_add_refspec(push, pushRefSpec);
+                Ensure.Success(res);
+            }
+        }
+
+        public static void git_push_finish(PushSafeHandle push)
+        {
+            using (ThreadAffinity())
+            {
+                int res = NativeMethods.git_push_finish(push);
+                Ensure.Success(res);
+            }
+        }
+
+        public static void git_push_free(IntPtr push)
+        {
+            NativeMethods.git_push_free(push);
+        }
+
+        public static PushSafeHandle git_push_new(RemoteSafeHandle remote)
+        {
+            using (ThreadAffinity())
+            {
+                PushSafeHandle handle;
+                int res = NativeMethods.git_push_new(out handle, remote);
+                Ensure.Success(res);
+                return handle;
+            }
+        }
+
+        public static void git_push_status_foreach(PushSafeHandle push, NativeMethods.push_status_foreach_cb status_cb)
+        {
+            using (ThreadAffinity())
+            {
+                int res = NativeMethods.git_push_status_foreach(push, status_cb, IntPtr.Zero);
+                Ensure.Success(res);
+            }
+        }
+
+        public static bool git_push_unpack_ok(PushSafeHandle push)
+        {
+            int res = NativeMethods.git_push_unpack_ok(push);
+            return res == 1;
+        }
+
+        public static void git_push_update_tips(PushSafeHandle push)
+        {
+            using (ThreadAffinity())
+            {
+                int res = NativeMethods.git_push_update_tips(push);
+                Ensure.Success(res);
+            }
+        }
+
+        #endregion
+
         #region git_reference_
 
         public static ReferenceSafeHandle git_reference_create_oid(RepositorySafeHandle repo, string name, ObjectId targetId, bool allowOverwrite)

--- a/LibGit2Sharp/Handlers.cs
+++ b/LibGit2Sharp/Handlers.cs
@@ -33,6 +33,12 @@
     public delegate void TransferProgressHandler(TransferProgress progress);
 
     /// <summary>
+    ///   Delegate definition to handle reporting errors when updating references on the remote.
+    /// </summary>
+    /// <param name="pushStatusErrors">The reference name and error from the server.</param>
+    public delegate void PushStatusErrorHandler(PushStatusError pushStatusErrors);
+
+    /// <summary>
     ///   Delegate definition for checkout progress callback.
     /// </summary>
     /// <param name="path">Path of the updated file.</param>

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -91,11 +91,15 @@
     <Compile Include="DiffOptions.cs" />
     <Compile Include="DiffTargets.cs" />
     <Compile Include="FetchHead.cs" />
+    <Compile Include="Core\Handles\PushSafeHandle.cs" />
     <Compile Include="Handlers.cs" />
     <Compile Include="Ignore.cs" />
     <Compile Include="MergeConflictException.cs" />
     <Compile Include="MergeHead.cs" />
     <Compile Include="NameConflictException.cs" />
+    <Compile Include="NetworkExtensions.cs" />
+    <Compile Include="PushResult.cs" />
+    <Compile Include="PushStatusError.cs" />
     <Compile Include="ReferenceCollectionExtensions.cs" />
     <Compile Include="Core\GitRemoteCallbacks.cs" />
     <Compile Include="RemoteCallbacks.cs" />

--- a/LibGit2Sharp/Network.cs
+++ b/LibGit2Sharp/Network.cs
@@ -1,5 +1,10 @@
+﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using LibGit2Sharp.Core;
+using LibGit2Sharp.Core.Handles;
+using LibGit2Sharp.Handlers;
 
 namespace LibGit2Sharp
 {
@@ -33,6 +38,141 @@ namespace LibGit2Sharp
                 return Proxy.git_repository_fetchhead_foreach(
                     repository.Handle,
                     (name, url, oid, isMerge) => new FetchHead(repository, name, url, new ObjectId(oid), isMerge, i++));
+            }
+        }
+
+        /// <summary>
+        ///   Push the objectish to the destination reference on the <see cref = "Remote" />.
+        /// </summary>
+        /// <param name="remote">The <see cref = "Remote" /> to push to.</param>
+        /// <param name="objectish">The source objectish to push.</param>
+        /// <param name="destinationSpec">The reference to update on the remote.</param>
+        /// <param name="onPushStatusError">Handler for reporting failed push updates.</param>
+        public virtual void Push(
+            Remote remote,
+            string objectish,
+            string destinationSpec,
+            PushStatusErrorHandler onPushStatusError)
+        {
+            Ensure.ArgumentNotNull(remote, "remote");
+            Ensure.ArgumentNotNull(objectish, "objectish");
+            Ensure.ArgumentNotNullOrEmptyString(destinationSpec, destinationSpec);
+
+            Push(remote, string.Format("{0}:{1}", objectish, destinationSpec), onPushStatusError);
+        }
+
+        /// <summary>
+        ///   Push specified reference to the <see cref="Remote"/>.
+        /// </summary>
+        /// <param name="remote">The <see cref = "Remote" /> to push to.</param>
+        /// <param name="pushRefSpec">The pushRefSpec to push.</param>
+        /// <param name="onPushStatusError">Handler for reporting failed push updates.</param>
+        public virtual void Push(
+            Remote remote,
+            string pushRefSpec,
+            PushStatusErrorHandler onPushStatusError)
+        {
+            Ensure.ArgumentNotNull(remote, "remote");
+            Ensure.ArgumentNotNullOrEmptyString(pushRefSpec, "pushRefSpec");
+
+            Push(remote, new string[] { pushRefSpec }, onPushStatusError);
+        }
+
+        /// <summary>
+        ///   Push specified references to the <see cref="Remote"/>.
+        /// </summary>
+        /// <param name="remote">The <see cref = "Remote" /> to push to.</param>
+        /// <param name="pushRefSpecs">The pushRefSpecs to push.</param>
+        /// <param name="onPushStatusError">Handler for reporting failed push updates.</param>
+        public virtual void Push(
+            Remote remote,
+            IEnumerable<string> pushRefSpecs,
+            PushStatusErrorHandler onPushStatusError)
+        {
+            Ensure.ArgumentNotNull(remote, "remote");
+            Ensure.ArgumentNotNull(pushRefSpecs, "pushRefSpecs");
+
+            // Return early if there is nothing to push.
+            if (!pushRefSpecs.Any())
+            {
+                return;
+            }
+
+            PushCallbacks pushStatusUpdates = new PushCallbacks(onPushStatusError);
+
+            // Load the remote.
+            using (RemoteSafeHandle remoteHandle = Proxy.git_remote_load(repository.Handle, remote.Name, true))
+            {
+                try
+                {
+                    Proxy.git_remote_connect(remoteHandle, GitDirection.Push);
+
+                    // Perform the actual push.
+                    using (PushSafeHandle pushHandle = Proxy.git_push_new(remoteHandle))
+                    {
+                        // Add refspecs.
+                        foreach (string pushRefSpec in pushRefSpecs)
+                        {
+                            Proxy.git_push_add_refspec(pushHandle, pushRefSpec);
+                        }
+
+                        Proxy.git_push_finish(pushHandle);
+
+                        if (!Proxy.git_push_unpack_ok(pushHandle))
+                        {
+                            throw new LibGit2SharpException("Push failed - remote did not successfully unpack.");
+                        }
+
+                        Proxy.git_push_status_foreach(pushHandle, pushStatusUpdates.Callback);
+
+                        Proxy.git_push_update_tips(pushHandle);
+                    }
+                }
+                finally
+                {
+                    Proxy.git_remote_disconnect(remoteHandle);
+                }
+            }
+        }
+
+        /// <summary>
+        ///   Helper class to handle callbacks during push.
+        /// </summary>
+        private class PushCallbacks
+        {
+            PushStatusErrorHandler OnError;
+
+            public PushCallbacks(PushStatusErrorHandler onError)
+            {
+                OnError = onError;
+            }
+
+            public int Callback(IntPtr referenceNamePtr, IntPtr msgPtr, IntPtr payload)
+            {
+                // Exit early if there is no callback.
+                if (OnError == null)
+                {
+                    return 0;
+                }
+
+                // The reference name pointer should never be null - if it is,
+                // this indicates a bug somewhere (libgit2, server, etc).
+                if (referenceNamePtr == IntPtr.Zero)
+                {
+                    Proxy.giterr_set_str(GitErrorCategory.Invalid, "Not expecting null for reference name in push status.");
+                    return -1;
+                }
+
+                // Only report updates where there is a message - indicating
+                // that there was an error.
+                if (msgPtr != IntPtr.Zero)
+                {
+                    string referenceName = Utf8Marshaler.FromNative(referenceNamePtr);
+                    string msg = Utf8Marshaler.FromNative(msgPtr);
+                    OnError(new PushStatusError(referenceName, msg));
+                }
+
+                return 0;
             }
         }
     }

--- a/LibGit2Sharp/NetworkExtensions.cs
+++ b/LibGit2Sharp/NetworkExtensions.cs
@@ -1,0 +1,72 @@
+﻿using LibGit2Sharp.Core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace LibGit2Sharp
+{
+    /// <summary>
+    ///   Provides helper overloads to a <see cref = "Network" />.
+    /// </summary>
+    public static class NetworkExtensions
+    {
+        /// <summary>
+        ///   Push the objectish to the destination reference on the <see cref = "Remote" />.
+        /// </summary>
+        /// <param name="network">The <see cref="Network"/> being worked with.</param>
+        /// <param name="remote">The <see cref = "Remote" /> to push to.</param>
+        /// <param name="objectish">The source objectish to push.</param>
+        /// <param name="destinationSpec">The reference to update on the remote.</param>
+        /// <returns>Results of the push operation.</returns>
+        public static PushResult Push(
+            this Network network,
+            Remote remote,
+            string objectish,
+            string destinationSpec)
+        {
+            Ensure.ArgumentNotNull(remote, "remote");
+            Ensure.ArgumentNotNull(objectish, "objectish");
+            Ensure.ArgumentNotNullOrEmptyString(destinationSpec, "destinationSpec");
+
+            return network.Push(remote, string.Format("{0}:{1}", objectish, destinationSpec));
+        }
+
+        /// <summary>
+        ///   Push specified reference to the <see cref="Remote"/>.
+        /// </summary>
+        /// <param name="network">The <see cref="Network"/> being worked with.</param>
+        /// <param name="remote">The <see cref = "Remote" /> to push to.</param>
+        /// <param name="pushRefSpec">The pushRefSpec to push.</param>
+        /// <returns>Results of the push operation.</returns>
+        public static PushResult Push(this Network network, Remote remote, string pushRefSpec)
+        {
+            Ensure.ArgumentNotNull(remote, "remote");
+            Ensure.ArgumentNotNullOrEmptyString(pushRefSpec, "pushRefSpec");
+
+            return network.Push(remote, new string[] { pushRefSpec });
+        }
+
+        /// <summary>
+        ///   Push specified references to the <see cref="Remote"/>.
+        /// </summary>
+        /// <param name="network">The <see cref="Network"/> being worked with.</param>
+        /// <param name="remote">The <see cref="Remote"/> to push to.</param>
+        /// <param name="pushRefSpecs">The pushRefSpecs to push.</param>
+        /// <returns>Results of the push operation.</returns>
+        public static PushResult Push(this Network network, Remote remote, IEnumerable<string> pushRefSpecs)
+        {
+            Ensure.ArgumentNotNull(remote, "remote");
+            Ensure.ArgumentNotNull(pushRefSpecs, "pushRefSpecs");
+
+            List<PushStatusError> failedRemoteUpdates = new List<PushStatusError>();
+
+            network.Push(
+                remote,
+                pushRefSpecs,
+                failedRemoteUpdates.Add);
+
+            return new PushResult(failedRemoteUpdates);
+        }
+    }
+}

--- a/LibGit2Sharp/PushResult.cs
+++ b/LibGit2Sharp/PushResult.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace LibGit2Sharp
+{
+    /// <summary>
+    ///   Contains the results of a push operation.
+    /// </summary>
+    public class PushResult
+    {
+        /// <summary>
+        ///   Needed for mocking purposes.
+        /// </summary>
+        protected PushResult()
+        { }
+
+        /// <summary>
+        ///   <see cref="PushStatusError"/>s that failed to update.
+        /// </summary>
+        public virtual IEnumerable<PushStatusError> FailedPushUpdates
+        {
+            get
+            {
+                return failedPushUpdates;
+            }
+        }
+
+        /// <summary>
+        ///   Flag indicating if there were errors reported
+        ///   when updating references on the remote.
+        /// </summary>
+        public virtual bool HasErrors
+        {
+            get
+            {
+                return failedPushUpdates.Count > 0;
+            }
+        }
+
+        internal PushResult(List<PushStatusError> failedPushUpdates)
+        {
+            this.failedPushUpdates = failedPushUpdates ?? new List<PushStatusError>();
+        }
+
+        private List<PushStatusError> failedPushUpdates;
+    }
+}

--- a/LibGit2Sharp/PushStatusError.cs
+++ b/LibGit2Sharp/PushStatusError.cs
@@ -1,0 +1,30 @@
+﻿namespace LibGit2Sharp
+{
+    /// <summary>
+    ///   Information on an error updating reference on remote during a push.
+    /// </summary>
+    public class PushStatusError
+    {
+        /// <summary>
+        ///   Needed for mocking purposes.
+        /// </summary>
+        protected PushStatusError()
+        { }
+
+        /// <summary>
+        ///   The reference this status refers to.
+        /// </summary>
+        public virtual string Reference { get; private set; }
+
+        /// <summary>
+        ///   The message regarding the update of this reference.
+        /// </summary>
+        public virtual string Message { get; private set; }
+
+        internal PushStatusError(string reference, string message)
+        {
+            Reference = reference;
+            Message = message;
+        }
+    }
+}


### PR DESCRIPTION
## Initial push implementation on top of libgit2.
#### Implementation:

I have implemented the Push logic in the `Network` namespace. The main API for push exposes a callback to report errors. There is an extension method that returns a status object at the end of the push with the results.
#### Future work:
1. Other high level entry points to push
2. No progress updates during push (libgit2/libgit2/issues/1178)
