### PR TITLE
Filter branch

### DIFF
--- a/LibGit2Sharp.Tests/FilterBranchFixture.cs
+++ b/LibGit2Sharp.Tests/FilterBranchFixture.cs
@@ -1,0 +1,375 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using LibGit2Sharp.Tests.TestHelpers;
+using Xunit;
+
+namespace LibGit2Sharp.Tests
+{
+    public class FilterBranchFixture : BaseFixture
+    {
+        private readonly Repository repo;
+
+        public FilterBranchFixture()
+        {
+            string path = CloneBareTestRepo();
+            repo = new Repository(path);
+        }
+
+        public override void Dispose()
+        {
+            repo.Dispose();
+        }
+
+        [Fact]
+        public void CanRewriteHistoryWithoutChangingCommitMetadata()
+        {
+            var originalRefs = repo.Refs.ToList().OrderBy(r => r.CanonicalName);
+            var commits = repo.Commits.QueryBy(new Filter { Since = repo.Refs }).ToArray();
+
+            // Noop header rewriter
+            repo.Refs.RewriteHistory(commits, commitHeaderRewriter: CommitRewriteInfo.From);
+
+            Assert.Equal(originalRefs, repo.Refs.ToList().OrderBy(r => r.CanonicalName));
+            Assert.Equal(commits, repo.Commits.QueryBy(new Filter { Since = repo.Refs }).ToArray());
+        }
+
+        [Fact]
+        public void CanRewriteHistoryWithoutChangingTrees()
+        {
+            var originalRefs = repo.Refs.ToList().OrderBy(r => r.CanonicalName);
+            var commits = repo.Commits.QueryBy(new Filter { Since = repo.Refs }).ToArray();
+
+            // Noop tree rewriter
+            repo.Refs.RewriteHistory(commits, commitTreeRewriter: TreeDefinition.From);
+
+            Assert.Equal(originalRefs, repo.Refs.ToList().OrderBy(r => r.CanonicalName));
+            Assert.Equal(commits, repo.Commits.QueryBy(new Filter { Since = repo.Refs }).ToArray());
+        }
+
+        [Fact]
+        public void CanRewriteAuthorOfCommits()
+        {
+            var commits = repo.Commits.QueryBy(new Filter { Since = repo.Refs }).ToArray();
+            repo.Refs.RewriteHistory(
+                commits,
+                commitHeaderRewriter: c => CommitRewriteInfo.From(c, author: new Signature("Ben Straub", "me@example.com", c.Author.When)));
+
+            var nonBackedUpRefs = repo.Refs.Where(x => !x.CanonicalName.StartsWith("refs/original"));
+            Assert.Empty(repo.Commits.QueryBy(new Filter { Since = nonBackedUpRefs })
+                             .Where(c => c.Author.Name != "Ben Straub"));
+        }
+
+        [Fact]
+        public void CanRewriteAuthorOfCommitsOnlyBeingPointedAtByTags()
+        {
+            var commit = repo.ObjectDatabase.CreateCommit(
+                "I'm a lonesome commit", DummySignature, DummySignature,
+                repo.Head.Tip.Tree, Enumerable.Empty<Commit>());
+
+            repo.Tags.Add("so-lonely", commit);
+
+            repo.Tags.Add("so-lonely-but-annotated", commit, DummySignature,
+                "Yeah, baby! I'm going to be rewritten as well");
+
+            repo.Refs.RewriteHistory(
+                new[] { commit },
+                commitHeaderRewriter: c => CommitRewriteInfo.From(c, message: "Bam!"));
+
+            var lightweightTag = repo.Tags["so-lonely"];
+            Assert.Equal("Bam!\n", ((Commit)lightweightTag.Target).Message);
+
+            var annotatedTag = repo.Tags["so-lonely-but-annotated"];
+            Assert.Equal("Bam!\n", ((Commit)annotatedTag.Target).Message);
+        }
+
+        [Fact]
+        public void CanRewriteTrees()
+        {
+            repo.Refs.RewriteHistory(repo.Head.Commits, commitTreeRewriter: c =>
+                {
+                    var td = TreeDefinition.From(c);
+                    td.Remove("README");
+                    return td;
+                });
+
+            Assert.True(repo.Head.Commits.All(c => c["README"] == null));
+        }
+
+        // * 41bc8c6  (packed)
+        // |
+        // * 5001298            <----- rewrite this commit message
+        [Fact]
+        public void OnlyRewriteSelectedCommits()
+        {
+            var commit = repo.Branches["packed"].Tip;
+            var parent = commit.Parents.Single();
+
+            Assert.True(parent.Sha.StartsWith("5001298"));
+            Assert.NotEqual(DummySignature, commit.Author);
+            Assert.NotEqual(DummySignature, parent.Author);
+
+            repo.Refs.RewriteHistory(
+                new[] { parent },
+                commitHeaderRewriter: c => CommitRewriteInfo.From(c, author: DummySignature));
+
+            commit = repo.Branches["packed"].Tip;
+            parent = commit.Parents.Single();
+
+            Assert.False(parent.Sha.StartsWith("5001298"));
+            Assert.NotEqual(DummySignature, commit.Author);
+            Assert.Equal(DummySignature, parent.Author);
+        }
+
+        [Fact]
+        public void CanCustomizeTheNamespaceOfBackedUpRefs()
+        {
+            repo.Refs.RewriteHistory(repo.Head.Commits, c => CommitRewriteInfo.From(c, message: ""));
+            Assert.NotEmpty(repo.Refs.Where(x => x.CanonicalName.StartsWith("refs/original")));
+
+            Assert.Empty(repo.Refs.Where(x => x.CanonicalName.StartsWith("refs/rewritten")));
+
+            repo.Refs.RewriteHistory(repo.Head.Commits,
+                                     commitHeaderRewriter: c => CommitRewriteInfo.From(c, message: "abc"),
+                                     backupRefsNamespace: "refs/rewritten");
+
+            Assert.NotEmpty(repo.Refs.Where(x => x.CanonicalName.StartsWith("refs/rewritten")));
+        }
+
+        [Fact]
+        public void RefRewritingRollsBackOnFailure()
+        {
+            IList<Reference> origRefs = repo.Refs.OrderBy(r => r.CanonicalName).ToArray();
+
+            const string backupNamespace = "refs/original/";
+
+            Assert.Throws<Exception>(
+                () =>
+                repo.Refs.RewriteHistory(
+                    new[] { repo.Lookup<Commit>("6dcf9bf7541ee10456529833502442f385010c3d") },
+                    c => CommitRewriteInfo.From(c, message: ""),
+                    backupRefsNamespace: backupNamespace,
+                    tagNameRewriter: (n, isA, t) =>
+                                            {
+                                                var newRef = repo.Refs.FromGlob(backupNamespace + "*").FirstOrDefault();
+
+                                                if (newRef == null)
+                                                    return n;
+
+                                                // At least one of the refs have been rewritten
+                                                // Let's make sure it's been updated to a new target
+                                                var oldName = newRef.CanonicalName.Replace(backupNamespace, "refs/");
+                                                Assert.NotEqual(origRefs.Single(r => r.CanonicalName == oldName), newRef);
+
+                                                // Violently interrupt the process
+                                                throw new Exception("BREAK");
+                                            }
+                    ));
+
+            // Ensure all the refs have been restored to their original targets
+            var newRefs = repo.Refs.OrderBy(r => r.CanonicalName).ToArray();
+            Assert.Equal(newRefs, origRefs);
+        }
+
+        // This test should rewrite br2, but not packed-test:
+        // *   a4a7dce (br2) Merge branch 'master' into br2
+        // |\
+        // | * 9fd738e a fourth commit
+        // | * 4a202b3 (packed-test) a third commit
+        // * | c47800c branch commit one                <----- rewrite this one
+        // |/
+        // * 5b5b025 another commit
+        // * 8496071 testing
+        [Fact]
+        public void DoesNotRewriteRefsThatDontChange()
+        {
+            repo.Refs.RewriteHistory(new[] { repo.Lookup<Commit>("c47800c") },
+                                c => CommitRewriteInfo.From(c, message: "abc"));
+
+            Assert.Null(repo.Refs["refs/original/heads/packed-test"]);
+            Assert.NotNull(repo.Refs["refs/original/heads/br2"]);
+
+            // Ensure br2 is still a merge commit
+            var parents = repo.Branches["br2"].Tip.Parents.ToList();
+            Assert.Equal(2, parents.Count());
+            Assert.NotEmpty(parents.Where(c => c.Sha.StartsWith("9fd738e")));
+            Assert.Equal("abc\n", parents.Single(c => !c.Sha.StartsWith("9fd738e")).Message);
+        }
+
+        [Fact]
+        public void CanNotOverWriteBackedUpReferences()
+        {
+            Func<Commit, CommitRewriteInfo> headerRewriter = c => CommitRewriteInfo.From(c, message: "abc");
+            Assert.Empty(repo.Refs.FromGlob("refs/original/*"));
+
+            repo.Refs.RewriteHistory(repo.Head.Commits, commitHeaderRewriter: headerRewriter);
+            var originalRefs = repo.Refs.FromGlob("refs/original/*").OrderBy(r => r.CanonicalName).ToArray();
+            Assert.NotEmpty(originalRefs);
+
+            headerRewriter = c => CommitRewriteInfo.From(c, message: "def");
+
+            Assert.Throws<InvalidOperationException>(() =>
+                repo.Refs.RewriteHistory(repo.Head.Commits, commitHeaderRewriter: headerRewriter));
+            Assert.Equal("abc\n", repo.Head.Tip.Message);
+
+            var newOriginalRefs = repo.Refs.FromGlob("refs/original/*").OrderBy(r => r.CanonicalName).ToArray();
+            Assert.Equal(originalRefs, newOriginalRefs);
+
+            Assert.Empty(repo.Refs.Where(x => x.CanonicalName.StartsWith("refs/original/original/")));
+        }
+
+        [Fact]
+        public void CanNotOverWriteAnExistingReference()
+        {
+            var commits = repo.Commits.QueryBy(new Filter { Since = repo.Refs }).ToArray();
+
+            Assert.Throws<NameConflictException>(() => repo.Refs.RewriteHistory(commits, tagNameRewriter: (n, b, t) => "test"));
+
+            Assert.Equal(0, repo.Refs.FromGlob("refs/original/*").Count());
+        }
+
+        // Graft the orphan "test" branch to the tip of "packed"
+        //
+        // Before:
+        // * e90810b  (test, lw, e90810b, test)
+        // |
+        // * 6dcf9bf
+        //     <------------------ note: no connection
+        // * 41bc8c6  (packed)
+        // |
+        // * 5001298
+        //
+        // ... and after:
+        //
+        // * f558880  (test, lw, e90810b, test)
+        // |
+        // * 0c25efa
+        // |   <------------------ add this link
+        // * 41bc8c6  (packed)
+        // |
+        // * 5001298
+        [Fact]
+        public void CanRewriteParents()
+        {
+            var commitToRewrite = repo.Lookup<Commit>("6dcf9bf");
+            var newParent = repo.Lookup<Commit>("41bc8c6");
+            bool hasBeenCalled = false;
+
+            repo.Refs.RewriteHistory(new[] { commitToRewrite }, commitParentsRewriter: originalParents =>
+            {
+                Assert.False(hasBeenCalled);
+                Assert.Empty(originalParents);
+                hasBeenCalled = true;
+                return new[] { newParent };
+            });
+
+            Assert.Contains(newParent, repo.Lookup<Commit>("refs/heads/test~").Parents);
+            Assert.True(hasBeenCalled);
+        }
+
+        [Fact]
+        public void WritesCorrectReflogMessagesForSimpleRewrites()
+        {
+            repo.Refs.RewriteHistory(repo.Head.Commits, c => CommitRewriteInfo.From(c, message: ""));
+
+            Assert.Equal("filter-branch: rewrite", repo.Refs.Log(repo.Refs["refs/heads/master"]).First().Message);
+            Assert.Equal("filter-branch: backup", repo.Refs.Log(repo.Refs["refs/original/heads/master"]).First().Message);
+        }
+
+        [Fact]
+        public void CanProvideNewNamesForTags()
+        {
+            GitObject lwTarget = repo.Tags["lw"].Target;
+            GitObject e908Target = repo.Tags["e90810b"].Target;
+            GitObject testTarget = repo.Tags["test"].Target;
+
+            repo.Refs.RewriteHistory(repo.Commits.QueryBy(new Filter { Since = repo.Refs["refs/heads/test"] }),
+                                     c => CommitRewriteInfo.From(c, message: ""),
+                                     tagNameRewriter: (oldName, isAnnotated, o) => oldName + "_new");
+
+            Assert.NotEqual(lwTarget, repo.Tags["lw_new"].Target);
+            Assert.NotEqual(e908Target, repo.Tags["e90810b_new"].Target);
+            Assert.NotEqual(testTarget, repo.Tags["test_new"].Target);
+        }
+
+        [Fact(Skip = "Rewriting of symbolic references is not supported yet")]
+        public void CanRewriteSymbolicRefsPointingToTags()
+        {
+            const string tagRefName = "refs/tags/test";
+
+            repo.Refs.Add("refs/tags/one_tracker", tagRefName);
+            repo.Refs.Add("refs/tags/another_tracker", tagRefName);
+            repo.Refs.Add("refs/attic/dusty_tracker", "refs/tags/another_tracker");
+
+            repo.Refs.RewriteHistory(new[] { repo.Lookup<Commit>("e90810b8df") },
+                                     c => CommitRewriteInfo.From(c, author: DummySignature),
+                                     tagNameRewriter: (oldName, isAnnotated, o) => oldName + "_new");
+
+            // Ensure the initial tags don't exist anymore...
+            Assert.Null(repo.Refs["refs/tags/one_tracker"]);
+            Assert.Null(repo.Refs["refs/tags/another_tracker"]);
+
+            // ...and have been backed up.
+            Assert.Equal(tagRefName, repo.Refs["refs/original/tags/one_tracker"].TargetIdentifier);
+            Assert.Equal(tagRefName, repo.Refs["refs/original/tags/another_tracker"].TargetIdentifier);
+
+            // Ensure the renamed symref tags points to the renamed target
+            Assert.Equal(tagRefName + "_new", repo.Refs["refs/tags/one_tracker_new"].TargetIdentifier);
+            Assert.Equal(tagRefName + "_new", repo.Refs["refs/tags/another_tracker_new"].TargetIdentifier);
+
+            // Ensure that the non tag symref points to a renamed target...
+            Assert.Equal("refs/tags/another_tracker_new", repo.Refs["refs/attic/dusty_tracker"].TargetIdentifier);
+
+            // ...and has been backed up as well.
+            Assert.Equal("refs/tags/another_tracker", repo.Refs["refs/original/attic/dusty_tracker"].TargetIdentifier);
+        }
+
+        [Fact]
+        public void HandlesNameRewritingOfChainedTags()
+        {
+            // Add a lightweight tag (A) that points to tag annotation (B) that points to another tag annotation (C),
+            // which points to a commit
+            var theCommit = repo.Lookup<Commit>("6dcf9bf");
+            var annotationC = repo.ObjectDatabase.CreateTag("annotationC", theCommit, DummySignature, "");
+            var annotationB = repo.ObjectDatabase.CreateTag("annotationB", annotationC, DummySignature, "");
+            var tagA = repo.Tags.Add("lightweightA", annotationB);
+
+            // Rewrite the commit, renaming the tag
+            repo.Refs.RewriteHistory(new[] { repo.Lookup<Commit>("6dcf9bf") },
+                                     c => CommitRewriteInfo.From(c, message: "Rewrote"),
+                                     tagNameRewriter:
+                                         (oldName, isAnnoted, newTarget) =>
+                                         isAnnoted ? oldName + "_ann" : oldName + "_lw");
+
+
+            // Verify the rewritten tag-annotation chain
+            var newTagA = repo.Tags["lightweightA_lw"];
+            Assert.NotNull(newTagA);
+            Assert.NotEqual(newTagA, tagA);
+            Assert.True(newTagA.IsAnnotated);
+
+            var newAnnotationB = newTagA.Annotation;
+            Assert.NotNull(newAnnotationB);
+            Assert.NotEqual(newAnnotationB, annotationB);
+            Assert.Equal("annotationB_ann", newAnnotationB.Name);
+
+            var newAnnotationC = newAnnotationB.Target as TagAnnotation;
+            Assert.NotNull(newAnnotationC);
+            Assert.NotEqual(newAnnotationC, annotationC);
+            Assert.Equal("annotationC_ann", newAnnotationC.Name);
+
+            var newCommit = newAnnotationC.Target as Commit;
+            Assert.NotNull(newCommit);
+            Assert.NotEqual(newCommit, theCommit);
+            Assert.Equal("Rewrote\n", newCommit.Message);
+
+            // Ensure the original tag doesn't exist anymore
+            Assert.Null(repo.Tags["lightweightA"]);
+
+            // ...but it's been backed up
+            Reference backedUpTag = repo.Refs["refs/original/tags/lightweightA"];
+            Assert.NotNull(backedUpTag);
+            Assert.Equal(annotationB, backedUpTag.ResolveToDirectReference().Target);
+        }
+    }
+}

