### PR TITLE
Improve exception message when configuration file is not found

### DIFF
--- a/LibGit2Sharp/Configuration.cs
+++ b/LibGit2Sharp/Configuration.cs
@@ -265,7 +265,8 @@ namespace LibGit2Sharp
 
             if (handle == null && throwIfStoreHasNotBeenFound)
             {
-                throw new LibGit2SharpException("No matching configuration file has been found.");
+                throw new LibGit2SharpException(string.Format("No {0} configuration file has been found.", 
+                    Enum.GetName(typeof(ConfigurationLevel), level)));
             }
 
             return handle;


### PR DESCRIPTION
Indicate which configuration level caused the exception.
