### PR TITLE
Less-strongly-typed FilePathMarshaler

### DIFF
--- a/LibGit2Sharp/Core/FilePathMarshaler.cs
+++ b/LibGit2Sharp/Core/FilePathMarshaler.cs
@@ -89,6 +89,16 @@ namespace LibGit2Sharp.Core
             var expectedType = typeof(FilePath);
             var actualType = managedObj.GetType();
 
+            if (actualType.FullName == expectedType.FullName)
+            {
+                var posixProperty = actualType.GetProperty("Posix");
+                if (posixProperty != null && posixProperty.PropertyType == typeof(string))
+                {
+                    var reflectedFilePath = (string)posixProperty.GetValue(managedObj, null);
+                    return FromManaged(reflectedFilePath);
+                }
+            }
+
             throw new MarshalDirectiveException(
                 string.Format(CultureInfo.InvariantCulture,
                               "FilePathMarshaler must be used on a FilePath. Expected '{0}' from '{1}'; received '{2}' from '{3}'.",
@@ -110,7 +120,12 @@ namespace LibGit2Sharp.Core
                 return IntPtr.Zero;
             }
 
-            return Utf8Marshaler.FromManaged(filePath.Posix);
+            return FromManaged(filePath.Posix);
+        }
+
+        private static IntPtr FromManaged(string posixFilePath)
+        {
+            return Utf8Marshaler.FromManaged(posixFilePath);
         }
 
         public static FilePath FromNative(IntPtr pNativeData)


### PR DESCRIPTION
As [proposed](https://github.com/libgit2/libgit2sharp/pull/430#issuecomment-18381466) on #430, to fix #241.

> If `managedObj as FilePath` fails, we could fallback to use reflection to grab a Posix property and fail if there isn't one.
