### PR TITLE
Move Repository.Conflicts to Index.Conflicts

### DIFF
--- a/LibGit2Sharp.Tests/ConflictFixture.cs
+++ b/LibGit2Sharp.Tests/ConflictFixture.cs
@@ -60,11 +60,11 @@ namespace LibGit2Sharp.Tests
                 string fullpath = Path.Combine(repo.Info.WorkingDirectory, filename);
 
                 Assert.Equal(existsBeforeRemove, File.Exists(fullpath));
-                Assert.NotNull(repo.Conflicts[filename]);
+                Assert.NotNull(repo.Index.Conflicts[filename]);
 
                 repo.Index.Remove(filename, removeFromWorkdir);
 
-                Assert.Null(repo.Conflicts[filename]);
+                Assert.Null(repo.Index.Conflicts[filename]);
                 Assert.Equal(count - removedIndexEntries, repo.Index.Count);
                 Assert.Equal(existsAfterRemove, File.Exists(fullpath));
                 Assert.Equal(lastStatus, repo.Index.RetrieveStatus(filename));
@@ -76,7 +76,7 @@ namespace LibGit2Sharp.Tests
         {
             using (var repo = new Repository(MergedTestRepoWorkingDirPath))
             {
-                Conflict conflict = repo.Conflicts[filepath];
+                Conflict conflict = repo.Index.Conflicts[filepath];
                 Assert.NotNull(conflict);
 
                 ObjectId expectedAncestor = ancestorId != null ? new ObjectId(ancestorId) : null;
@@ -123,7 +123,7 @@ namespace LibGit2Sharp.Tests
         {
             using (var repo = new Repository(MergedTestRepoWorkingDirPath))
             {
-                var expected = repo.Conflicts.Select(c => new[] { GetPath(c), GetId(c.Ancestor), GetId(c.Ours), GetId(c.Theirs) }).ToArray();
+                var expected = repo.Index.Conflicts.Select(c => new[] { GetPath(c), GetId(c.Ancestor), GetId(c.Ours), GetId(c.Theirs) }).ToArray();
                 Assert.Equal(expected, ConflictData);
             }
         }

--- a/LibGit2Sharp/Index.cs
+++ b/LibGit2Sharp/Index.cs
@@ -21,6 +21,7 @@ namespace LibGit2Sharp
     {
         private readonly IndexSafeHandle handle;
         private readonly Repository repo;
+        private readonly ConflictCollection conflicts;
 
         /// <summary>
         ///   Needed for mocking purposes.
@@ -33,6 +34,8 @@ namespace LibGit2Sharp
             this.repo = repo;
 
             handle = Proxy.git_repository_index(repo.Handle);
+            conflicts = new ConflictCollection(repo);
+
             repo.RegisterForCleanup(handle);
         }
 
@@ -42,6 +45,7 @@ namespace LibGit2Sharp
 
             handle = Proxy.git_index_open(indexPath);
             Proxy.git_repository_set_index(repo.Handle, handle);
+            conflicts = new ConflictCollection(repo);
 
             repo.RegisterForCleanup(handle);
         }
@@ -526,6 +530,17 @@ namespace LibGit2Sharp
             }
 
             UpdatePhysicalIndex();
+        }
+
+        /// <summary>
+        ///  Gets the conflicts that exist.
+        /// </summary>
+        public virtual ConflictCollection Conflicts
+        {
+            get
+            {
+                return conflicts;
+            }
         }
 
         private void ReplaceIndexEntryWith(TreeEntryChanges treeEntryChanges)

--- a/LibGit2Sharp/Repository.cs
+++ b/LibGit2Sharp/Repository.cs
@@ -25,7 +25,6 @@ namespace LibGit2Sharp
         private readonly Lazy<Configuration> config;
         private readonly RepositorySafeHandle handle;
         private readonly Index index;
-        private readonly ConflictCollection conflicts;
         private readonly ReferenceCollection refs;
         private readonly TagCollection tags;
         private readonly StashCollection stashes;
@@ -99,7 +98,6 @@ namespace LibGit2Sharp
                 if (!isBare)
                 {
                     index = indexBuilder();
-                    conflicts = new ConflictCollection(this);
                 }
 
                 commits = new CommitLog(this);
@@ -233,16 +231,12 @@ namespace LibGit2Sharp
         /// <summary>
         ///  Gets the conflicts that exist.
         /// </summary>
+        [Obsolete("This property will be removed in the next release. Please use Index.Conflicts instead.")]
         public ConflictCollection Conflicts
         {
             get
             {
-                if (isBare)
-                {
-                    throw new BareRepositoryException("Conflicts are not available in a bare repository.");
-                }
-
-                return conflicts;
+                return Index.Conflicts;
             }
         }
 


### PR DESCRIPTION
Another small refactoring, suggested by @nulltoken and @yorah.

`Repository.Conflicts` is now tagged as obsolete and moved to `Repository.Index.Conflicts`.
