### PR TITLE
Bind git_graph_ahead_behind native method

### DIFF
--- a/LibGit2Sharp/Branch.cs
+++ b/LibGit2Sharp/Branch.cs
@@ -120,7 +120,7 @@ namespace LibGit2Sharp
         /// </summary>
         public virtual int? AheadBy
         {
-            get { return ExistsPathToTrackedBranch() ? repo.Commits.QueryBy(new Filter { Since = Tip, Until = TrackedBranch }).Count() : (int?)null; }
+            get { return ExistsPathToTrackedBranch() ? Proxy.git_graph_ahead_behind(repo.Handle, TrackedBranch.Tip.Id, Tip.Id).Item1 : (int?)null; }
         }
 
         /// <summary>
@@ -132,7 +132,7 @@ namespace LibGit2Sharp
         /// </summary>
         public virtual int? BehindBy
         {
-            get { return ExistsPathToTrackedBranch() ? repo.Commits.QueryBy(new Filter { Since = TrackedBranch, Until = Tip }).Count() : (int?)null; }
+            get { return ExistsPathToTrackedBranch() ? Proxy.git_graph_ahead_behind(repo.Handle, TrackedBranch.Tip.Id, Tip.Id).Item2 : (int?)null; }
         }
 
         /// <summary>

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -392,6 +392,9 @@ namespace LibGit2Sharp.Core
             IntPtr payload);
 
         [DllImport(libgit2)]
+        internal static extern int git_graph_ahead_behind(out UIntPtr ahead, out UIntPtr behind, RepositorySafeHandle repo, ref GitOid one, ref GitOid two);
+
+        [DllImport(libgit2)]
         internal static extern int git_index_add_from_workdir(
             IndexSafeHandle index,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(FilePathMarshaler))] FilePath path);

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
+using LibGit2Sharp.Core.Compat;
 using LibGit2Sharp.Core.Handles;
 using LibGit2Sharp.Handlers;
 
@@ -612,6 +613,24 @@ namespace LibGit2Sharp.Core
             }
         }
 
+        #endregion
+
+        #region git_graph_
+        public static Tuple<int, int> git_graph_ahead_behind(RepositorySafeHandle repo, ObjectId firstId, ObjectId secondId)
+        {
+            GitOid oid1 = firstId.Oid;
+            GitOid oid2 = secondId.Oid;
+            using (ThreadAffinity())
+            {
+                UIntPtr ahead;
+                UIntPtr behind;
+                int res = NativeMethods.git_graph_ahead_behind(out ahead, out behind, repo, ref oid1, ref oid2);
+
+                Ensure.Success(res);
+
+                return new Tuple<int, int>((int)ahead, (int)behind);
+            }
+        }
         #endregion
 
         #region git_index_


### PR DESCRIPTION
Hello,

I bound the `git_graph_ahead_behind` from Libgit2
From there, I replaced current implementation of `Branch.AheadBy` and `Branch.BehindBy` with `git_graph_ahead_behind` call

I rely on `BranchFixture` code coverage for now, but this binding might later be use for other purposes.
