### PR TITLE
Set upstream information on a branch

### DIFF
--- a/LibGit2Sharp/BranchCollection.cs
+++ b/LibGit2Sharp/BranchCollection.cs
@@ -190,6 +190,24 @@ namespace LibGit2Sharp
             return this[newName];
         }
 
+        /// <summary>
+        ///   Update properties of a branch.
+        /// </summary>
+        /// <param name="branch">The branch to update.</param>
+        /// <param name="actions">Delegate to perform updates on the branch.</param>
+        /// <returns>The updated branch.</returns>
+        public virtual Branch Update(Branch branch, params Action<BranchUpdater>[] actions)
+        {
+            var updater = new BranchUpdater(repo, branch);
+
+            foreach (Action<BranchUpdater> action in actions)
+            {
+                action(updater);
+            }
+
+            return this[branch.Name];
+        }
+
         private static bool LooksLikeABranchName(string referenceName)
         {
             return referenceName == "HEAD" ||

--- a/LibGit2Sharp/BranchUpdater.cs
+++ b/LibGit2Sharp/BranchUpdater.cs
@@ -1,0 +1,129 @@
+using System;
+using LibGit2Sharp.Core;
+using System.Globalization;
+using LibGit2Sharp.Core.Handles;
+
+namespace LibGit2Sharp
+{
+    /// <summary>
+    ///   Exposes properties of a branch that can be updated.
+    /// </summary>
+    public class BranchUpdater
+    {
+        private readonly Repository repo;
+        private readonly Branch branch;
+
+        /// <summary>
+        ///   Needed for mocking purposes.
+        /// </summary>
+        protected BranchUpdater()
+        { }
+
+        internal BranchUpdater(Repository repo, Branch branch)
+        {
+            Ensure.ArgumentNotNull(repo, "repo");
+            Ensure.ArgumentNotNull(branch, "branch");
+
+            this.repo = repo;
+            this.branch = branch;
+        }
+
+        /// <summary>
+        ///   Sets the upstream information for the branch.
+        ///   <para>
+        ///     Passing null or string.Empty will unset the upstream.
+        ///   </para>
+        /// </summary>
+        public virtual string Upstream
+        {
+            set
+            {
+                if (string.IsNullOrEmpty(value))
+                {
+                    UnsetUpstream();
+                    return;
+                }
+
+                SetUpstream(value);
+            }
+        }
+
+        private void UnsetUpstream()
+        {
+            repo.Config.Unset(string.Format("branch.{0}.remote", branch.Name));
+            repo.Config.Unset(string.Format("branch.{0}.merge", branch.Name));
+        }
+
+        /// <summary>
+        ///   Set the upstream information for the current branch.
+        /// </summary>
+        /// <param name="value">The upstream branch to track.</param>
+        private void SetUpstream(string value)
+        {
+            if (branch.IsRemote)
+            {
+                throw new LibGit2SharpException("Cannot set upstream branch on a remote branch.");
+            }
+
+            string remoteName;
+            string branchName;
+
+            GetUpstreamInformation(value, out remoteName, out branchName);
+
+            SetUpstreamTo(remoteName, branchName);
+        }
+
+        private void SetUpstreamTo(string remoteName, string branchName)
+        {
+            if (!remoteName.Equals(".", StringComparison.Ordinal))
+            {
+                // Verify that remote exists.
+                repo.Network.Remotes.RemoteForName(remoteName, true);
+            }
+
+            repo.Config.Set<string>(string.Format("branch.{0}.remote", branch.Name), remoteName);
+            repo.Config.Set<string>(string.Format("branch.{0}.merge", branch.Name), string.Format("{0}", branchName));
+        }
+
+        /// <summary>
+        ///   Get the upstream remote and merge branch name from a Canonical branch name.
+        ///   This will return the remote name (or ".") if a local branch for the remote name.
+        /// </summary>
+        /// <param name="canonicalName">The canonical branch name to parse.</param>
+        /// <param name="remoteName">The name of the corresponding remote the branch belongs to
+        /// or "." if it is a local branch.</param>
+        /// <param name="mergeBranchName">The name of the upstream branch to merge into.</param>
+        private void GetUpstreamInformation(string canonicalName, out string remoteName, out string mergeBranchName)
+        {
+            remoteName = null;
+            mergeBranchName = null;
+
+            string localPrefix = "refs/heads/";
+            string remotePrefix = "refs/remotes/";
+
+            if (canonicalName.StartsWith(localPrefix, StringComparison.Ordinal))
+            {
+                remoteName = ".";
+                mergeBranchName = canonicalName;
+            }
+            else if (canonicalName.StartsWith(remotePrefix, StringComparison.Ordinal))
+            {
+                using (ReferenceSafeHandle branchPtr = repo.Refs.RetrieveReferencePtr(canonicalName))
+                {
+                    remoteName = Proxy.git_branch_remote_name(repo.Handle, branchPtr);
+                }
+
+                Remote remote = repo.Network.Remotes.RemoteForName(remoteName, true);
+                using (RemoteSafeHandle remoteHandle = Proxy.git_remote_load(repo.Handle, remote.Name, true))
+                {
+                    GitFetchSpecHandle fetchSpecPtr = Proxy.git_remote_fetchspec(remoteHandle);
+                    mergeBranchName = Proxy.git_fetchspec_rtransform(fetchSpecPtr, canonicalName);
+                }
+            }
+            else
+            {
+                throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "'{0}' does not look like a valid branch name.", canonicalName));
+            }
+        }
+    }
+}

