### PR TITLE
Ensure libgit2 calling convention

### DIFF
--- a/UpdateLibgit2ToSha.ps1
+++ b/UpdateLibgit2ToSha.ps1
@@ -173,7 +173,7 @@ namespace LibGit2Sharp.Core
 {
 	internal static class NativeDllName
 	{
-		public const string Name = "$binaryFilename.dll";
+		public const string Name = "$binaryFilename";
 	}
 }
 "@


### PR DESCRIPTION
Ensure that libgit2 is always built with the `__stdcall` convention. As the great and wise @xpaulbettsx [mentioned](https://github.com/libgit2/libgit2/pull/356):

> [U]sing cdecl means that it is impossible to use functions that use callbacks from .NET code, since there is no way to marshal a delegate => function pointer with the cdecl calling convention.

So we definitely want stdcall.
