### PR TITLE
File or directory starting with ! is always ignored

### DIFF
--- a/LibGit2Sharp.Tests/StageFixture.cs
+++ b/LibGit2Sharp.Tests/StageFixture.cs
@@ -126,13 +126,15 @@ namespace LibGit2Sharp.Tests
             }
         }
 
-        [Fact]
-        public void CanStageANewFileInAPersistentManner()
+        [Theory]
+        [InlineData("unit_test.txt")]
+        [InlineData("!unit_test.txt")]
+        [InlineData("!bang/unit_test.txt")]
+        public void CanStageANewFileInAPersistentManner(string filename)
         {
             string path = CloneStandardTestRepo();
             using (var repo = new Repository(path))
             {
-                const string filename = "unit_test.txt";
                 Assert.Equal(FileStatus.Nonexistent, repo.Index.RetrieveStatus(filename));
                 Assert.Null(repo.Index[filename]);
 
@@ -147,7 +149,6 @@ namespace LibGit2Sharp.Tests
 
             using (var repo = new Repository(path))
             {
-                const string filename = "unit_test.txt";
                 Assert.NotNull(repo.Index[filename]);
                 Assert.Equal(FileStatus.Added, repo.Index.RetrieveStatus(filename));
             }

--- a/LibGit2Sharp.Tests/StatusFixture.cs
+++ b/LibGit2Sharp.Tests/StatusFixture.cs
@@ -20,6 +20,42 @@ namespace LibGit2Sharp.Tests
             }
         }
 
+        [Theory]
+        [InlineData("file")]
+        [InlineData("file.txt")]
+        [InlineData("$file")]
+        [InlineData("$file.txt")]
+        [InlineData("$dir/file")]
+        [InlineData("$dir/file.txt")]
+        [InlineData("#file")]
+        [InlineData("#file.txt")]
+        [InlineData("#dir/file")]
+        [InlineData("#dir/file.txt")]
+        [InlineData("^file")]
+        [InlineData("^file.txt")]
+        [InlineData("^dir/file")]
+        [InlineData("^dir/file.txt")]
+        [InlineData("!file")]
+        [InlineData("!file.txt")]
+        [InlineData("!dir/file")]
+        [InlineData("!dir/file.txt")]
+        [InlineData("file!")]
+        [InlineData("file!.txt")]
+        [InlineData("dir!/file")]
+        [InlineData("dir!/file.txt")]
+        public void CanRetrieveTheStatusOfAnUntrackedFile(string filePath)
+        {
+            var clone = CloneStandardTestRepo();
+
+            using (var repo = new Repository(clone))
+            {
+                Touch(repo.Info.WorkingDirectory, filePath, "content");
+
+                FileStatus status = repo.Index.RetrieveStatus(filePath);
+                Assert.Equal(FileStatus.Untracked, status);
+            }
+        }
+
         [Fact]
         public void RetrievingTheStatusOfADirectoryThrows()
         {


### PR DESCRIPTION
I'm not able to reproduce Phil's "Can not stage '!orphans/images/001.gif'. The file does not exist." error, but I do consistently see files/directories showing `FileStatus.Ignored`. I can't find an ignore rule in our test repository that would cause this behavior...maybe a libgit2 bug?
