### PR TITLE
Allow commits on any unparented branch

### DIFF
--- a/LibGit2Sharp.Tests/CommitFixture.cs
+++ b/LibGit2Sharp.Tests/CommitFixture.cs
@@ -618,7 +618,7 @@ namespace LibGit2Sharp.Tests
                 AssertBlobContent(commit[relativeFilepath], "nulltoken\n");
 
                 Assert.Equal(0, commit.Parents.Count());
-                Assert.False(repo.Info.IsEmpty);
+                Assert.False(repo.Info.IsHeadOrphaned);
 
                 File.WriteAllText(filePath, "nulltoken commits!\n");
                 repo.Index.Stage(relativeFilepath);

--- a/LibGit2Sharp.Tests/RepositoryFixture.cs
+++ b/LibGit2Sharp.Tests/RepositoryFixture.cs
@@ -150,7 +150,6 @@ namespace LibGit2Sharp.Tests
         private static void AssertInitializedRepository(Repository repo)
         {
             Assert.NotNull(repo.Info.Path);
-            Assert.True(repo.Info.IsEmpty);
             Assert.False(repo.Info.IsHeadDetached);
             Assert.True(repo.Info.IsHeadOrphaned);
 
@@ -215,7 +214,6 @@ namespace LibGit2Sharp.Tests
                 Assert.NotNull(repo.Info.Path);
                 Assert.Null(repo.Info.WorkingDirectory);
                 Assert.True(repo.Info.IsBare);
-                Assert.False(repo.Info.IsEmpty);
                 Assert.False(repo.Info.IsHeadDetached);
             }
         }

--- a/LibGit2Sharp.Tests/TagFixture.cs
+++ b/LibGit2Sharp.Tests/TagFixture.cs
@@ -603,7 +603,7 @@ namespace LibGit2Sharp.Tests
 
             using (var repo = Repository.Init(scd.DirectoryPath))
             {
-                Assert.True(repo.Info.IsEmpty);
+                Assert.True(repo.Info.IsHeadOrphaned);
                 Assert.Equal(0, repo.Tags.Count());
             }
         }

--- a/LibGit2Sharp/Repository.cs
+++ b/LibGit2Sharp/Repository.cs
@@ -657,7 +657,7 @@ namespace LibGit2Sharp
         /// <returns>The generated <see cref = "Commit" />.</returns>
         public Commit Commit(string message, Signature author, Signature committer, bool amendPreviousCommit = false)
         {
-            if (amendPreviousCommit && Info.IsEmpty)
+            if (amendPreviousCommit && Info.IsHeadOrphaned)
             {
                 throw new LibGit2SharpException("Can not amend anything. The Head doesn't point at any commit.");
             }

--- a/LibGit2Sharp/RepositoryInformation.cs
+++ b/LibGit2Sharp/RepositoryInformation.cs
@@ -1,4 +1,5 @@
-﻿using LibGit2Sharp.Core;
+﻿using System;
+using LibGit2Sharp.Core;
 
 namespace LibGit2Sharp
 {
@@ -51,6 +52,7 @@ namespace LibGit2Sharp
         /// <value>
         ///   <c>true</c> if this repository is empty; otherwise, <c>false</c>.
         /// </value>
+        [Obsolete("This method will be removed in the next release.")]
         public virtual bool IsEmpty
         {
             get { return Proxy.git_repository_is_empty(repo.Handle); }


### PR DESCRIPTION
LibGit2Sharp will currently only allow a commit on an "orphaned" or unparented branch if the libgit2 repository is "empty" - in particular, an initial commit is only allowed on the "master" branch.

This PR changes the condition that is checked for the initial commit to see if the current branch is orphaned.