--- a/LibGit2Sharp/Core/Handles/GitFetchSpecHandle.cs
+++ b/LibGit2Sharp/Core/Handles/GitFetchSpecHandle.cs
@@ -1,0 +1,8 @@
+﻿using System.Runtime.InteropServices;
+
+namespace LibGit2Sharp.Core.Handles
+{
+    internal class GitFetchSpecHandle : NotOwnedSafeHandleBase
+    {
+    }
+}

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -656,6 +656,13 @@ namespace LibGit2Sharp.Core
         internal static extern GitReferenceType git_reference_type(ReferenceSafeHandle reference);
 
         [DllImport(libgit2)]
+        internal static extern int git_refspec_rtransform(
+            byte[] target,
+            UIntPtr outlen,
+            GitFetchSpecHandle refSpec,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(Utf8Marshaler))] string name);
+
+        [DllImport(libgit2)]
         internal static extern int git_remote_connect(RemoteSafeHandle remote, GitDirection direction);
 
         [DllImport(libgit2)]
@@ -691,6 +698,9 @@ namespace LibGit2Sharp.Core
 
         [DllImport(libgit2)]
         internal static extern int git_remote_ls(RemoteSafeHandle remote, git_headlist_cb headlist_cb, IntPtr payload);
+
+        [DllImport(libgit2)]
+        internal static extern GitFetchSpecHandle git_remote_fetchspec(RemoteSafeHandle remote);
 
         [DllImport(libgit2)]
         [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(Utf8NoCleanupMarshaler))]

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -1227,6 +1227,25 @@ namespace LibGit2Sharp.Core
 
         #endregion
 
+        #region git_refspec
+
+        public static string git_fetchspec_rtransform(GitFetchSpecHandle refSpecPtr, string name)
+        {
+            using (ThreadAffinity())
+            {
+                // libgit2 API does not support querying for required buffer size.
+                // Use a sufficiently large buffer until it does.
+                var buffer = new byte[1024];
+
+                int res = NativeMethods.git_refspec_rtransform(buffer, (UIntPtr)buffer.Length, refSpecPtr, name);
+                Ensure.ZeroResult(res);
+
+                return Utf8Marshaler.Utf8FromBuffer(buffer) ?? string.Empty;
+            }
+        }
+
+        #endregion
+
         #region git_remote_
 
         public static RemoteSafeHandle git_remote_create(RepositorySafeHandle repo, string name, string url)
@@ -1256,6 +1275,11 @@ namespace LibGit2Sharp.Core
             {
                 NativeMethods.git_remote_disconnect(remote);
             }
+        }
+
+        public static GitFetchSpecHandle git_remote_fetchspec(RemoteSafeHandle remote)
+        {
+            return NativeMethods.git_remote_fetchspec(remote);
         }
 
         public static void git_remote_download(RemoteSafeHandle remote, TransferProgressHandler onTransferProgress)

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -62,9 +62,11 @@
     <Compile Include="Branch.cs" />
     <Compile Include="BranchCollection.cs" />
     <Compile Include="BranchCollectionExtensions.cs" />
+    <Compile Include="BranchUpdater.cs" />
     <Compile Include="Changes.cs" />
     <Compile Include="CheckoutCallbacks.cs" />
     <Compile Include="CheckoutOptions.cs" />
+    <Compile Include="Core\Handles\GitFetchSpecHandle.cs" />
     <Compile Include="Network.cs" />
     <Compile Include="Core\GitRemoteHead.cs" />
     <Compile Include="OrphanedHeadException.cs" />


### PR DESCRIPTION
Expose methods to set the Upstream information on a given branch. The API sets the specified branch as the upstream branch on the current branch object instance. If a local branch is passed in, it sets the upstream remote to the local remote ".".

I would appreciate any thoughts / alternatives on the reference string manipulations I am doing. I think these are correct and reasonable (maybe libgit2 can provide this utility in the future).

Also, the `TrackedBranch` property is a Lazy property - so, if this property has been read, and then we set the upstream information, it will not be reflected in the current branch object. The branch object has to be reloaded in order to get the current up to date information. I am not sure we want to invalidate the current branch object when we set a property that we know can make the object's state out of date.
