### PR TITLE
Make LambdaEqualityHelper.Equals symmetric

### DIFF
--- a/LibGit2Sharp/Core/LambdaEqualityHelper.cs
+++ b/LibGit2Sharp/Core/LambdaEqualityHelper.cs
@@ -13,7 +13,7 @@ namespace LibGit2Sharp.Core
 
         public bool Equals(T instance, T other)
         {
-            if (ReferenceEquals(null, other))
+            if (ReferenceEquals(null, instance) || ReferenceEquals(null, other))
             {
                 return false;
             }


### PR DESCRIPTION
The current implementation violates the symmetric requirement of `IEqualityComparer.Equals` in the case where exactly one of the inputs is null.
