### PR TITLE
Add type details to FilePathMarshaler error

### DIFF
--- a/LibGit2Sharp/Core/FilePathMarshaler.cs
+++ b/LibGit2Sharp/Core/FilePathMarshaler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Runtime.InteropServices;
 
 namespace LibGit2Sharp.Core
@@ -83,7 +84,14 @@ namespace LibGit2Sharp.Core
 
             if (null == filePath)
             {
-                throw new MarshalDirectiveException("FilePathMarshaler must be used on a FilePath.");
+                var expectedType = typeof(FilePath);
+                var actualType = managedObj.GetType();
+
+                throw new MarshalDirectiveException(
+                    string.Format(CultureInfo.InvariantCulture,
+                    "FilePathMarshaler must be used on a FilePath. Expected '{0}' from '{1}'; received '{2}' from '{3}'.",
+                    expectedType.FullName, expectedType.Assembly.Location,
+                    actualType.FullName, actualType.Assembly.Location));
             }
 
             return FromManaged(filePath);


### PR DESCRIPTION
To help diagnose #241...

Example error message if I replace a `Utf8Marshaler`:

```
    System.Runtime.InteropServices.MarshalDirectiveException : FilePathMarshaler must be used on a FilePath. Expected 'LibGit2Sharp.Core.FilePath' from 'C:\Dev\GitHub\libgit2sharp\LibGit2Sharp.Tests\bin\Debug\LibGit2Sharp.dll'; received 'System.String' from 'C:\Windows\Microsoft.NET\Framework\v2.0.50727\mscorlib.dll'.
    Core\FilePathMarshaler.cs(90,0): at LibGit2Sharp.Core.FilePathMarshaler.MarshalManagedToNative(Object managedObj)
```
