### PR TITLE
Introduce RepositoryInformation.Message to expose git_repository_message

### DIFF
--- a/LibGit2Sharp.Tests/RepositoryFixture.cs
+++ b/LibGit2Sharp.Tests/RepositoryFixture.cs
@@ -477,5 +477,30 @@ namespace LibGit2Sharp.Tests
                 Assert.Null(trackLocal.Remote);
             }
         }
+
+        [Fact]
+        public void ReadingEmptyRepositoryMessageReturnsNull()
+        {
+            SelfCleaningDirectory scd = BuildSelfCleaningDirectory();
+
+            using (var repo = Repository.Init(scd.DirectoryPath))
+            {
+                Assert.Null(repo.Info.Message);
+            }
+        }
+
+        [Fact]
+        public void CanReadRepositoryMessage()
+        {
+            SelfCleaningDirectory scd = BuildSelfCleaningDirectory();
+            string testMessage = "This is a test message!";
+
+            using (var repo = Repository.Init(scd.DirectoryPath))
+            {
+                File.WriteAllText(Path.Combine(repo.Info.Path, "MERGE_MSG"), testMessage);
+
+                Assert.Equal(testMessage, repo.Info.Message);
+            }
+        }
     }
 }

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -818,6 +818,12 @@ namespace LibGit2Sharp.Core
             IntPtr payload);
 
         [DllImport(libgit2)]
+        internal static extern int git_repository_message(
+            byte[] message_out,
+            UIntPtr buffer_size,
+            RepositorySafeHandle repository);
+
+        [DllImport(libgit2)]
         internal static extern int git_repository_odb(out ObjectDatabaseSafeHandle odb, RepositorySafeHandle repo);
 
         [DllImport(libgit2)]

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -1515,6 +1515,31 @@ namespace LibGit2Sharp.Core
                 GitErrorCode.NotFound);
         }
 
+        public static string git_repository_message(RepositorySafeHandle repo)
+        {
+            using (ThreadAffinity())
+            {
+                int bufSize = NativeMethods.git_repository_message(null, (UIntPtr)0, repo);
+
+                if (bufSize == (int)GitErrorCode.NotFound)
+                {
+                    return null;
+                }
+
+                Ensure.Int32Result(bufSize);
+
+                byte[] buf = new byte[bufSize];
+                int len = NativeMethods.git_repository_message(buf, (UIntPtr)bufSize, repo);
+
+                if (len != bufSize)
+                {
+                    throw new LibGit2SharpException("Repository message file changed as we were reading it");
+                }
+
+                return Utf8Marshaler.Utf8FromBuffer(buf);
+            }
+        }
+
         public static ObjectDatabaseSafeHandle git_repository_odb(RepositorySafeHandle repo)
         {
             using (ThreadAffinity())

--- a/LibGit2Sharp/RepositoryInformation.cs
+++ b/LibGit2Sharp/RepositoryInformation.cs
@@ -79,5 +79,13 @@ namespace LibGit2Sharp
         {
             get { return Proxy.git_repository_state(repo.Handle); }
         }
+
+        /// <summary>
+        ///   The message for a pending interactive operation.
+        /// </summary>
+        public virtual string Message
+        {
+            get { return Proxy.git_repository_message(repo.Handle); }
+        }
     }
 }


### PR DESCRIPTION
repository.Info.Message will now reflect `MERGE_MSG` via `git_repository_message`.

Returns `null` if there is no MERGE_MSG file - throwing seems like overkill since this doesn't seem like an exceptional case.

I put buffer allocation in a loop until it's big enough.  I don't think there's a real likelihood of getting into a race where MERGE_MSG grows and we need to accommodate that, but this tends to be the way we do this.  If you're opposed to this pattern, I'm not tied to it.
