### PR TITLE
Cannot get remotes when one of remotes has empty URL

### DIFF
--- a/LibGit2Sharp.Tests/RemoteFixture.cs
+++ b/LibGit2Sharp.Tests/RemoteFixture.cs
@@ -40,7 +40,7 @@ namespace LibGit2Sharp.Tests
                     count++;
                 }
 
-                Assert.Equal(1, count);
+                Assert.Equal(2, count);
             }
         }
 
@@ -153,6 +153,17 @@ namespace LibGit2Sharp.Tests
             using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Equal(expectedResult, repo.Network.Remotes.IsValidName(refname));
+            }
+        }
+
+        [Fact]
+        public void DoesNotThrowWhenARemoteHasNoUrlSet()
+        {
+            using (var repo = new Repository(StandardTestRepoPath))
+            {
+                var noUrlRemote = repo.Network.Remotes["no_url"];
+                Assert.NotNull(noUrlRemote);
+                Assert.Equal(string.Empty, noUrlRemote.Url);
             }
         }
     }

--- a/LibGit2Sharp.Tests/Resources/testrepo_wd/dot_git/config
+++ b/LibGit2Sharp.Tests/Resources/testrepo_wd/dot_git/config
@@ -9,6 +9,9 @@
 [remote "origin"]
 	fetch = +refs/heads/*:refs/remotes/origin/*
 	url = c:/GitHub/libgit2sharp/Resources/testrepo.git
+[remote "no_url"]
+	url =
+	fetch = +refs/heads/*:refs/remotes/no_url/*
 [branch "master"]
 	remote = origin
 	merge = refs/heads/master


### PR DESCRIPTION
Repository.Network.Remotes throw exception when one of remotes without URL
