### PR TITLE
Non-extensible Sealed

### DIFF
--- a/LibGit2Sharp.Tests/MetaFixture.cs
+++ b/LibGit2Sharp.Tests/MetaFixture.cs
@@ -10,20 +10,6 @@ namespace LibGit2Sharp.Tests
 {
     public class MetaFixture
     {
-        private static readonly Type[] excludedTypes = new[]
-        {
-            typeof(CheckoutOptions),
-            typeof(CommitFilter),
-            typeof(CommitRewriteInfo),
-            typeof(CompareOptions),
-            typeof(Credentials),
-            typeof(ExplicitPathsOptions),
-            typeof(ObjectId),
-            typeof(Repository),
-            typeof(RepositoryOptions),
-            typeof(Signature),
-        };
-
         // Related to https://github.com/libgit2/libgit2sharp/pull/251
         [Fact]
         public void TypesInLibGit2DecoratedWithDebuggerDisplayMustFollowTheStandardImplPattern()
@@ -71,7 +57,7 @@ namespace LibGit2Sharp.Tests
             var nonTestableTypes = new Dictionary<Type, IEnumerable<string>>();
 
             IEnumerable<Type> libGit2SharpTypes = Assembly.GetAssembly(typeof(Repository)).GetExportedTypes()
-                .Where(t => !excludedTypes.Contains(t) && t.Namespace == typeof(Repository).Namespace && !t.IsSubclassOf(typeof(Delegate)));
+                .Where(t => !t.IsSealed && t.Namespace == typeof(Repository).Namespace);
 
             foreach (Type type in libGit2SharpTypes)
             {

--- a/LibGit2Sharp/CheckoutOptions.cs
+++ b/LibGit2Sharp/CheckoutOptions.cs
@@ -5,7 +5,7 @@ namespace LibGit2Sharp
     /// <summary>
     /// Collection of parameters controlling Checkout behavior.
     /// </summary>
-    public class CheckoutOptions
+    public sealed class CheckoutOptions
     {
         /// <summary>
         /// Options controlling checkout behavior.

--- a/LibGit2Sharp/CommitFilter.cs
+++ b/LibGit2Sharp/CommitFilter.cs
@@ -7,7 +7,7 @@ namespace LibGit2Sharp
     /// <summary>
     /// Criterias used to filter out and order the commits of the repository when querying its history.
     /// </summary>
-    public class CommitFilter
+    public sealed class CommitFilter
     {
         /// <summary>
         /// Initializes a new instance of <see cref="CommitFilter"/>.

--- a/LibGit2Sharp/CommitRewriteInfo.cs
+++ b/LibGit2Sharp/CommitRewriteInfo.cs
@@ -3,7 +3,7 @@ namespace LibGit2Sharp
     /// <summary>
     /// Commit metadata when rewriting history
     /// </summary>
-    public class CommitRewriteInfo
+    public sealed class CommitRewriteInfo
     {
         /// <summary>
         /// The author to be used for the new commit

--- a/LibGit2Sharp/CompareOptions.cs
+++ b/LibGit2Sharp/CompareOptions.cs
@@ -3,7 +3,7 @@ namespace LibGit2Sharp
     /// <summary>
     /// Options to define file comparison behavior.
     /// </summary>
-    public class CompareOptions
+    public sealed class CompareOptions
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CompareOptions"/> class.

--- a/LibGit2Sharp/Credentials.cs
+++ b/LibGit2Sharp/Credentials.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Class that holds credentials for remote repository access.
     /// </summary>
-    public class Credentials
+    public sealed class Credentials
     {
         /// <summary>
         /// Username for username/password authentication (as in HTTP basic auth).

--- a/LibGit2Sharp/ExplicitPathsOptions.cs
+++ b/LibGit2Sharp/ExplicitPathsOptions.cs
@@ -10,7 +10,7 @@ namespace LibGit2Sharp
     ///   explicit paths, and NOT pathspecs containing globs.
     /// </para>
     /// </summary>
-    public class ExplicitPathsOptions
+    public sealed class ExplicitPathsOptions
     {
         /// <summary>
         /// Associated paths will be treated as explicit paths.

--- a/LibGit2Sharp/ObjectId.cs
+++ b/LibGit2Sharp/ObjectId.cs
@@ -8,7 +8,7 @@ namespace LibGit2Sharp
     /// <summary>
     /// Uniquely identifies a <see cref="GitObject"/>.
     /// </summary>
-    public class ObjectId : IEquatable<ObjectId>
+    public sealed class ObjectId : IEquatable<ObjectId>
     {
         private readonly GitOid oid;
         private const int rawSize = 20;
@@ -17,7 +17,7 @@ namespace LibGit2Sharp
         /// <summary>
         /// Size of the string-based representation of a SHA-1.
         /// </summary>
-        protected const int HexSize = rawSize * 2;
+        private const int HexSize = rawSize * 2;
 
         private const string hexDigits = "0123456789abcdef";
         private static readonly byte[] reverseHexDigits = BuildReverseHexDigits();
@@ -85,7 +85,7 @@ namespace LibGit2Sharp
         /// <summary>
         /// Gets the sha.
         /// </summary>
-        public virtual string Sha
+        public string Sha
         {
             get { return sha; }
         }

--- a/LibGit2Sharp/Repository.cs
+++ b/LibGit2Sharp/Repository.cs
@@ -17,7 +17,7 @@ namespace LibGit2Sharp
     /// A Repository is the primary interface into a git repository
     /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
-    public class Repository : IRepository
+    public sealed class Repository : IRepository
     {
         private readonly bool isBare;
         private readonly BranchCollection branches;
@@ -347,7 +347,7 @@ namespace LibGit2Sharp
         /// <summary>
         /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
         /// </summary>
-        protected virtual void Dispose(bool disposing)
+        private void Dispose(bool disposing)
         {
             CleanupDisposableDependencies();
         }
@@ -960,7 +960,7 @@ namespace LibGit2Sharp
         /// <summary>
         /// Clean the working tree by removing files that are not under version control.
         /// </summary>
-        public virtual void RemoveUntrackedFiles()
+        public void RemoveUntrackedFiles()
         {
             var options = new GitCheckoutOpts
             {
@@ -1036,7 +1036,7 @@ namespace LibGit2Sharp
         /// <summary>
         /// Gets the references to the tips that are currently being merged.
         /// </summary>
-        public virtual IEnumerable<MergeHead> MergeHeads
+        public IEnumerable<MergeHead> MergeHeads
         {
             get
             {

--- a/LibGit2Sharp/RepositoryOptions.cs
+++ b/LibGit2Sharp/RepositoryOptions.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Provides optional additional information to the Repository to be opened.
     /// </summary>
-    public class RepositoryOptions
+    public sealed class RepositoryOptions
     {
         /// <summary>
         /// Overrides the probed location of the working directory of a standard repository,

--- a/LibGit2Sharp/Signature.cs
+++ b/LibGit2Sharp/Signature.cs
@@ -8,7 +8,7 @@ namespace LibGit2Sharp
     /// <summary>
     /// A signature
     /// </summary>
-    public class Signature : IEquatable<Signature>
+    public sealed class Signature : IEquatable<Signature>
     {
         private readonly DateTimeOffset when;
         private readonly string name;


### PR DESCRIPTION
It occurs to me that our explicit list of types excepted from the virtual member rule could be eliminated by just marking such types as `sealed` instead. The only type for which this might be debated is `Repository`, but my thought is that any reason to subclass it could be handled by a proxy that implements `IRepository`.

Also, an `[Obsolete]` purge.
