### PR TITLE
Update CheckoutPaths method to handle null or empty paths parameter

### DIFF
--- a/LibGit2Sharp.Tests/CheckoutFixture.cs
+++ b/LibGit2Sharp.Tests/CheckoutFixture.cs
@@ -966,6 +966,27 @@ namespace LibGit2Sharp.Tests
             }
         }
 
+        [Fact]
+        public void CannotCheckoutPathsWithEmptyOrNullPathArgument()
+        {
+            string repoPath = CloneStandardTestRepo();
+
+            using (var repo = new Repository(repoPath))
+            {
+                // Set the working directory to the current head
+                ResetAndCleanWorkingDirectory(repo);
+                Assert.False(repo.Index.RetrieveStatus().IsDirty);
+
+                // Passing null 'paths' parameter should throw
+                Assert.Throws(typeof(ArgumentNullException),
+                    () => repo.CheckoutPaths("i-do-numbers", null));
+
+                // Passing empty list should do nothing
+                repo.CheckoutPaths("i-do-numbers", Enumerable.Empty<string>());
+                Assert.False(repo.Index.RetrieveStatus().IsDirty);
+            }
+        }
+
         [Theory]
         [InlineData("new.txt")]
         [InlineData("1.txt")]

--- a/LibGit2Sharp/Repository.cs
+++ b/LibGit2Sharp/Repository.cs
@@ -838,11 +838,18 @@ namespace LibGit2Sharp
         /// </para>
         /// </summary>
         /// <param name = "committishOrBranchSpec">A revparse spec for the commit or branch to checkout paths from.</param>
-        /// <param name="paths">The paths to checkout.</param>
+        /// <param name="paths">The paths to checkout. Will throw if null is passed in. Passing an empty enumeration results in nothing being checked out.</param>
         /// <param name="checkoutOptions">Collection of parameters controlling checkout behavior.</param>
         public void CheckoutPaths(string committishOrBranchSpec, IEnumerable<string> paths, CheckoutOptions checkoutOptions = null)
         {
             Ensure.ArgumentNotNullOrEmptyString(committishOrBranchSpec, "committishOrBranchSpec");
+            Ensure.ArgumentNotNull(paths, "paths");
+
+            // If there are no paths, then there is nothing to do.
+            if (!paths.Any())
+            {
+                return;
+            }
 
             Commit commit = LookupCommit(committishOrBranchSpec);
             CheckoutTree(commit.Tree, paths.ToList(), checkoutOptions ?? new CheckoutOptions());  


### PR DESCRIPTION
Fixes an issue where passing an empty enumeration to CheckoutPaths results in the entire commit being checked out - which is not how I expect the method to operate. Instead, this method will now ensure that the path parameter is not null and if the path parameter is an empty list the method will return without checking out any paths.
