### PR TITLE
Diff Context Lines (--unified=...)

### DIFF
--- a/LibGit2Sharp.Tests/MetaFixture.cs
+++ b/LibGit2Sharp.Tests/MetaFixture.cs
@@ -12,13 +12,14 @@ namespace LibGit2Sharp.Tests
     {
         private static readonly Type[] excludedTypes = new[]
         {
+            typeof(CompareOptions),
             typeof(Credentials),
+            typeof(ExplicitPathsOptions),
             typeof(Filter),
             typeof(ObjectId),
             typeof(Repository),
             typeof(RepositoryOptions),
             typeof(Signature),
-            typeof(ExplicitPathsOptions),
         };
 
         // Related to https://github.com/libgit2/libgit2sharp/pull/251

--- a/LibGit2Sharp.Tests/Resources/expected/f8d44d7...7252fe2/full-0-3.diff
+++ b/LibGit2Sharp.Tests/Resources/expected/f8d44d7...7252fe2/full-0-3.diff
@@ -1,0 +1,32 @@
+diff --git a/my-name-does-not-feel-right.txt b/my-name-does-not-feel-right.txt
+deleted file mode 100644
+index e8953ab..0000000
+--- a/my-name-does-not-feel-right.txt
++++ /dev/null
+@@ -1,4 +0,0 @@
+-That's a terrible name!
+-I don't like it.
+-People look down at me and laugh. :-(
+-Really!!!!
+diff --git a/numbers.txt b/numbers.txt
+index 7909961..4e935b7 100644
+--- a/numbers.txt
++++ b/numbers.txt
+@@ -1,0 +2 @@
++2
+@@ -11 +12 @@
+-12
++11
+@@ -15,0 +17 @@
++16
+diff --git a/super-file.txt b/super-file.txt
+new file mode 100644
+index 0000000..16bdf1d
+--- /dev/null
++++ b/super-file.txt
+@@ -0,0 +1,5 @@
++That's a terrible name!
++I don't like it.
++People look down at me and laugh. :-(
++Really!!!!
++Yeah! Better!

--- a/LibGit2Sharp.Tests/Resources/expected/f8d44d7...7252fe2/full-0-4.diff
+++ b/LibGit2Sharp.Tests/Resources/expected/f8d44d7...7252fe2/full-0-4.diff
@@ -1,0 +1,35 @@
+diff --git a/my-name-does-not-feel-right.txt b/my-name-does-not-feel-right.txt
+deleted file mode 100644
+index e8953ab..0000000
+--- a/my-name-does-not-feel-right.txt
++++ /dev/null
+@@ -1,4 +0,0 @@
+-That's a terrible name!
+-I don't like it.
+-People look down at me and laugh. :-(
+-Really!!!!
+diff --git a/numbers.txt b/numbers.txt
+index 7909961..4e935b7 100644
+--- a/numbers.txt
++++ b/numbers.txt
+@@ -1,0 +2 @@
++2
+@@ -11,5 +12,6 @@
+-12
++11
+ 12
+ 13
+ 14
+ 15
++16
+diff --git a/super-file.txt b/super-file.txt
+new file mode 100644
+index 0000000..16bdf1d
+--- /dev/null
++++ b/super-file.txt
+@@ -0,0 +1,5 @@
++That's a terrible name!
++I don't like it.
++People look down at me and laugh. :-(
++Really!!!!
++Yeah! Better!

--- a/LibGit2Sharp.Tests/Resources/expected/f8d44d7...7252fe2/full-1-1.diff
+++ b/LibGit2Sharp.Tests/Resources/expected/f8d44d7...7252fe2/full-1-1.diff
@@ -1,0 +1,37 @@
+diff --git a/my-name-does-not-feel-right.txt b/my-name-does-not-feel-right.txt
+deleted file mode 100644
+index e8953ab..0000000
+--- a/my-name-does-not-feel-right.txt
++++ /dev/null
+@@ -1,4 +0,0 @@
+-That's a terrible name!
+-I don't like it.
+-People look down at me and laugh. :-(
+-Really!!!!
+diff --git a/numbers.txt b/numbers.txt
+index 7909961..4e935b7 100644
+--- a/numbers.txt
++++ b/numbers.txt
+@@ -1,2 +1,3 @@
+ 1
++2
+ 3
+@@ -10,3 +11,3 @@
+ 10
+-12
++11
+ 12
+@@ -15 +16,2 @@
+ 15
++16
+diff --git a/super-file.txt b/super-file.txt
+new file mode 100644
+index 0000000..16bdf1d
+--- /dev/null
++++ b/super-file.txt
+@@ -0,0 +1,5 @@
++That's a terrible name!
++I don't like it.
++People look down at me and laugh. :-(
++Really!!!!
++Yeah! Better!

--- a/LibGit2Sharp.Tests/Resources/expected/f8d44d7...7252fe2/full-1-2.diff
+++ b/LibGit2Sharp.Tests/Resources/expected/f8d44d7...7252fe2/full-1-2.diff
@@ -1,0 +1,38 @@
+diff --git a/my-name-does-not-feel-right.txt b/my-name-does-not-feel-right.txt
+deleted file mode 100644
+index e8953ab..0000000
+--- a/my-name-does-not-feel-right.txt
++++ /dev/null
+@@ -1,4 +0,0 @@
+-That's a terrible name!
+-I don't like it.
+-People look down at me and laugh. :-(
+-Really!!!!
+diff --git a/numbers.txt b/numbers.txt
+index 7909961..4e935b7 100644
+--- a/numbers.txt
++++ b/numbers.txt
+@@ -1,2 +1,3 @@
+ 1
++2
+ 3
+@@ -10,6 +11,7 @@
+ 10
+-12
++11
+ 12
+ 13
+ 14
+ 15
++16
+diff --git a/super-file.txt b/super-file.txt
+new file mode 100644
+index 0000000..16bdf1d
+--- /dev/null
++++ b/super-file.txt
+@@ -0,0 +1,5 @@
++That's a terrible name!
++I don't like it.
++People look down at me and laugh. :-(
++Really!!!!
++Yeah! Better!

--- a/LibGit2Sharp.Tests/Resources/expected/f8d44d7...7252fe2/full-2-4.diff
+++ b/LibGit2Sharp.Tests/Resources/expected/f8d44d7...7252fe2/full-2-4.diff
@@ -1,0 +1,40 @@
+diff --git a/my-name-does-not-feel-right.txt b/my-name-does-not-feel-right.txt
+deleted file mode 100644
+index e8953ab..0000000
+--- a/my-name-does-not-feel-right.txt
++++ /dev/null
+@@ -1,4 +0,0 @@
+-That's a terrible name!
+-I don't like it.
+-People look down at me and laugh. :-(
+-Really!!!!
+diff --git a/numbers.txt b/numbers.txt
+index 7909961..4e935b7 100644
+--- a/numbers.txt
++++ b/numbers.txt
+@@ -1,3 +1,4 @@
+ 1
++2
+ 3
+ 4
+@@ -9,7 +10,8 @@
+ 9
+ 10
+-12
++11
+ 12
+ 13
+ 14
+ 15
++16
+diff --git a/super-file.txt b/super-file.txt
+new file mode 100644
+index 0000000..16bdf1d
+--- /dev/null
++++ b/super-file.txt
+@@ -0,0 +1,5 @@
++That's a terrible name!
++I don't like it.
++People look down at me and laugh. :-(
++Really!!!!
++Yeah! Better!

--- a/LibGit2Sharp.Tests/Resources/expected/f8d44d7...7252fe2/full-2-5.diff
+++ b/LibGit2Sharp.Tests/Resources/expected/f8d44d7...7252fe2/full-2-5.diff
@@ -1,0 +1,44 @@
+diff --git a/my-name-does-not-feel-right.txt b/my-name-does-not-feel-right.txt
+deleted file mode 100644
+index e8953ab..0000000
+--- a/my-name-does-not-feel-right.txt
++++ /dev/null
+@@ -1,4 +0,0 @@
+-That's a terrible name!
+-I don't like it.
+-People look down at me and laugh. :-(
+-Really!!!!
+diff --git a/numbers.txt b/numbers.txt
+index 7909961..4e935b7 100644
+--- a/numbers.txt
++++ b/numbers.txt
+@@ -1,15 +1,17 @@
+ 1
++2
+ 3
+ 4
+ 5
+ 6
+ 7
+ 7.2
+ 8
+ 9
+ 10
+-12
++11
+ 12
+ 13
+ 14
+ 15
++16
+diff --git a/super-file.txt b/super-file.txt
+new file mode 100644
+index 0000000..16bdf1d
+--- /dev/null
++++ b/super-file.txt
+@@ -0,0 +1,5 @@
++That's a terrible name!
++I don't like it.
++People look down at me and laugh. :-(
++Really!!!!
++Yeah! Better!

--- a/LibGit2Sharp.Tests/Resources/expected/f8d44d7...7252fe2/full-3-2.diff
+++ b/LibGit2Sharp.Tests/Resources/expected/f8d44d7...7252fe2/full-3-2.diff
@@ -1,0 +1,42 @@
+diff --git a/my-name-does-not-feel-right.txt b/my-name-does-not-feel-right.txt
+deleted file mode 100644
+index e8953ab..0000000
+--- a/my-name-does-not-feel-right.txt
++++ /dev/null
+@@ -1,4 +0,0 @@
+-That's a terrible name!
+-I don't like it.
+-People look down at me and laugh. :-(
+-Really!!!!
+diff --git a/numbers.txt b/numbers.txt
+index 7909961..4e935b7 100644
+--- a/numbers.txt
++++ b/numbers.txt
+@@ -1,4 +1,5 @@
+ 1
++2
+ 3
+ 4
+ 5
+@@ -8,8 +9,9 @@
+ 8
+ 9
+ 10
+-12
++11
+ 12
+ 13
+ 14
+ 15
++16
+diff --git a/super-file.txt b/super-file.txt
+new file mode 100644
+index 0000000..16bdf1d
+--- /dev/null
++++ b/super-file.txt
+@@ -0,0 +1,5 @@
++That's a terrible name!
++I don't like it.
++People look down at me and laugh. :-(
++Really!!!!
++Yeah! Better!

--- a/LibGit2Sharp.Tests/Resources/expected/f8d44d7...7252fe2/full-3-3.diff
+++ b/LibGit2Sharp.Tests/Resources/expected/f8d44d7...7252fe2/full-3-3.diff
@@ -1,0 +1,44 @@
+diff --git a/my-name-does-not-feel-right.txt b/my-name-does-not-feel-right.txt
+deleted file mode 100644
+index e8953ab..0000000
+--- a/my-name-does-not-feel-right.txt
++++ /dev/null
+@@ -1,4 +0,0 @@
+-That's a terrible name!
+-I don't like it.
+-People look down at me and laugh. :-(
+-Really!!!!
+diff --git a/numbers.txt b/numbers.txt
+index 7909961..4e935b7 100644
+--- a/numbers.txt
++++ b/numbers.txt
+@@ -1,15 +1,17 @@
+ 1
++2
+ 3
+ 4
+ 5
+ 6
+ 7
+ 7.2
+ 8
+ 9
+ 10
+-12
++11
+ 12
+ 13
+ 14
+ 15
++16
+diff --git a/super-file.txt b/super-file.txt
+new file mode 100644
+index 0000000..16bdf1d
+--- /dev/null
++++ b/super-file.txt
+@@ -0,0 +1,5 @@
++That's a terrible name!
++I don't like it.
++People look down at me and laugh. :-(
++Really!!!!
++Yeah! Better!

--- a/LibGit2Sharp.Tests/Resources/expected/f8d44d7...7252fe2/full-4-0.diff
+++ b/LibGit2Sharp.Tests/Resources/expected/f8d44d7...7252fe2/full-4-0.diff
@@ -1,0 +1,44 @@
+diff --git a/my-name-does-not-feel-right.txt b/my-name-does-not-feel-right.txt
+deleted file mode 100644
+index e8953ab..0000000
+--- a/my-name-does-not-feel-right.txt
++++ /dev/null
+@@ -1,4 +0,0 @@
+-That's a terrible name!
+-I don't like it.
+-People look down at me and laugh. :-(
+-Really!!!!
+diff --git a/numbers.txt b/numbers.txt
+index 7909961..4e935b7 100644
+--- a/numbers.txt
++++ b/numbers.txt
+@@ -1,5 +1,6 @@
+ 1
++2
+ 3
+ 4
+ 5
+ 6
+@@ -7,9 +8,10 @@
+ 7.2
+ 8
+ 9
+ 10
+-12
++11
+ 12
+ 13
+ 14
+ 15
++16
+diff --git a/super-file.txt b/super-file.txt
+new file mode 100644
+index 0000000..16bdf1d
+--- /dev/null
++++ b/super-file.txt
+@@ -0,0 +1,5 @@
++That's a terrible name!
++I don't like it.
++People look down at me and laugh. :-(
++Really!!!!
++Yeah! Better!

--- a/LibGit2Sharp.Tests/Resources/expected/f8d44d7...7252fe2/full-4-1.diff
+++ b/LibGit2Sharp.Tests/Resources/expected/f8d44d7...7252fe2/full-4-1.diff
@@ -1,0 +1,44 @@
+diff --git a/my-name-does-not-feel-right.txt b/my-name-does-not-feel-right.txt
+deleted file mode 100644
+index e8953ab..0000000
+--- a/my-name-does-not-feel-right.txt
++++ /dev/null
+@@ -1,4 +0,0 @@
+-That's a terrible name!
+-I don't like it.
+-People look down at me and laugh. :-(
+-Really!!!!
+diff --git a/numbers.txt b/numbers.txt
+index 7909961..4e935b7 100644
+--- a/numbers.txt
++++ b/numbers.txt
+@@ -1,15 +1,17 @@
+ 1
++2
+ 3
+ 4
+ 5
+ 6
+ 7
+ 7.2
+ 8
+ 9
+ 10
+-12
++11
+ 12
+ 13
+ 14
+ 15
++16
+diff --git a/super-file.txt b/super-file.txt
+new file mode 100644
+index 0000000..16bdf1d
+--- /dev/null
++++ b/super-file.txt
+@@ -0,0 +1,5 @@
++That's a terrible name!
++I don't like it.
++People look down at me and laugh. :-(
++Really!!!!
++Yeah! Better!

--- a/LibGit2Sharp.Tests/Resources/expected/f8d44d7...7252fe2/numbers.txt-0-3.diff
+++ b/LibGit2Sharp.Tests/Resources/expected/f8d44d7...7252fe2/numbers.txt-0-3.diff
@@ -1,0 +1,11 @@
+diff --git a/numbers.txt b/numbers.txt
+index 7909961..4e935b7 100644
+--- a/numbers.txt
++++ b/numbers.txt
+@@ -1,0 +2 @@
++2
+@@ -11 +12 @@
+-12
++11
+@@ -15,0 +17 @@
++16

--- a/LibGit2Sharp.Tests/Resources/expected/f8d44d7...7252fe2/numbers.txt-0-4.diff
+++ b/LibGit2Sharp.Tests/Resources/expected/f8d44d7...7252fe2/numbers.txt-0-4.diff
@@ -1,0 +1,14 @@
+diff --git a/numbers.txt b/numbers.txt
+index 7909961..4e935b7 100644
+--- a/numbers.txt
++++ b/numbers.txt
+@@ -1,0 +2 @@
++2
+@@ -11,5 +12,6 @@
+-12
++11
+ 12
+ 13
+ 14
+ 15
++16

--- a/LibGit2Sharp.Tests/Resources/expected/f8d44d7...7252fe2/numbers.txt-1-1.diff
+++ b/LibGit2Sharp.Tests/Resources/expected/f8d44d7...7252fe2/numbers.txt-1-1.diff
@@ -1,0 +1,16 @@
+diff --git a/numbers.txt b/numbers.txt
+index 7909961..4e935b7 100644
+--- a/numbers.txt
++++ b/numbers.txt
+@@ -1,2 +1,3 @@
+ 1
++2
+ 3
+@@ -10,3 +11,3 @@
+ 10
+-12
++11
+ 12
+@@ -15 +16,2 @@
+ 15
++16

--- a/LibGit2Sharp.Tests/Resources/expected/f8d44d7...7252fe2/numbers.txt-1-2.diff
+++ b/LibGit2Sharp.Tests/Resources/expected/f8d44d7...7252fe2/numbers.txt-1-2.diff
@@ -1,0 +1,17 @@
+diff --git a/numbers.txt b/numbers.txt
+index 7909961..4e935b7 100644
+--- a/numbers.txt
++++ b/numbers.txt
+@@ -1,2 +1,3 @@
+ 1
++2
+ 3
+@@ -10,6 +11,7 @@
+ 10
+-12
++11
+ 12
+ 13
+ 14
+ 15
++16

--- a/LibGit2Sharp.Tests/Resources/expected/f8d44d7...7252fe2/numbers.txt-2-4.diff
+++ b/LibGit2Sharp.Tests/Resources/expected/f8d44d7...7252fe2/numbers.txt-2-4.diff
@@ -1,0 +1,19 @@
+diff --git a/numbers.txt b/numbers.txt
+index 7909961..4e935b7 100644
+--- a/numbers.txt
++++ b/numbers.txt
+@@ -1,3 +1,4 @@
+ 1
++2
+ 3
+ 4
+@@ -9,7 +10,8 @@
+ 9
+ 10
+-12
++11
+ 12
+ 13
+ 14
+ 15
++16

--- a/LibGit2Sharp.Tests/Resources/expected/f8d44d7...7252fe2/numbers.txt-2-5.diff
+++ b/LibGit2Sharp.Tests/Resources/expected/f8d44d7...7252fe2/numbers.txt-2-5.diff
@@ -1,0 +1,23 @@
+diff --git a/numbers.txt b/numbers.txt
+index 7909961..4e935b7 100644
+--- a/numbers.txt
++++ b/numbers.txt
+@@ -1,15 +1,17 @@
+ 1
++2
+ 3
+ 4
+ 5
+ 6
+ 7
+ 7.2
+ 8
+ 9
+ 10
+-12
++11
+ 12
+ 13
+ 14
+ 15
++16

--- a/LibGit2Sharp.Tests/Resources/expected/f8d44d7...7252fe2/numbers.txt-3-2.diff
+++ b/LibGit2Sharp.Tests/Resources/expected/f8d44d7...7252fe2/numbers.txt-3-2.diff
@@ -1,0 +1,21 @@
+diff --git a/numbers.txt b/numbers.txt
+index 7909961..4e935b7 100644
+--- a/numbers.txt
++++ b/numbers.txt
+@@ -1,4 +1,5 @@
+ 1
++2
+ 3
+ 4
+ 5
+@@ -8,8 +9,9 @@
+ 8
+ 9
+ 10
+-12
++11
+ 12
+ 13
+ 14
+ 15
++16

--- a/LibGit2Sharp.Tests/Resources/expected/f8d44d7...7252fe2/numbers.txt-3-3.diff
+++ b/LibGit2Sharp.Tests/Resources/expected/f8d44d7...7252fe2/numbers.txt-3-3.diff
@@ -1,0 +1,23 @@
+diff --git a/numbers.txt b/numbers.txt
+index 7909961..4e935b7 100644
+--- a/numbers.txt
++++ b/numbers.txt
+@@ -1,15 +1,17 @@
+ 1
++2
+ 3
+ 4
+ 5
+ 6
+ 7
+ 7.2
+ 8
+ 9
+ 10
+-12
++11
+ 12
+ 13
+ 14
+ 15
++16

--- a/LibGit2Sharp.Tests/Resources/expected/f8d44d7...7252fe2/numbers.txt-4-0.diff
+++ b/LibGit2Sharp.Tests/Resources/expected/f8d44d7...7252fe2/numbers.txt-4-0.diff
@@ -1,0 +1,23 @@
+diff --git a/numbers.txt b/numbers.txt
+index 7909961..4e935b7 100644
+--- a/numbers.txt
++++ b/numbers.txt
+@@ -1,5 +1,6 @@
+ 1
++2
+ 3
+ 4
+ 5
+ 6
+@@ -7,9 +8,10 @@
+ 7.2
+ 8
+ 9
+ 10
+-12
++11
+ 12
+ 13
+ 14
+ 15
++16

--- a/LibGit2Sharp.Tests/Resources/expected/f8d44d7...7252fe2/numbers.txt-4-1.diff
+++ b/LibGit2Sharp.Tests/Resources/expected/f8d44d7...7252fe2/numbers.txt-4-1.diff
@@ -1,0 +1,23 @@
+diff --git a/numbers.txt b/numbers.txt
+index 7909961..4e935b7 100644
+--- a/numbers.txt
++++ b/numbers.txt
+@@ -1,15 +1,17 @@
+ 1
++2
+ 3
+ 4
+ 5
+ 6
+ 7
+ 7.2
+ 8
+ 9
+ 10
+-12
++11
+ 12
+ 13
+ 14
+ 15
++16

--- a/LibGit2Sharp.Tests/TestHelpers/BaseFixture.cs
+++ b/LibGit2Sharp.Tests/TestHelpers/BaseFixture.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -220,6 +221,16 @@ namespace LibGit2Sharp.Tests.TestHelpers
             File.AppendAllText(filePath, content ?? string.Empty, Encoding.ASCII);
 
             return file;
+        }
+
+        protected string Expected(string filename)
+        {
+            return File.ReadAllText(Path.Combine(ResourcesDirectory.FullName, "expected/" + filename));
+        }
+
+        protected string Expected(string filenameFormat, params object[] args)
+        {
+            return Expected(string.Format(CultureInfo.InvariantCulture, filenameFormat, args));
         }
     }
 }

--- a/LibGit2Sharp/CompareOptions.cs
+++ b/LibGit2Sharp/CompareOptions.cs
@@ -1,0 +1,29 @@
+namespace LibGit2Sharp
+{
+    /// <summary>
+    ///   Options to define file comparison behavior.
+    /// </summary>
+    public class CompareOptions
+    {
+        /// <summary>
+        ///   Initializes a new instance of the <see cref = "CompareOptions" /> class.
+        /// </summary>
+        public CompareOptions()
+        {
+            ContextLines = 3;
+            InterhunkLines = 0;
+        }
+
+        /// <summary>
+        ///   The number of unchanged lines that define the boundary of a hunk (and to display before and after).
+        ///   (Default = 3)
+        /// </summary>
+        public int ContextLines { get; set; }
+
+        /// <summary>
+        ///   The maximum number of unchanged lines between hunk boundaries before the hunks will be merged into a one.
+        ///   (Default = 0)
+        /// </summary>
+        public int InterhunkLines { get; set; }
+    }
+}

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -67,6 +67,7 @@
     <Compile Include="Changes.cs" />
     <Compile Include="CheckoutCallbacks.cs" />
     <Compile Include="CheckoutOptions.cs" />
+    <Compile Include="CompareOptions.cs" />
     <Compile Include="ObjectType.cs" />
     <Compile Include="ReferenceExtensions.cs" />
     <Compile Include="Conflict.cs" />


### PR DESCRIPTION
http://stackoverflow.com/questions/16402124/equivalent-to-git-diff-unified-0-with-libgit2sharp

Currently 3 lines of context is hard-coded: https://github.com/libgit2/libgit2sharp/blob/6a2d99ecdf35288df88c0e6fe8985969042d82a6/LibGit2Sharp/Diff.cs#L27. That should be configurable.
