### PR TITLE
Rename ObjectDatabase.CreateTag into ObjectDatabase.CreateTagAnnotation

### DIFF
--- a/LibGit2Sharp.Tests/FilterBranchFixture.cs
+++ b/LibGit2Sharp.Tests/FilterBranchFixture.cs
@@ -330,8 +330,8 @@ namespace LibGit2Sharp.Tests
             // Add a lightweight tag (A) that points to tag annotation (B) that points to another tag annotation (C),
             // which points to a commit
             var theCommit = repo.Lookup<Commit>("6dcf9bf");
-            var annotationC = repo.ObjectDatabase.CreateTag("annotationC", theCommit, DummySignature, "");
-            var annotationB = repo.ObjectDatabase.CreateTag("annotationB", annotationC, DummySignature, "");
+            var annotationC = repo.ObjectDatabase.CreateTagAnnotation("annotationC", theCommit, DummySignature, "");
+            var annotationB = repo.ObjectDatabase.CreateTagAnnotation("annotationB", annotationC, DummySignature, "");
             var tagA = repo.Tags.Add("lightweightA", annotationB);
 
             // Rewrite the commit, renaming the tag

--- a/LibGit2Sharp.Tests/ObjectDatabaseFixture.cs
+++ b/LibGit2Sharp.Tests/ObjectDatabaseFixture.cs
@@ -348,7 +348,7 @@ namespace LibGit2Sharp.Tests
                 var blob = repo.Head.Tip["README"].Target as Blob;
                 Assert.NotNull(blob);
 
-                TagAnnotation tag = repo.ObjectDatabase.CreateTag(
+                TagAnnotation tag = repo.ObjectDatabase.CreateTagAnnotation(
                     "nice_blob",
                     blob,
                     DummySignature,

--- a/LibGit2Sharp/Core/HistoryRewriter.cs
+++ b/LibGit2Sharp/Core/HistoryRewriter.cs
@@ -194,7 +194,7 @@ namespace LibGit2Sharp.Core
                 newName = tagNameRewriter(annotation.Name, true, annotation.Target);
             }
 
-            var newAnnotation = repo.ObjectDatabase.CreateTag(newName, newTarget, annotation.Tagger,
+            var newAnnotation = repo.ObjectDatabase.CreateTagAnnotation(newName, newTarget, annotation.Tagger,
                                                               annotation.Message);
             shaMap[annotation.Id] = newAnnotation.Id;
             return newAnnotation.Id;

--- a/LibGit2Sharp/ObjectDatabase.cs
+++ b/LibGit2Sharp/ObjectDatabase.cs
@@ -167,8 +167,22 @@ namespace LibGit2Sharp
         /// <param name="target">The <see cref="GitObject"/> being pointed at.</param>
         /// <param name="tagger">The tagger.</param>
         /// <param name="message">The message.</param>
-        /// <returns>The created <see cref = "Commit"/>.</returns>
+        /// <returns>The created <see cref = "TagAnnotation"/>.</returns>
+        [Obsolete("This method will be removed in the next release. Please use CreateTagAnnontation(string, GitObject, Signature, string) instead.")]
         public virtual TagAnnotation CreateTag(string name, GitObject target, Signature tagger, string message)
+        {
+            return CreateTagAnnotation(name, target, tagger, message);
+        }
+
+        /// <summary>
+        ///   Inserts a <see cref = "TagAnnotation"/> into the object database, pointing to a specific <see cref = "GitObject"/>.
+        /// </summary>
+        /// <param name="name">The name.</param>
+        /// <param name="target">The <see cref="GitObject"/> being pointed at.</param>
+        /// <param name="tagger">The tagger.</param>
+        /// <param name="message">The message.</param>
+        /// <returns>The created <see cref = "TagAnnotation"/>.</returns>
+        public virtual TagAnnotation CreateTagAnnotation(string name, GitObject target, Signature tagger, string message)
         {
             string prettifiedMessage = Proxy.git_message_prettify(message);
 


### PR DESCRIPTION
Fixes #450
- [ ] Create new method `CreateTagAnnotation()`
- [ ] Decorate the old `CreateTag()` method with the `[Obsolete]` attribute
