### PR TITLE
commit adds parents in MERGE_HEAD

### DIFF
--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -703,6 +703,19 @@ namespace LibGit2Sharp.Core
         internal static extern int git_repository_is_empty(RepositorySafeHandle repo);
 
         [DllImport(libgit2)]
+        internal static extern int git_repository_merge_cleanup(RepositorySafeHandle repo);
+
+        internal delegate int git_repository_mergehead_foreach_cb(
+            ref GitOid oid,
+            IntPtr payload);
+
+        [DllImport(libgit2)]
+        internal static extern int git_repository_mergehead_foreach(
+            RepositorySafeHandle repo,
+            git_repository_mergehead_foreach_cb cb,
+            IntPtr payload);
+
+        [DllImport(libgit2)]
         internal static extern int git_repository_open(
             out RepositorySafeHandle repository,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(FilePathMarshaler))] FilePath path);

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -1320,6 +1320,25 @@ namespace LibGit2Sharp.Core
             return RepositoryStateChecker(repo, NativeMethods.git_repository_is_empty);
         }
 
+        public static void git_repository_merge_cleanup(RepositorySafeHandle repo)
+        {
+            using (ThreadAffinity())
+            {
+                int res = NativeMethods.git_repository_merge_cleanup(repo);
+                Ensure.Success(res);
+            }
+        }
+
+        public static ICollection<TResult> git_repository_mergehead_foreach<TResult>(
+            RepositorySafeHandle repo,
+            Func<GitOid, TResult> resultSelector)
+        {
+            using (ThreadAffinity())
+            {
+                return git_foreach(resultSelector, c => NativeMethods.git_repository_mergehead_foreach(repo, (ref GitOid x, IntPtr p) => c(x, p), IntPtr.Zero));
+            }
+        }
+
         public static ObjectDatabaseSafeHandle git_repository_odb(RepositorySafeHandle repo)
         {
             using (ThreadAffinity())

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -87,6 +87,7 @@
     <Compile Include="DiffTargets.cs" />
     <Compile Include="Handlers.cs" />
     <Compile Include="MergeConflictException.cs" />
+    <Compile Include="MergeHeadCollection.cs" />
     <Compile Include="ReferenceCollectionExtensions.cs" />
     <Compile Include="Core\GitRemoteCallbacks.cs" />
     <Compile Include="RemoteCallbacks.cs" />

--- a/LibGit2Sharp/MergeHeadCollection.cs
+++ b/LibGit2Sharp/MergeHeadCollection.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using LibGit2Sharp.Core;
+using LibGit2Sharp.Core.Handles;
+
+namespace LibGit2Sharp
+{
+    /// <summary>
+    /// The commit IDs that are currently being merged into a repository.
+    /// </summary>
+    public class MergeHeadCollection : IEnumerable<Commit>
+    {
+        internal readonly Repository repo;
+
+        /// <summary>
+        ///   Needed for mocking purposes.
+        /// </summary>
+        protected MergeHeadCollection()
+        { }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref = "MergeHeadCollection" /> class.
+        /// </summary>
+        /// <param name = "repo">The repo.</param>
+        internal MergeHeadCollection(Repository repo)
+        {
+            this.repo = repo;
+        }
+
+        #region IEnumerable<Commit> Members
+
+        /// <summary>
+        ///   Returns an enumerator that iterates through the collection.
+        /// </summary>
+        /// <returns>An <see cref = "IEnumerator{T}" /> object that can be used to iterate through the collection.</returns>
+        public virtual IEnumerator<Commit> GetEnumerator()
+        {
+            return Proxy.git_repository_mergehead_foreach(repo.Handle,
+                (commitId) => (Commit)repo.Lookup(new ObjectId(commitId), GitObjectType.Commit))
+                .GetEnumerator();
+        }
+
+        /// <summary>
+        ///   Returns an enumerator that iterates through the collection.
+        /// </summary>
+        /// <returns>An <see cref = "IEnumerator" /> object that can be used to iterate through the collection.</returns>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Commit() should add parents in MERGE_HEAD (if it exists) and then clean up the merge metadata files
