### PR TITLE
Wrap git_blob_is_binary native method as Blob.IsBinary

### DIFF
--- a/LibGit2Sharp.Tests/BlobFixture.cs
+++ b/LibGit2Sharp.Tests/BlobFixture.cs
@@ -113,5 +113,15 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal("baae1fb3760a73481ced1fa03dc15614142c19ef", newentry.Id.Sha);
             }
         }
+
+        [Fact]
+        public void CanTellIfTheBlobContentLooksLikeBinary()
+        {
+            using (var repo = new Repository(BareTestRepoPath))
+            {
+                var blob = repo.Lookup<Blob>("a8233120f6ad708f843d861ce2b7228ec4e3dec6");
+                Assert.Equal(false, blob.IsBinary);
+            }
+        }
     }
 }

--- a/LibGit2Sharp.Tests/ObjectDatabaseFixture.cs
+++ b/LibGit2Sharp.Tests/ObjectDatabaseFixture.cs
@@ -286,5 +286,24 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal("Ü message\n", commit.Message);
             }
         }
+
+        [Fact]
+        public void CanCreateABinaryBlobFromABinaryReader()
+        {
+            TemporaryCloneOfTestRepo scd = BuildTemporaryCloneOfTestRepo();
+
+            var binaryContent = new byte[] { 0, 1, 2, 3, 4, 5 };
+
+            using (var repo = new Repository(scd.RepositoryPath))
+            {
+                using (var stream = new MemoryStream(binaryContent))
+                using (var binReader = new BinaryReader(stream))
+                {
+                    Blob blob = repo.ObjectDatabase.CreateBlob(binReader);
+                    Assert.Equal(6, blob.Size);
+                    Assert.Equal(true, blob.IsBinary);
+                }
+            }
+        }
     }
 }

--- a/LibGit2Sharp/Blob.cs
+++ b/LibGit2Sharp/Blob.cs
@@ -10,6 +10,7 @@ namespace LibGit2Sharp
     public class Blob : GitObject
     {
         private readonly ILazy<Int64> lazySize;
+        private readonly ILazy<bool> lazyIsBinary;
 
         /// <summary>
         ///   Needed for mocking purposes.
@@ -21,12 +22,18 @@ namespace LibGit2Sharp
             : base(repo, id)
         {
             lazySize = GitObjectLazyGroup.Singleton(repo, id, Proxy.git_blob_rawsize);
+            lazyIsBinary = GitObjectLazyGroup.Singleton(repo, id, Proxy.git_blob_is_binary);
         }
 
         /// <summary>
         ///   Gets the size in bytes of the contents of a blob
         /// </summary>
         public virtual int Size { get { return (int)lazySize.Value; } }
+
+        /// <summary>
+        ///    Determine if the blob content is most certainly binary or not.
+        /// </summary>
+        public virtual bool IsBinary { get { return lazyIsBinary.Value; } }
 
         /// <summary>
         ///   Gets the blob content in a <see cref="byte" /> array.

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -887,6 +887,9 @@ namespace LibGit2Sharp.Core
 
         [DllImport(libgit2)]
         internal static extern void git_treebuilder_free(IntPtr bld);
+
+        [DllImport(libgit2)]
+        internal static extern bool git_blob_is_binary(GitObjectSafeHandle blob);
     }
 }
 // ReSharper restore InconsistentNaming

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -99,6 +99,11 @@ namespace LibGit2Sharp.Core
             return NativeMethods.git_blob_rawsize(obj);
         }
 
+        public static bool git_blob_is_binary(GitObjectSafeHandle obj)
+        {
+            return NativeMethods.git_blob_is_binary(obj);
+        }
+
         #endregion
 
         #region git_branch_


### PR DESCRIPTION
Hi,

I just implemented the [`git_blob_is_binary`](https://github.com/libgit2/libgit2/blob/development/src/blob.c#L300-310) method. I took the implementation of `Blob.Size` as an example, using the `GitObjectLazyGroup` to call the native method lazily.

I would have like to test the true case as well, but it seems there is no binary blob in the test fixture repo. Am I right?
