### PR TITLE
Ensure Mono build fails when there are errors

### DIFF
--- a/build.libgit2sharp.sh
+++ b/build.libgit2sharp.sh
@@ -19,5 +19,9 @@ cd ..
 echo $LD_LIBRARY_PATH
 xbuild CI-build.msbuild /t:Deploy
 
+EXIT_CODE=$?
+
 LD_LIBRARY_PATH=$PREVIOUS_LD
 export LD_LIBRARY_PATH
+
+exit $EXIT_CODE


### PR DESCRIPTION
This **[Travis build log](https://travis-ci.org/nulltoken/libgit2sharp/builds/9279673)** shows there are failing tests, but the error isn't propagated up the call chain. As such, the build is considered to be passing, which is very **NOT** expected.

```
    /home/travis/build/nulltoken/libgit2sharp/CI-build.msbuild: error : LibGit2Sharp.Tests.CheckoutFixture.CanCheckoutPath(originalBranch: "I-do-numbers", checkoutFrom: "diff-test-cases", path: "numbers.txt", expectedStatus: Staged): LibGit2Sharp.LibGit2SharpException : No valid git object identified by 'I-do-numbers' exists in the repository.
    /home/travis/build/nulltoken/libgit2sharp/CI-build.msbuild: error :   at LibGit2Sharp.Core.Ensure.GitObjectIsNotNull (LibGit2Sharp.GitObject gitObject, System.String identifier) [0x00000] in <filename unknown>:0 
  at LibGit2Sharp.Repository.Checkout (System.String committishOrBranchSpec, CheckoutModifiers checkoutModifiers, LibGit2Sharp.Handlers.CheckoutProgressHandler onCheckoutProgress, LibGit2Sharp.CheckoutNotificationOptions checkoutNotifications) [0x00000] in <filename unknown>:0 
  at LibGit2Sharp.RepositoryExtensions.Checkout (IRepository repository, System.String commitOrBranchSpec) [0x00000] in <filename unknown>:0 
  at LibGit2Sharp.Tests.CheckoutFixture.CanCheckoutPath (System.String originalBranch, System.String checkoutFrom, System.String path, FileStatus expectedStatus) [0x00000] in <filename unknown>:0 
  at (wrapper managed-to-native) System.Reflection.MonoMethod:InternalInvoke (System.Reflection.MonoMethod,object,object[],System.Exception&)
  at System.Reflection.MonoMethod.Invoke (System.Object obj, BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00000] in <filename unknown>:0 
     67 Warning(s)
     2 Error(s)
Time Elapsed 00:00:40.8949590
The command "./build.libgit2sharp.sh" exited with 0.
Done. Your build exited with 0.
```