--- a/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
+++ b/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
@@ -59,6 +59,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CheckoutFixture.cs" />
+    <Compile Include="FilterBranchFixture.cs" />
     <Compile Include="RemoveFixture.cs" />
     <Compile Include="RemoteFixture.cs" />
     <Compile Include="PushFixture.cs" />

--- a/LibGit2Sharp.Tests/MetaFixture.cs
+++ b/LibGit2Sharp.Tests/MetaFixture.cs
@@ -12,6 +12,7 @@ namespace LibGit2Sharp.Tests
     {
         private static readonly Type[] excludedTypes = new[]
         {
+            typeof(CommitRewriteInfo),
             typeof(CompareOptions),
             typeof(Credentials),
             typeof(ExplicitPathsOptions),

--- a/LibGit2Sharp.Tests/TestHelpers/BaseFixture.cs
+++ b/LibGit2Sharp.Tests/TestHelpers/BaseFixture.cs
@@ -141,7 +141,7 @@ namespace LibGit2Sharp.Tests.TestHelpers
             directories.Add(directoryPath);
         }
 
-        public void Dispose()
+        public virtual void Dispose()
         {
 #if LEAKS
             GC.Collect();

--- a/LibGit2Sharp/CommitRewriteInfo.cs
+++ b/LibGit2Sharp/CommitRewriteInfo.cs
@@ -1,0 +1,61 @@
+namespace LibGit2Sharp
+{
+    /// <summary>
+    ///   Commit metadata when rewriting history
+    /// </summary>
+    public class CommitRewriteInfo
+    {
+        /// <summary>
+        ///   The author to be used for the new commit
+        /// </summary>
+        public Signature Author { get; set; }
+
+        /// <summary>
+        ///   The committer to be used for the new commit
+        /// </summary>
+        public Signature Committer { get; set; }
+
+        /// <summary>
+        ///   The message to be used for the new commit
+        /// </summary>
+        public string Message { get; set; }
+
+        /// <summary>
+        ///   Build a <see cref="CommitRewriteInfo"/> from the <see cref="Commit"/> passed in
+        /// </summary>
+        /// <param name="commit">The <see cref="Commit"/> whose information is to be copied</param>
+        /// <returns>A new <see cref="CommitRewriteInfo"/> object that matches the info for the <paramref name="commit"/>.</returns>
+        public static CommitRewriteInfo From(Commit commit)
+        {
+            return new CommitRewriteInfo
+                {
+                    Author = commit.Author,
+                    Committer = commit.Committer,
+                    Message = commit.Message
+                };
+        }
+
+        /// <summary>
+        ///   Build a <see cref="CommitRewriteInfo"/> from the <see cref="Commit"/> passed in,
+        ///   optionally overriding some of its properties 
+        /// </summary>
+        /// <param name="commit">The <see cref="Commit"/> whose information is to be copied</param>
+        /// <param name="author">Optional override for the author</param>
+        /// <param name="committer">Optional override for the committer</param>
+        /// <param name="message">Optional override for the message</param>
+        /// <returns>A new <see cref="CommitRewriteInfo"/> object that matches the info for the
+        /// <paramref name="commit"/> with the optional parameters replaced..</returns>
+        public static CommitRewriteInfo From(Commit commit,
+                                             Signature author = null,
+                                             Signature committer = null,
+                                             string message = null)
+        {
+            var cri = From(commit);
+            cri.Author = author ?? cri.Author;
+            cri.Committer = committer ?? cri.Committer;
+            cri.Message = message ?? cri.Message;
+
+            return cri;
+        }
+    }
+}

--- a/LibGit2Sharp/Core/HistoryRewriter.cs
+++ b/LibGit2Sharp/Core/HistoryRewriter.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace LibGit2Sharp.Core
+{
+    internal class HistoryRewriter
+    {
+        private readonly Repository repo;
+
+        private readonly HashSet<Commit> targetedCommits;
+        private readonly Dictionary<ObjectId, ObjectId> shaMap = new Dictionary<ObjectId, ObjectId>();
+
+        private readonly Func<Commit, CommitRewriteInfo> headerRewriter;
+        private readonly Func<Commit, TreeDefinition> treeRewriter;
+        private readonly string backupRefsNamespace;
+        private readonly Func<IEnumerable<Commit>, IEnumerable<Commit>> parentsRewriter;
+        private readonly Func<String, bool, GitObject, string> tagNameRewriter;
+
+        public HistoryRewriter(
+            Repository repo,
+            IEnumerable<Commit> commitsToRewrite,
+            Func<Commit, CommitRewriteInfo> headerRewriter,
+            Func<Commit, TreeDefinition> treeRewriter,
+            Func<IEnumerable<Commit>, IEnumerable<Commit>> parentsRewriter,
+            Func<String, bool, GitObject, string> tagNameRewriter,
+            string backupRefsNamespace)
+        {
+            this.repo = repo;
+            targetedCommits = new HashSet<Commit>(commitsToRewrite);
+
+            this.headerRewriter = headerRewriter ?? CommitRewriteInfo.From;
+            this.treeRewriter = treeRewriter;
+            this.tagNameRewriter = tagNameRewriter;
+            this.parentsRewriter = parentsRewriter ?? (ps => ps);
+
+            this.backupRefsNamespace = backupRefsNamespace;
+        }
+
+        public void Execute()
+        {
+            // Find out which refs lead to at least one the commits
+            var refsToRewrite = repo.Refs.ReachableFrom(targetedCommits).ToList();
+
+            var filter = new Filter
+                             {
+                                 Since = refsToRewrite,
+                                 SortBy = GitSortOptions.Reverse | GitSortOptions.Topological
+                             };
+
+            var commits = repo.Commits.QueryBy(filter);
+            foreach (var commit in commits)
+            {
+                RewriteCommit(commit);
+            }
+
+            var rollbackActions = new Queue<Action>();
+
+            try
+            {
+                // Ordering matters. In the case of `A -> B -> commit`, we need to make sure B is rewritten
+                // before A.
+                foreach (var reference in refsToRewrite.OrderBy(ReferenceDepth))
+                {
+                    // TODO: Check how rewriting of notes actually behaves
+
+                    var dref = reference as DirectReference;
+                    if (dref == null)
+                    {
+                        // TODO: Handle a cornercase where a symbolic reference
+                        //       points to a Tag which name has been rewritten
+                        continue;
+                    }
+
+                    var newTarget = RewriteTarget(dref.Target);
+
+                    RewriteReference(dref, newTarget, backupRefsNamespace, rollbackActions);
+                }
+            }
+            catch (Exception)
+            {
+                foreach (var action in rollbackActions)
+                {
+                    action();
+                }
+
+                throw;
+            }
+        }
+
+        private void RewriteReference(DirectReference oldRef, ObjectId newTarget, string backupNamePrefix, Queue<Action> rollbackActions)
+        {
+            string newRefName = oldRef.CanonicalName;
+            if (oldRef.IsTag() && tagNameRewriter != null)
+            {
+                newRefName = Reference.TagPrefix +
+                             tagNameRewriter(oldRef.CanonicalName.Substring(Reference.TagPrefix.Length), false, oldRef.Target);
+            }
+
+            if (oldRef.Target.Id == newTarget && oldRef.CanonicalName == newRefName)
+            {
+                // The reference isn't rewritten
+                return;
+            }
+
+            string backupName = backupNamePrefix + oldRef.CanonicalName.Substring("refs/".Length);
+
+            if (repo.Refs.Resolve<Reference>(backupName) != null)
+            {
+                throw new InvalidOperationException(
+                    String.Format("Can't back up reference '{0}' - '{1}' already exists", oldRef.CanonicalName, backupName));
+            }
+
+            repo.Refs.Add(backupName, oldRef.TargetIdentifier, false, "filter-branch: backup");
+            rollbackActions.Enqueue(() => repo.Refs.Remove(backupName));
+
+            Reference newRef = repo.Refs.UpdateTarget(oldRef, newTarget, "filter-branch: rewrite");
+            rollbackActions.Enqueue(() => repo.Refs.UpdateTarget(oldRef, oldRef.Target.Id, "filter-branch: abort"));
+
+            if (newRef.CanonicalName == newRefName)
+            {
+                return;
+            }
+
+            repo.Refs.Move(newRef, newRefName);
+            rollbackActions.Enqueue(() => repo.Refs.Move(newRef, oldRef.CanonicalName));
+        }
+
+        private void RewriteCommit(Commit commit)
+        {
+            var newHeader = CommitRewriteInfo.From(commit);
+            var newTree = commit.Tree;
+
+            // Find the new parents
+            var newParents = commit.Parents
+                .Select(oldParent =>
+                        shaMap.ContainsKey(oldParent.Id)
+                            ? shaMap[oldParent.Id]
+                            : oldParent.Id)
+                .Select(id => repo.Lookup<Commit>(id));
+
+            if (targetedCommits.Contains(commit))
+            {
+                // Get the new commit header
+                newHeader = headerRewriter(commit);
+
+                if (treeRewriter != null)
+                {
+                    // Get the new commit tree
+                    var newTreeDefinition = treeRewriter(commit);
+                    newTree = repo.ObjectDatabase.CreateTree(newTreeDefinition);
+                }
+
+                // Retrieve new parents
+                newParents = parentsRewriter(newParents);
+            }
+
+            // Create the new commit
+            var newCommit = repo.ObjectDatabase.CreateCommit(newHeader.Message, newHeader.Author,
+                                                             newHeader.Committer, newTree,
+                                                             newParents);
+
+            // Record the rewrite
+            shaMap[commit.Id] = newCommit.Id;
+        }
+
+        private ObjectId RewriteTarget(GitObject oldTarget)
+        {
+            // Has this target already been rewritten?
+            if (shaMap.ContainsKey(oldTarget.Id))
+            {
+                return shaMap[oldTarget.Id];
+            }
+
+            Debug.Assert((oldTarget as Commit) == null);
+
+            var annotation = oldTarget as TagAnnotation;
+            if (annotation == null)
+            {
+                //TODO: Probably a Tree or a Blob. This is not covered by any test
+                return oldTarget.Id;
+            }
+
+            // Recursively rewrite annotations if necessary
+            ObjectId newTargetId = RewriteTarget(annotation.Target);
+
+            var newTarget = repo.Lookup(newTargetId);
+
+            string newName = annotation.Name;
+
+            if (tagNameRewriter != null)
+            {
+                newName = tagNameRewriter(annotation.Name, true, annotation.Target);
+            }
+
+            var newAnnotation = repo.ObjectDatabase.CreateTag(newName, newTarget, annotation.Tagger,
+                                                              annotation.Message);
+            shaMap[annotation.Id] = newAnnotation.Id;
+            return newAnnotation.Id;
+        }
+
+        private int ReferenceDepth(Reference reference)
+        {
+            var dref = reference as DirectReference;
+            return dref == null
+                       ? 1 + ReferenceDepth(((SymbolicReference)reference).Target)
+                       : 1;
+        }
+    }
+}

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -68,7 +68,9 @@
     <Compile Include="CheckoutCallbacks.cs" />
     <Compile Include="CheckoutOptions.cs" />
     <Compile Include="CompareOptions.cs" />
+    <Compile Include="Core\HistoryRewriter.cs" />
     <Compile Include="Core\NativeDllName.cs" />
+    <Compile Include="CommitRewriteInfo.cs" />
     <Compile Include="ObjectType.cs" />
     <Compile Include="Core\UniqueIdentifier.cs" />
     <Compile Include="ReferenceExtensions.cs" />


### PR DESCRIPTION
This adds an idiomatic c-sharpy api for doing filter-branch-like operations. This works without ever touching the index or the working directory, so it should be wicked fast.
- [x] Header rewriting (author, message, etc)
- [x] Tree rewriting using `TreeDefinition`
- [x] Tag rewriting (like `--tag-filter`)
- [x] Parent-commit munging (like `--parent-filter`)
- [x] Back up original refs to `refs/original`
- [x] Name review
- [x] XML documenation
- [x] Squash

The API looks like this:

``` csharp
repo.Refs.RewriteHistory(
    // A collection of commits that should be rewritten
    repo.Head.Commits,

    // A function that returns a `TreeDefinition` for the new commit
    commitTreeRewriter: c =>
        {
            var td = TreeDefinition.From(c);
            td.Remove("README");
            return td;
        },

    // A function that returns header information to be used for the new commit
    commitHeaderRewriter: c =>
        {
            var ch = CommitRewriteInfo.From(c);
            ch.Message += "\n\nCleaned-by: The Cleaner";
            return ch;
        });
```
