### PR TITLE
Fix test for non-virtual methods in types with public ctor

### DIFF
--- a/LibGit2Sharp/IndexEntry.cs
+++ b/LibGit2Sharp/IndexEntry.cs
@@ -22,7 +22,7 @@ namespace LibGit2Sharp
         ///   compared against the <see cref = "Blob" /> known from the <see cref = "Repository.Head" /> and the file in the working directory.
         /// </summary>
         [Obsolete("This method will be removed in the next release. Please use Repository.Index.RetrieveStatus(filePath) overload instead.")]
-        public FileStatus State
+        public virtual FileStatus State
         {
             get { return state(); }
         }
@@ -30,22 +30,22 @@ namespace LibGit2Sharp
         /// <summary>
         ///   Gets the relative path to the file within the working directory.
         /// </summary>
-        public string Path { get; private set; }
+        public virtual string Path { get; private set; }
 
         /// <summary>
         ///   Gets the file mode.
         /// </summary>
-        public Mode Mode { get; private set; }
+        public virtual Mode Mode { get; private set; }
 
         /// <summary>
         ///   Gets the stage number.
         /// </summary>
-        public StageLevel StageLevel { get; private set; }
+        public virtual StageLevel StageLevel { get; private set; }
 
         /// <summary>
         ///   Gets the id of the <see cref = "Blob" /> pointed at by this index entry.
         /// </summary>
-        public ObjectId Id { get; private set; }
+        public virtual ObjectId Id { get; private set; }
 
         internal static IndexEntry BuildFromPtr(Repository repo, IndexEntrySafeHandle handle)
         {

--- a/LibGit2Sharp/TreeDefinition.cs
+++ b/LibGit2Sharp/TreeDefinition.cs
@@ -51,7 +51,7 @@ namespace LibGit2Sharp
         /// </summary>
         /// <param name="treeEntryPath">The path within this <see cref="TreeDefinition"/>.</param>
         /// <returns>The current <see cref="TreeDefinition"/>.</returns>
-        public TreeDefinition Remove(string treeEntryPath)
+        public virtual TreeDefinition Remove(string treeEntryPath)
         {
             Ensure.ArgumentNotNullOrEmptyString(treeEntryPath, "treeEntryPath");
 
@@ -92,7 +92,7 @@ namespace LibGit2Sharp
         /// <param name="targetTreeEntryPath">The path within this <see cref="TreeDefinition"/>.</param>
         /// <param name="treeEntryDefinition">The <see cref="TreeEntryDefinition"/> to be stored at the described location.</param>
         /// <returns>The current <see cref="TreeDefinition"/>.</returns>
-        public TreeDefinition Add(string targetTreeEntryPath, TreeEntryDefinition treeEntryDefinition)
+        public virtual TreeDefinition Add(string targetTreeEntryPath, TreeEntryDefinition treeEntryDefinition)
         {
             Ensure.ArgumentNotNullOrEmptyString(targetTreeEntryPath, "targetTreeEntryPath");
             Ensure.ArgumentNotNull(treeEntryDefinition, "treeEntryDefinition");
@@ -132,7 +132,7 @@ namespace LibGit2Sharp
         /// <param name="blob">The <see cref="Blob"/> to be stored at the described location.</param>
         /// <param name="mode">The file related <see cref="Mode"/> attributes.</param>
         /// <returns>The current <see cref="TreeDefinition"/>.</returns>
-        public TreeDefinition Add(string targetTreeEntryPath, Blob blob, Mode mode)
+        public virtual TreeDefinition Add(string targetTreeEntryPath, Blob blob, Mode mode)
         {
             Ensure.ArgumentNotNull(blob, "blob");
             Ensure.ArgumentConformsTo(mode,
@@ -151,7 +151,7 @@ namespace LibGit2Sharp
         /// <see cref="Repository" /> is a standard, non-bare, repository. The path will then be considered as a path relative to the root of the working directory.</param>
         /// <param name="mode">The file related <see cref="Mode"/> attributes.</param>
         /// <returns>The current <see cref="TreeDefinition"/>.</returns>
-        public TreeDefinition Add(string targetTreeEntryPath, string filePath, Mode mode)
+        public virtual TreeDefinition Add(string targetTreeEntryPath, string filePath, Mode mode)
         {
             Ensure.ArgumentNotNullOrEmptyString(filePath, "filePath");
 
@@ -166,7 +166,7 @@ namespace LibGit2Sharp
         /// <param name="targetTreeEntryPath">The path within this <see cref="TreeDefinition"/>.</param>
         /// <param name="tree">The <see cref="Tree"/> to be stored at the described location.</param>
         /// <returns>The current <see cref="TreeDefinition"/>.</returns>
-        public TreeDefinition Add(string targetTreeEntryPath, Tree tree)
+        public virtual TreeDefinition Add(string targetTreeEntryPath, Tree tree)
         {
             Ensure.ArgumentNotNull(tree, "tree");
 
@@ -281,7 +281,7 @@ namespace LibGit2Sharp
         /// </summary>
         /// <param name="treeEntryPath">The path within this <see cref="TreeDefinition"/>.</param>
         /// <returns>The found <see cref="TreeEntryDefinition"/> if any; null otherwise.</returns>
-        public TreeEntryDefinition this[string treeEntryPath]
+        public virtual TreeEntryDefinition this[string treeEntryPath]
         {
             get
             {


### PR DESCRIPTION
I made the call on a few types that don't seem like they need to be mockable because they're easy enough to construct in any meaningful state:
- `Credential`
- `Filter`
- `ObjectId`
- `RepositoryOptions`
- `Signature`

/cc @yorah, @nulltoken, @half-ogre
