### PR TITLE
Skip building diff patch while doing stage/reset

### DIFF
--- a/LibGit2Sharp/CompareOptions.cs
+++ b/LibGit2Sharp/CompareOptions.cs
@@ -12,6 +12,7 @@ namespace LibGit2Sharp
         {
             ContextLines = 3;
             InterhunkLines = 0;
+            SkipPatchBuilding = false;
         }
 
         /// <summary>
@@ -25,5 +26,11 @@ namespace LibGit2Sharp
         /// (Default = 0)
         /// </summary>
         public int InterhunkLines { get; set; }
+
+        /// <summary>
+        /// Flag to skip patch building. May be used if only file name and status required.
+        /// (Default = false)
+        /// </summary>
+        internal bool SkipPatchBuilding { get; set; }
     }
 }

--- a/LibGit2Sharp/Diff.cs
+++ b/LibGit2Sharp/Diff.cs
@@ -270,7 +270,8 @@ namespace LibGit2Sharp
                     DispatchUnmatchedPaths(explicitPathsOptions, filePaths, matchedPaths);
                 }
 
-                return new TreeChanges(diffList);
+                bool skipPatchBuilding = (compareOptions != null) && compareOptions.SkipPatchBuilding;
+                return new TreeChanges(diffList, skipPatchBuilding);
             }
         }
 

--- a/LibGit2Sharp/Index.cs
+++ b/LibGit2Sharp/Index.cs
@@ -156,7 +156,8 @@ namespace LibGit2Sharp
         {
             Ensure.ArgumentNotNull(paths, "paths");
 
-            TreeChanges changes = repo.Diff.Compare(DiffModifiers.IncludeUntracked | DiffModifiers.IncludeIgnored, paths, explicitPathsOptions);
+            var compareOptions = new CompareOptions { SkipPatchBuilding = true };
+            TreeChanges changes = repo.Diff.Compare(DiffModifiers.IncludeUntracked | DiffModifiers.IncludeIgnored, paths, explicitPathsOptions, compareOptions);
 
             foreach (var treeEntryChanges in changes)
             {
@@ -213,7 +214,8 @@ namespace LibGit2Sharp
 
             if (repo.Info.IsHeadOrphaned)
             {
-                TreeChanges changes = repo.Diff.Compare(null, DiffTargets.Index, paths, explicitPathsOptions);
+                var compareOptions = new CompareOptions { SkipPatchBuilding = true };
+                TreeChanges changes = repo.Diff.Compare(null, DiffTargets.Index, paths, explicitPathsOptions, compareOptions);
 
                 Reset(changes);
             }
@@ -348,7 +350,8 @@ namespace LibGit2Sharp
         public virtual void Remove(IEnumerable<string> paths, bool removeFromWorkingDirectory = true, ExplicitPathsOptions explicitPathsOptions = null)
         {
             var pathsList = paths.ToList();
-            TreeChanges changes = repo.Diff.Compare(DiffModifiers.IncludeUnmodified | DiffModifiers.IncludeUntracked, pathsList, explicitPathsOptions);
+            var compareOptions = new CompareOptions { SkipPatchBuilding = true };
+            TreeChanges changes = repo.Diff.Compare(DiffModifiers.IncludeUnmodified | DiffModifiers.IncludeUntracked, pathsList, explicitPathsOptions, compareOptions);
 
             var pathsTodelete = pathsList.Where(p => Directory.Exists(Path.Combine(repo.Info.WorkingDirectory, p))).ToList();
 

--- a/LibGit2Sharp/TreeChanges.cs
+++ b/LibGit2Sharp/TreeChanges.cs
@@ -48,10 +48,14 @@ namespace LibGit2Sharp
         protected TreeChanges()
         { }
 
-        internal TreeChanges(DiffListSafeHandle diff)
+        internal TreeChanges(DiffListSafeHandle diff, bool skipPatchBuilding = false)
         {
             Proxy.git_diff_foreach(diff, FileCallback, null, DataCallback);
-            Proxy.git_diff_print_patch(diff, PrintCallBack);
+
+            if (!skipPatchBuilding)
+            {
+                Proxy.git_diff_print_patch(diff, PrintCallBack);
+            }
         }
 
         private int DataCallback(GitDiffDelta delta, GitDiffRange range, GitDiffLineOrigin lineOrigin, IntPtr content, UIntPtr contentLen, IntPtr payload)


### PR DESCRIPTION
TreeChanges constructor always builds diff string in TreeChanges.fullPatchBuilder (and additionally adds diff string in per-file TreeChanges.changes dictionary).

This behavior leads to wasting time and memory in Index.Stage and Index.Reset methods. In our particular case, it fails with System.OutOfMemoryException in attempt to build full patch for a big initial commit.

This change adds a flag to CompareOptions to be able to skip building patch where it is not required.
