### PR TITLE
Teach BranchUpdater to set merge branch directly

### DIFF
--- a/LibGit2Sharp.Tests/BranchFixture.cs
+++ b/LibGit2Sharp.Tests/BranchFixture.cs
@@ -471,6 +471,38 @@ namespace LibGit2Sharp.Tests
         }
 
         [Fact]
+        public void CanSetUpstreamMergeBranch()
+        {
+            const string testBranchName = "branchToSetUpstreamInfoFor";
+            const string mergeBranchName = "refs/heads/master";
+            const string upstreamBranchName = "refs/remotes/origin/master";
+            const string upstreamRemoteName = "origin";
+
+            TemporaryCloneOfTestRepo path = BuildTemporaryCloneOfTestRepo(StandardTestRepoPath);
+
+            using (var repo = new Repository(path.RepositoryPath))
+            {
+                Branch branch = repo.CreateBranch(testBranchName);
+                Assert.False(branch.IsTracking);
+
+                Branch upstreamBranch = repo.Branches[upstreamBranchName];
+                Branch updatedBranch = repo.Branches.Update(branch,
+                    b => b.UpstreamRemote = upstreamRemoteName,
+                    b => b.UpstreamMergeBranch =  mergeBranchName);
+
+                // Verify the immutability of the branch.
+                Assert.False(branch.IsTracking);
+
+                Remote upstreamRemote = repo.Network.Remotes[upstreamRemoteName];
+                Assert.NotNull(upstreamRemote);
+
+                Assert.True(updatedBranch.IsTracking);
+                Assert.Equal(upstreamBranch, updatedBranch.TrackedBranch);
+                Assert.Equal(upstreamRemote, updatedBranch.Remote);
+            }
+        }
+
+        [Fact]
         public void CanSetLocalUpstreamBranch()
         {
             const string testBranchName = "branchToSetUpstreamInfoFor";


### PR DESCRIPTION
This PR lets us set the upstream remote and merge branch onto a local branch directly.

This is useful when we are pushing a new local branch to a remote and want to set the upstream tracking info. Instead of performing the refspec transform to identify the name of the tracked branch in the `refs/remotes` namespace, we can set the merge branch directly (e.g., using the transforms exposed in #349)
