### PR TITLE
Check all [Flags] enums for overlaps

### DIFF
--- a/LibGit2Sharp.Tests/MetaFixture.cs
+++ b/LibGit2Sharp.Tests/MetaFixture.cs
@@ -93,6 +93,25 @@ namespace LibGit2Sharp.Tests
             }
         }
 
+        [Fact]
+        public void EnumsWithFlagsHaveMutuallyExclusiveValues()
+        {
+            var flagsEnums = Assembly.GetAssembly(typeof(Repository)).GetExportedTypes()
+                                     .Where(t => t.IsEnum && t.GetCustomAttributes(typeof(FlagsAttribute), false).Any());
+
+            var overlaps = from t in flagsEnums
+                           from int x in Enum.GetValues(t)
+                           where x != 0
+                           from int y in Enum.GetValues(t)
+                           where y != 0
+                           where x != y && (x & y) == y
+                           select string.Format("{0}.{1} overlaps with {0}.{2}", t.Name, Enum.ToObject(t, x), Enum.ToObject(t, y));
+
+            var message = string.Join(Environment.NewLine, overlaps.ToArray());
+
+            Assert.Equal("", message);
+        }
+
         private string BuildMissingDebuggerDisplayPropertyMessage(IEnumerable<Type> typesWithDebuggerDisplayAndInvalidImplPattern)
         {
             var sb = new StringBuilder();

--- a/LibGit2Sharp.Tests/StatusFixture.cs
+++ b/LibGit2Sharp.Tests/StatusFixture.cs
@@ -10,21 +10,6 @@ namespace LibGit2Sharp.Tests
     public class StatusFixture : BaseFixture
     {
         [Fact]
-        public void FileStatusFlagsAreMutuallyExclusive()
-        {
-            var overlaps = from FileStatus x in Enum.GetValues(typeof(FileStatus))
-                           where x != default(FileStatus)
-                           from FileStatus y in Enum.GetValues(typeof(FileStatus))
-                           where y != default(FileStatus)
-                           where x != y && (x & y) == y
-                           select string.Format("{0} overlaps with {1}", x, y);
-
-            var message = string.Join(Environment.NewLine, overlaps.ToArray());
-
-            Assert.Equal("", message);
-        }
-
-        [Fact]
         public void CanRetrieveTheStatusOfAFile()
         {
             using (var repo = new Repository(StandardTestRepoPath))


### PR DESCRIPTION
Rules for `FileStatus` should really apply for any enum with `[Flags]`.

Result if I add bad values:

```
Test 'LibGit2Sharp.Tests.MetaFixture.EnumsWithFlagsHaveMutuallyExclusiveValues' failed: Assert.Equal() Failure
Position: First difference is at position 0
Expected: 
Actual:   SubmoduleStatus.Nonexistent overlaps with SubmoduleStatus.InHead
          SubmoduleStatus.Nonexistent overlaps with SubmoduleStatus.InIndex
          SubmoduleStatus.Nonexistent overlaps with SubmoduleStatus.InConfig
          SubmoduleStatus.Nonexistent overlaps with SubmoduleStatus.InWorkDir
          SubmoduleStatus.Nonexistent overlaps with SubmoduleStatus.IndexAdded
          SubmoduleStatus.Nonexistent overlaps with SubmoduleStatus.IndexDeleted
          SubmoduleStatus.Nonexistent overlaps with SubmoduleStatus.IndexModified
          SubmoduleStatus.Nonexistent overlaps with SubmoduleStatus.WorkDirUninitialized
          SubmoduleStatus.Nonexistent overlaps with SubmoduleStatus.WorkDirAdded
          SubmoduleStatus.Nonexistent overlaps with SubmoduleStatus.WorkDirDeleted
          SubmoduleStatus.Nonexistent overlaps with SubmoduleStatus.WorkDirModified
          SubmoduleStatus.Nonexistent overlaps with SubmoduleStatus.WorkDirFilesIndexDirty
          SubmoduleStatus.Nonexistent overlaps with SubmoduleStatus.WorkDirFilesModified
          SubmoduleStatus.Nonexistent overlaps with SubmoduleStatus.WorkDirFilesUntracked
          FileStatus.Nonexistent overlaps with FileStatus.Added
          FileStatus.Nonexistent overlaps with FileStatus.Staged
          FileStatus.Nonexistent overlaps with FileStatus.Removed
          FileStatus.Nonexistent overlaps with FileStatus.Renamed
          FileStatus.Nonexistent overlaps with FileStatus.StagedTypeChange
          FileStatus.Nonexistent overlaps with FileStatus.Untracked
          FileStatus.Nonexistent overlaps with FileStatus.Modified
          FileStatus.Nonexistent overlaps with FileStatus.Missing
          FileStatus.Nonexistent overlaps with FileStatus.TypeChanged
          FileStatus.Nonexistent overlaps with FileStatus.Ignored
    MetaFixture.cs(113,0): at LibGit2Sharp.Tests.MetaFixture.EnumsWithFlagsHaveMutuallyExclusiveValues()

```
