### PR TITLE
Teach Remote to transform references using its default fetchspec

### DIFF
--- a/LibGit2Sharp.Tests/RemoteFixture.cs
+++ b/LibGit2Sharp.Tests/RemoteFixture.cs
@@ -236,5 +236,29 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(expectedResult, repo.Network.Remotes.IsValidName(refname));
             }
         }
+
+        [Fact]
+        public void CanFetchSpecTransformReferenceToTarget()
+        {
+            TemporaryCloneOfTestRepo path = BuildTemporaryCloneOfTestRepo(StandardTestRepoPath);
+            using (var repo = new Repository(StandardTestRepoPath))
+            {
+                Remote remote = repo.Network.Remotes["origin"];
+                Assert.NotNull(remote);
+                Assert.Equal("refs/remotes/origin/test", remote.FetchSpecTransformToTarget("refs/heads/test"));
+            }
+        }
+
+        [Fact]
+        public void CanFetchSpecTransformReferenceToSource()
+        {
+            TemporaryCloneOfTestRepo path = BuildTemporaryCloneOfTestRepo(StandardTestRepoPath);
+            using (var repo = new Repository(StandardTestRepoPath))
+            {
+                Remote remote = repo.Network.Remotes["origin"];
+                Assert.NotNull(remote);
+                Assert.Equal("refs/heads/test", remote.FetchSpecTransformToSource("refs/remotes/origin/test"));
+            }
+        }
     }
 }

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -670,8 +670,15 @@ namespace LibGit2Sharp.Core
         internal static extern GitReferenceType git_reference_type(ReferenceSafeHandle reference);
 
         [DllImport(libgit2)]
+        internal static extern int git_refspec_transform(
+            byte[] reference,
+            UIntPtr outlen,
+            GitFetchSpecHandle refSpec,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(Utf8Marshaler))] string name);
+
+        [DllImport(libgit2)]
         internal static extern int git_refspec_rtransform(
-            byte[] target,
+            byte[] reference,
             UIntPtr outlen,
             GitFetchSpecHandle refSpec,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(Utf8Marshaler))] string name);

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -1252,6 +1252,21 @@ namespace LibGit2Sharp.Core
 
         #region git_refspec
 
+        public static string git_fetchspec_transform(GitFetchSpecHandle refSpecPtr, string name)
+        {
+            using (ThreadAffinity())
+            {
+                // libgit2 API does not support querying for required buffer size.
+                // Use a sufficiently large buffer until it does.
+                var buffer = new byte[1024];
+
+                int res = NativeMethods.git_refspec_transform(buffer, (UIntPtr)buffer.Length, refSpecPtr, name);
+                Ensure.ZeroResult(res);
+
+                return Utf8Marshaler.Utf8FromBuffer(buffer) ?? string.Empty;
+            }
+        }
+
         public static string git_fetchspec_rtransform(GitFetchSpecHandle refSpecPtr, string name)
         {
             using (ThreadAffinity())

--- a/LibGit2Sharp/Remote.cs
+++ b/LibGit2Sharp/Remote.cs
@@ -52,6 +52,34 @@ namespace LibGit2Sharp
         public virtual string Url { get; private set; }
 
         /// <summary>
+        ///   Transform a reference to its target reference using the <see cref = "Remote" />'s default fetchspec.
+        /// </summary>
+        /// <param name="reference">The reference to transform.</param>
+        /// <returns>The transformed reference.</returns>
+        public virtual string FetchSpecTransformToTarget(string reference)
+        {
+            using (RemoteSafeHandle remoteHandle = Proxy.git_remote_load(repository.Handle, Name, true))
+            {
+                GitFetchSpecHandle fetchSpecPtr = Proxy.git_remote_fetchspec(remoteHandle);
+                return Proxy.git_fetchspec_transform(fetchSpecPtr, reference);
+            }
+        }
+
+        /// <summary>
+        ///   Transform a reference to its source reference using the <see cref = "Remote" />'s default fetchspec.
+        /// </summary>
+        /// <param name="reference">The reference to transform.</param>
+        /// <returns>The transformed reference.</returns>
+        public virtual string FetchSpecTransformToSource(string reference)
+        {
+            using (RemoteSafeHandle remoteHandle = Proxy.git_remote_load(repository.Handle, Name, true))
+            {
+                GitFetchSpecHandle fetchSpecPtr = Proxy.git_remote_fetchspec(remoteHandle);
+                return Proxy.git_fetchspec_rtransform(fetchSpecPtr, reference);
+            }
+        }
+
+        /// <summary>
         ///   Fetch from the <see cref = "Remote" />.
         /// </summary>
         /// <param name="tagFetchMode">Optional parameter indicating what tags to download.</param>


### PR DESCRIPTION
Expose the refspec transform for a remote's default fetchspec.
