### PR TITLE
move conflicts to reuc when removing index entries

### DIFF
--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -461,6 +461,11 @@ namespace LibGit2Sharp.Core
             int stage);
 
         [DllImport(libgit2)]
+        internal static extern int git_index_remove_bypath(
+            IndexSafeHandle index,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(FilePathMarshaler))] FilePath path);
+
+        [DllImport(libgit2)]
         internal static extern int git_index_write(IndexSafeHandle index);
 
         [DllImport(libgit2)]

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -778,6 +778,15 @@ namespace LibGit2Sharp.Core
             }
         }
 
+        public static void git_index_remove_bypath(IndexSafeHandle index, FilePath path)
+        {
+            using (ThreadAffinity())
+            {
+                int res = NativeMethods.git_index_remove_bypath(index, path);
+                Ensure.ZeroResult(res);
+            }
+        }
+
         public static void git_index_write(IndexSafeHandle index)
         {
             using (ThreadAffinity())

--- a/LibGit2Sharp/Index.cs
+++ b/LibGit2Sharp/Index.cs
@@ -427,7 +427,7 @@ namespace LibGit2Sharp
 
         private void RemoveFromIndex(string relativePath)
         {
-            Proxy.git_index_remove(handle, relativePath, 0);
+            Proxy.git_index_remove_bypath(handle, relativePath);
         }
 
         private void UpdatePhysicalIndex()


### PR DESCRIPTION
When removing files from the index, remove the associated conflicts and move them to the REUC.

I'm stumped as to how to add a test for this, though.  We can't, it seems, add conflicts to the index directory.  We could expose some methods that allow for that.

Or we could add some test repository that has conflicts in it...

Preferences?

/cc @yishaigalatzer
