### PR TITLE
Fix credential acquire callback interop

### DIFF
--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -304,6 +304,7 @@ namespace LibGit2Sharp.Core
         internal delegate int git_cred_acquire_cb(
             out IntPtr cred,
             IntPtr url,
+            IntPtr username_from_url,
             uint allowed_types,
             IntPtr payload);
 

--- a/LibGit2Sharp/Remote.cs
+++ b/LibGit2Sharp/Remote.cs
@@ -69,6 +69,11 @@ namespace LibGit2Sharp
             TransferProgressHandler onTransferProgress = null,
             Credentials credentials = null)
         {
+            // We need to keep a reference to the git_cred_acquire_cb callback around
+            // so it will not be garbage collected before we are done with it.
+            // Note that we also have a GC.KeepAlive call at the end of the method.
+            NativeMethods.git_cred_acquire_cb credentialCallback = null;
+
             using (RemoteSafeHandle remoteHandle = Proxy.git_remote_load(repository.Handle, this.Name, true))
             {
                 var callbacks = new RemoteCallbacks(onProgress, onCompletion, onUpdateTips);
@@ -76,15 +81,14 @@ namespace LibGit2Sharp
 
                 Proxy.git_remote_set_autotag(remoteHandle, tagFetchMode);
 
-                // Username/password auth
                 if (credentials != null)
                 {
+                    credentialCallback = (out IntPtr cred, IntPtr url, IntPtr username_from_url, uint types, IntPtr payload) =>
+                        NativeMethods.git_cred_userpass_plaintext_new(out cred, credentials.Username, credentials.Password);
+
                     Proxy.git_remote_set_cred_acquire_cb(
                         remoteHandle,
-                        (out IntPtr cred, IntPtr url, uint types, IntPtr payload) =>
-                        NativeMethods.git_cred_userpass_plaintext_new(out cred,
-                                                                      credentials.Username,
-                                                                      credentials.Password),
+                        credentialCallback,
                         IntPtr.Zero);
                 }
 
@@ -109,6 +113,10 @@ namespace LibGit2Sharp
                     Proxy.git_remote_disconnect(remoteHandle);
                 }
             }
+
+            // To be safe, make sure the credential callback is kept until
+            // alive until at least this point.
+            GC.KeepAlive(credentialCallback);
         }
 
         /// <summary>

--- a/LibGit2Sharp/Repository.cs
+++ b/LibGit2Sharp/Repository.cs
@@ -503,11 +503,16 @@ namespace LibGit2Sharp
             if (credentials != null)
             {
                 cloneOpts.CredAcquireCallback =
-                    (out IntPtr cred, IntPtr url, uint types, IntPtr payload) =>
+                    (out IntPtr cred, IntPtr url, IntPtr username_from_url, uint types, IntPtr payload) =>
                     NativeMethods.git_cred_userpass_plaintext_new(out cred, credentials.Username, credentials.Password);
             }
 
             using(Proxy.git_clone(sourceUrl, workdirPath, cloneOpts)) {}
+
+            // To be safe, make sure the credential callback is kept until
+            // alive until at least this point.
+            GC.KeepAlive(cloneOpts.CredAcquireCallback);
+
             return new Repository(workdirPath, options);
         }
 


### PR DESCRIPTION
Fix two issues with the credential callback interop
1) fix issue where credential callback delegate could be garbage collected before we are done with it
2) Update `git_cred_actuire_cb` method signature to match native function signature.

/cc @phkelley
