### PR TITLE
Don't try to negate in an attributes file

### DIFF
--- a/Lib/.gitattributes
+++ b/Lib/.gitattributes
@@ -1,1 +1,3 @@
-!*.txt binary
+* binary
+.gitattributes text -binary
+*.txt text -binary


### PR DESCRIPTION
This is not supported, and newer versions of git will outright refuse
to work with a tree that contains one.

This should keep the intent of the negation it's replacing.
