### PR TITLE
Ensure Diff.Compare() cannot apply on a bare repository

### DIFF
--- a/LibGit2Sharp.Tests/DiffTreeToTargetFixture.cs
+++ b/LibGit2Sharp.Tests/DiffTreeToTargetFixture.cs
@@ -321,5 +321,19 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(expected.ToString(), changes.Patch);
             }
         }
+
+        [Fact]
+        public void ComparingATreeInABareRepositoryAgainstTheWorkDirOrTheIndexThrows()
+        {
+            using (var repo = new Repository(BareTestRepoPath))
+            {
+                Assert.Throws<BareRepositoryException>(
+                    () => repo.Diff.Compare(repo.Head.Tip.Tree, DiffTargets.WorkingDirectory));
+                Assert.Throws<BareRepositoryException>(
+                    () => repo.Diff.Compare(repo.Head.Tip.Tree, DiffTargets.Index));
+                Assert.Throws<BareRepositoryException>(
+                    () => repo.Diff.Compare(repo.Head.Tip.Tree, DiffTargets.WorkingDirectory | DiffTargets.Index));
+            }
+        }
     }
 }


### PR DESCRIPTION
Doing a `Diff.Compare()` should not be allowed on a Bare repository.
I wrote the unit test, and it seems to work as expected : it throws a `BareRepositoryException`
