### PR TITLE
Remove orphan hack for Commits.QueryBy() 

### DIFF
--- a/LibGit2Sharp.Tests/RepositoryFixture.cs
+++ b/LibGit2Sharp.Tests/RepositoryFixture.cs
@@ -174,7 +174,7 @@ namespace LibGit2Sharp.Tests
             Assert.Equal(0, repo.Commits.QueryBy(new Filter { Since = repo.Refs.Head }).Count());
             Assert.Equal(0, repo.Commits.QueryBy(new Filter { Since = repo.Head }).Count());
             Assert.Equal(0, repo.Commits.QueryBy(new Filter { Since = "HEAD" }).Count());
-            Assert.Throws<LibGit2SharpException>(() => repo.Commits.QueryBy(new Filter { Since = expectedHeadTargetIdentifier }).Count());
+            Assert.Equal(0, repo.Commits.QueryBy(new Filter { Since = expectedHeadTargetIdentifier }).Count());
 
             Assert.Null(repo.Head["subdir/I-do-not-exist"]);
 

--- a/LibGit2Sharp/CommitLog.cs
+++ b/LibGit2Sharp/CommitLog.cs
@@ -271,7 +271,8 @@ namespace LibGit2Sharp
 
             private bool AllowOrphanReference(string identifier)
             {
-                return string.Equals(identifier, "HEAD", StringComparison.Ordinal);
+                return string.Equals(identifier, "HEAD", StringComparison.Ordinal)
+                       || string.Equals(identifier, repo.Head.CanonicalName, StringComparison.Ordinal);
             }
 
             private IEnumerable<ObjectId> RetrieveCommitOids(object identifier)


### PR DESCRIPTION
Related: #30, #355

This seems like a more reliable way to support any empty commit list since `HEAD` on orphan branches.

d31afcd includes a breaking change to handling for `Since = "refs/remotes/master"` that I think is the right thing to do: the branch doesn't exist, so we shouldn't go out of our way in this case to make it behave as if it does.

That said, if I'm on the wrong side of the "orphan branch as semi-real reference but only for `CommitLog`" issue, e6dbc3a makes the behavior depend on the current `HEAD` ref rather than hard-coded to `master`.

/cc @tclem @jamill @nulltoken
