### PR TITLE
Teach BranchCollection to disambiguate local and remote branch names

### DIFF
--- a/LibGit2Sharp.Tests/BranchFixture.cs
+++ b/LibGit2Sharp.Tests/BranchFixture.cs
@@ -190,6 +190,27 @@ namespace LibGit2Sharp.Tests
         }
 
         [Fact]
+        public void CanListBranchesWithRemoteAndLocalBranchWithSameShortName()
+        {
+            TemporaryCloneOfTestRepo path = BuildTemporaryCloneOfTestRepo(StandardTestRepoWorkingDirPath);
+
+            using (var repo = new Repository(path.RepositoryPath))
+            {
+                // Create a local branch with the same short name as a remote branch.
+                repo.Branches.Add("origin/master", repo.Branches["origin/test"].Tip);
+
+                var expectedWdBranches = new[]
+                                             {
+                                                 "diff-test-cases", "i-do-numbers", "logo", "master", "origin/master", "track-local",
+                                             };
+
+                Assert.Equal(expectedWdBranches, repo.Branches
+                    .Where(b => !b.IsRemote)
+                    .Select(b => b.Name).ToArray());
+            }
+        }
+
+        [Fact]
         public void CanListAllBranchesWhenGivenWorkingDir()
         {
             using (var repo = new Repository(StandardTestRepoWorkingDirPath))

--- a/LibGit2Sharp/BranchCollection.cs
+++ b/LibGit2Sharp/BranchCollection.cs
@@ -91,7 +91,7 @@ namespace LibGit2Sharp
         /// <returns>An <see cref = "IEnumerator{T}" /> object that can be used to iterate through the collection.</returns>
         public virtual IEnumerator<Branch> GetEnumerator()
         {
-            return Proxy.git_branch_foreach(repo.Handle, GitBranchType.GIT_BRANCH_LOCAL | GitBranchType.GIT_BRANCH_REMOTE, (b, t) => Utf8Marshaler.FromNative(b))
+            return Proxy.git_branch_foreach(repo.Handle, GitBranchType.GIT_BRANCH_LOCAL | GitBranchType.GIT_BRANCH_REMOTE, branchToCanoncialName)
                 .Select(n => this[n])
                 .OrderBy(b => b.CanonicalName, StringComparer.Ordinal)
                 .GetEnumerator();
@@ -195,6 +195,21 @@ namespace LibGit2Sharp
             return referenceName == "HEAD" ||
                 referenceName.StartsWith("refs/heads/", StringComparison.Ordinal) ||
                 referenceName.StartsWith("refs/remotes/", StringComparison.Ordinal);
+        }
+
+        private static string branchToCanoncialName(IntPtr namePtr, GitBranchType branchType)
+        {
+            string shortName = Utf8Marshaler.FromNative(namePtr);
+
+            switch (branchType)
+            {
+                case GitBranchType.GIT_BRANCH_LOCAL:
+                    return ShortToLocalName(shortName);
+                case GitBranchType.GIT_BRANCH_REMOTE:
+                    return ShortToRemoteName(shortName);
+                default:
+                    return shortName;
+            }
         }
 
         private string DebuggerDisplay


### PR DESCRIPTION
When there is a local branch whose short name is the same as an existing remote branch, the branch is counted as a local branch twice, and the remote branch to not be listed at all.

For instance, `refs/heads/origin/master` and `refs/remotes/origin/master` both have the short name `origin/master`. When we look up the branch by it's short name, both of these will resolve to the local branch. 

This leads to the Branch enumerator (in `BranchCollection`) to count both branches as local branches. This is because the enumerator currently only uses the short name of the branch to populate the list of branches, and thus both the local and remote branch resolve to the local branch.

The fix is to use the GitBranchType parameter to disambiguate between the local and remote branch and prefix the branch name. As part of this change, I went and made the code a little bit more resilient to an unknown `GitBranchType` enum value in the callback. If we are not concerned about this error, the code change becomes quite a bit smaller.
