### PR TITLE
Diff.Compare overload to include untracked changes

### DIFF
--- a/LibGit2Sharp.Tests/DiffWorkdirToIndexFixture.cs
+++ b/LibGit2Sharp.Tests/DiffWorkdirToIndexFixture.cs
@@ -35,5 +35,19 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal("modified_unstaged_file.txt", changes.Modified.Single().Path);
             }
         }
+
+        [Fact]
+        public void CanCompareTheWorkDirAgainstTheIndexWithUntrackedFiles()
+        {
+            using (var repo = new Repository(StandardTestRepoPath))
+            {
+                TreeChanges changes = repo.Diff.Compare(null, true);
+
+                Assert.Equal(3, changes.Count());
+                Assert.Equal("deleted_unstaged_file.txt", changes.Deleted.Single().Path);
+                Assert.Equal("modified_unstaged_file.txt", changes.Modified.Single().Path);
+                Assert.Equal("new_untracked_file.txt", changes.Added.Single().Path);
+            }
+        }
     }
 }

--- a/LibGit2Sharp/Diff.cs
+++ b/LibGit2Sharp/Diff.cs
@@ -200,12 +200,13 @@ namespace LibGit2Sharp
         ///   Show changes between the working directory and the index.
         /// </summary>
         /// <param name = "paths">The list of paths (either files or directories) that should be compared.</param>
+        /// <param name = "includeUntracked">If true, include untracked files from the working dir as additions. Otherwise ignore them.</param>
         /// <returns>A <see cref = "TreeChanges"/> containing the changes between the working directory and the index.</returns>
-        public virtual TreeChanges Compare(IEnumerable<string> paths = null)
+        public virtual TreeChanges Compare(IEnumerable<string> paths = null, bool includeUntracked = false)
         {
             var comparer = WorkdirToIndex(repo);
 
-            using (GitDiffOptions options = BuildOptions(DiffOptions.None, paths))
+            using (GitDiffOptions options = BuildOptions(includeUntracked ? DiffOptions.IncludeUntracked : DiffOptions.None, paths))
             using (DiffListSafeHandle dl = BuildDiffListFromComparer(null, comparer, options))
             {
                 return new TreeChanges(dl);


### PR DESCRIPTION
It seems odd to me that untracked changes aren't included by default when comparing the working tree against the index. The other ways I could find to obtain them were much more roundabout.

(I'm new to the project so please decline and tell me if there's a better way to do this already.)
