### PR TITLE
Allow ObjectDatabase.CreateBlob() to limit the number of bytes to consume

### DIFF
--- a/LibGit2Sharp.Tests/ObjectDatabaseFixture.cs
+++ b/LibGit2Sharp.Tests/ObjectDatabaseFixture.cs
@@ -104,6 +104,35 @@ namespace LibGit2Sharp.Tests
             }
         }
 
+        [Theory]
+        [InlineData(16, 32)]
+        [InlineData(34, 8)]
+        [InlineData(7584, 5879)]
+        [InlineData(7854, 1247)]
+        [InlineData(7854, 9785)]
+        [InlineData(8192, 4096)]
+        [InlineData(8192, 4095)]
+        [InlineData(8192, 4097)]
+        public void CanCreateABlobFromAStreamWithANumberOfBytesToConsume(int contentSize, int numberOfBytesToConsume)
+        {
+            string path = CloneBareTestRepo();
+
+            var sb = new StringBuilder();
+            for (int i = 0; i < contentSize; i++)
+            {
+                sb.Append(i % 10);
+            }
+
+            using (var repo = new Repository(path))
+            {
+                using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(sb.ToString())))
+                {
+                    Blob blob = repo.ObjectDatabase.CreateBlob(stream, numberOfBytesToConsume: numberOfBytesToConsume);
+                    Assert.Equal(Math.Min(numberOfBytesToConsume, contentSize), blob.Size);
+                }
+            }
+        }
+
         [Fact]
         public void CreatingABlobFromANonReadableStreamThrows()
         {


### PR DESCRIPTION
Fixes #447
- [x] Update the `CreateBlob()` overload with the following signature:
  `public virtual Blob CreateBlob(Stream stream, string hintpath = null, int? numberOfBytesToConsume = null);`
- [x] Cover the new behavior with some tests
