### PR TITLE
Add strongly typed NonFastForward exception

### DIFF
--- a/LibGit2Sharp/Core/Ensure.cs
+++ b/LibGit2Sharp/Core/Ensure.cs
@@ -67,6 +67,9 @@ namespace LibGit2Sharp.Core
                 case (int)GitErrorCode.UnmergedEntries:
                     throw new UnmergedIndexEntriesException(errorMessage, (GitErrorCode)result, error.Category);
 
+                case (int)GitErrorCode.NonFastForward:
+                    throw new NonFastForwardException(errorMessage, (GitErrorCode)result, error.Category);
+
                 case (int)GitErrorCode.MergeConflict:
                     throw new MergeConflictException(errorMessage, (GitErrorCode)result, error.Category);
 

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -99,6 +99,7 @@
     <Compile Include="MergeHead.cs" />
     <Compile Include="NameConflictException.cs" />
     <Compile Include="NetworkExtensions.cs" />
+    <Compile Include="NonFastForwardException.cs" />
     <Compile Include="PushResult.cs" />
     <Compile Include="PushStatusError.cs" />
     <Compile Include="ReferenceCollectionExtensions.cs" />

--- a/LibGit2Sharp/NonFastForwardException.cs
+++ b/LibGit2Sharp/NonFastForwardException.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Runtime.Serialization;
+using LibGit2Sharp.Core;
+
+namespace LibGit2Sharp
+{
+    /// <summary>
+    ///   The exception that is thrown when push cannot be performed
+    ///   against the remote without losing commits.
+    /// </summary>
+    [Serializable]
+    public class NonFastForwardException : LibGit2SharpException
+    {
+        /// <summary>
+        ///   Initializes a new instance of the <see cref = "LibGit2Sharp.NonFastForwardException" /> class.
+        /// </summary>
+        public NonFastForwardException()
+        {
+        }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref = "LibGit2Sharp.NonFastForwardException" /> class with a specified error message.
+        /// </summary>
+        /// <param name = "message">A message that describes the error. </param>
+        public NonFastForwardException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref = "LibGit2Sharp.NonFastForwardException" /> class with a specified error message and a reference to the inner exception that is the cause of this exception.
+        /// </summary>
+        /// <param name = "message">The error message that explains the reason for the exception. </param>
+        /// <param name = "innerException">The exception that is the cause of the current exception. If the <paramref name = "innerException" /> parameter is not a null reference, the current exception is raised in a catch block that handles the inner exception.</param>
+        public NonFastForwardException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref = "LibGit2Sharp.NonFastForwardException" /> class with a serialized data.
+        /// </summary>
+        /// <param name = "info">The <see cref="SerializationInfo "/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name = "context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        protected NonFastForwardException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+
+        internal NonFastForwardException(string message, GitErrorCode code, GitErrorCategory category)
+            : base(message, code, category)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Wrap the NonFastForward error code from libgit2 in a strongly typed exception.
