### PR TITLE
Remove empty method from release build

### DIFF
--- a/LibGit2Sharp/Core/Handles/SafeHandleBase.cs
+++ b/LibGit2Sharp/Core/Handles/SafeHandleBase.cs
@@ -19,9 +19,9 @@ namespace LibGit2Sharp.Core.Handles
 #endif
         }
 
+#if DEBUG
         protected override void Dispose(bool disposing)
         {
-#if DEBUG
             if (!disposing && !IsInvalid)
             {
                 Trace.WriteLine(string.Format(CultureInfo.InvariantCulture, "A {0} handle wrapper has not been properly disposed.", GetType().Name));
@@ -30,9 +30,10 @@ namespace LibGit2Sharp.Core.Handles
 #endif
                 Trace.WriteLine("");
             }
-#endif
+
             base.Dispose(disposing);
         }
+#endif
 
         public override bool IsInvalid
         {


### PR DESCRIPTION
I relocated the `#if DEBUG` and `#endif` lines to fully exclude the empty method `SafeHandleBase.Dispose` from release builds.
