### PR TITLE
Teach repo.ObjectDatabase to enumerate GitObjects

### DIFF
--- a/LibGit2Sharp.Tests/ObjectDatabaseFixture.cs
+++ b/LibGit2Sharp.Tests/ObjectDatabaseFixture.cs
@@ -400,5 +400,22 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(tag, fetched);
             }
         }
+
+        [Fact]
+        public void CanEnumerateTheGitObjectsFromBareRepository()
+        {
+            using (var repo = new Repository(BareTestRepoPath))
+            {
+                int count = 0;
+
+                foreach (var obj in repo.ObjectDatabase)
+                {
+                    Assert.NotNull(obj);
+                    count++;
+                }
+
+                Assert.True(count >= 1683);
+            }
+        }
     }
 }

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -579,6 +579,16 @@ namespace LibGit2Sharp.Core
         [DllImport(libgit2)]
         internal static extern int git_odb_exists(ObjectDatabaseSafeHandle odb, ref GitOid id);
 
+        internal delegate int git_odb_foreach_cb(
+            IntPtr id,
+            IntPtr payload);
+
+        [DllImport(libgit2)]
+        internal static extern int git_odb_foreach(
+            ObjectDatabaseSafeHandle odb,
+            git_odb_foreach_cb cb,
+            IntPtr payload);
+
         [DllImport(libgit2)]
         internal static extern void git_odb_free(IntPtr odb);
 

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -1045,6 +1046,18 @@ namespace LibGit2Sharp.Core
             Ensure.BooleanResult(res);
 
             return (res == 1);
+        }
+
+        public static ICollection<TResult> git_odb_foreach<TResult>(
+            ObjectDatabaseSafeHandle odb,
+            Func<IntPtr, TResult> resultSelector)
+        {
+            return git_foreach(
+                resultSelector,
+                c => NativeMethods.git_odb_foreach(
+                    odb,
+                    (x, p) => c(x, p),
+                    IntPtr.Zero));
         }
 
         public static void git_odb_free(IntPtr odb)


### PR DESCRIPTION
Should help introspecting the content of the object database.
- The oids are eagerly loaded into a `List<>` as I haven't found a proper way to stream them from libgit2.
- The GitObjects _should_ be yielded one after another, without adding too much memory pressure.

**Warning:** This hasn't been tested against a huge repository (think Linux.git, for instance).
