### PR TITLE
Create a new repo.Checkout() overload which accepts a Commit object

### DIFF
--- a/LibGit2Sharp/IRepository.cs
+++ b/LibGit2Sharp/IRepository.cs
@@ -72,7 +72,11 @@ namespace LibGit2Sharp
         SubmoduleCollection Submodules { get; }
 
         /// <summary>
-        ///   Checkout the specified <see cref = "Branch" />.
+        ///   Checkout the commit pointed at by the tip of the specified <see cref = "Branch" />.
+        ///   <para>
+        ///     If this commit is the current tip of the branch as it exists in the repository, the HEAD
+        ///     will point to this branch. Otherwise, the HEAD will be detached, pointing at the commit sha.
+        ///   </para>
         /// </summary>
         /// <param name="branch">The <see cref = "Branch" /> to check out. </param>
         /// <param name="checkoutOptions"><see cref = "CheckoutOptions" /> controlling checkout behavior.</param>
@@ -88,6 +92,18 @@ namespace LibGit2Sharp
         /// <param name="onCheckoutProgress">Callback method to report checkout progress updates through.</param>
         /// <returns>The new HEAD.</returns>
         Branch Checkout(string committishOrBranchSpec, CheckoutOptions checkoutOptions, CheckoutProgressHandler onCheckoutProgress);
+
+        /// <summary>
+        ///   Checkout the specified <see cref = "Commit" />.
+        ///   <para>
+        ///     Will detach the HEAD and make it point to this commit sha.
+        ///   </para>
+        /// </summary>
+        /// <param name="commit">The <see cref = "Commit" /> to check out. </param>
+        /// <param name="checkoutOptions"><see cref = "CheckoutOptions" /> controlling checkout behavior.</param>
+        /// <param name="onCheckoutProgress"><see cref = "CheckoutProgressHandler" /> that checkout progress is reported through.</param>
+        /// <returns>The <see cref = "Branch" /> that was checked out.</returns>
+        Branch Checkout(Commit commit, CheckoutOptions checkoutOptions, CheckoutProgressHandler onCheckoutProgress);
 
         /// <summary>
         ///   Try to lookup an object by its <see cref = "ObjectId" />. If no matching object is found, null will be returned.

--- a/LibGit2Sharp/RepositoryExtensions.cs
+++ b/LibGit2Sharp/RepositoryExtensions.cs
@@ -259,9 +259,12 @@ namespace LibGit2Sharp
             return repository.Checkout(commitOrBranchSpec, CheckoutOptions.None, null);
         }
 
-
         /// <summary>
-        ///   Checkout the specified <see cref = "Branch" />.
+        ///   Checkout the commit pointed at by the tip of the specified <see cref = "Branch" />.
+        ///   <para>
+        ///     If this commit is the current tip of the branch as it exists in the repository, the HEAD
+        ///     will point to this branch. Otherwise, the HEAD will be detached, pointing at the commit sha.
+        ///   </para>
         /// </summary>
         /// <param name="repository">The <see cref = "Repository" /> being worked with.</param>
         /// <param name="branch">The <see cref = "Branch" /> to check out.</param>
@@ -269,6 +272,20 @@ namespace LibGit2Sharp
         public static Branch Checkout(this IRepository repository, Branch branch)
         {
             return repository.Checkout(branch, CheckoutOptions.None, null);
+        }
+
+        /// <summary>
+        ///   Checkout the specified <see cref = "LibGit2Sharp.Commit" />.
+        ///   <para>
+        ///     Will detach the HEAD and make it point to this commit sha.
+        ///   </para>
+        /// </summary>
+        /// <param name="repository">The <see cref = "Repository" /> being worked with.</param>
+        /// <param name="commit">The <see cref = "LibGit2Sharp.Commit" /> to check out.</param>
+        /// <returns>The <see cref = "Branch" /> that was checked out.</returns>
+        public static Branch Checkout(this IRepository repository, Commit commit)
+        {
+            return repository.Checkout(commit, CheckoutOptions.None, null);
         }
 
         internal static string BuildRelativePathFrom(this Repository repo, string path)


### PR DESCRIPTION
Fixes #445
- [x] Add `Branch Checkout(Commit commit, CheckoutOptions checkoutOptions, CheckoutProgressHandler onCheckoutProgress);` prototype to `IRepository`
- [x] Make `Repository` implement this
- [x] Refactor the existing `Repository.Checkout()` methods to delegate to the same internal method
- [x] Create new method `public static Branch Checkout(this IRepository repository, Commit commit)` in `RepositoryExtensions`
- [x] Modify `CheckoutFixture.CanCheckoutAnArbitraryCommit()` to leverage this and actually test the processing of either the commit or the commitPointer

Differences from the initial issue:
- I modified the `CheckoutFixture.CanCheckoutAnArbitraryCommit()`, and not the `CheckoutFixture.CheckoutFromDetachedHead()`
- Due to differences in reflog expectations when passing a committish or a branch spec, the new `Checkout()` methods actually delegate to the private `CheckoutTree`
