### PR TITLE
Teach Index.Stage to stage files in ignored dirs

### DIFF
--- a/LibGit2Sharp.Tests/StageFixture.cs
+++ b/LibGit2Sharp.Tests/StageFixture.cs
@@ -298,5 +298,21 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(count, repo.Index.Count);  // 1 added file, 1 deleted file, so same count
             }
         }
+
+        [Theory]
+        [InlineData("ignored_file.txt")]
+        [InlineData("ignored_folder/file.txt")]
+        public void CanStageIgnoredPaths(string path)
+        {
+            using (var repo = new Repository(CloneStandardTestRepo()))
+            {
+                Touch(repo.Info.WorkingDirectory, ".gitignore", "ignored_file.txt\nignored_folder/\n");
+                Touch(repo.Info.WorkingDirectory, path, "This file is ignored.");
+
+                Assert.Equal(FileStatus.Ignored, repo.Index.RetrieveStatus(path));
+                repo.Index.Stage(path);
+                Assert.Equal(FileStatus.Added, repo.Index.RetrieveStatus(path));
+            }
+        }
     }
 }

--- a/LibGit2Sharp/Core/GitDiff.cs
+++ b/LibGit2Sharp/Core/GitDiff.cs
@@ -111,6 +111,13 @@ namespace LibGit2Sharp.Core
         /// Ignore file mode changes.
         /// </summary>
         GIT_DIFF_IGNORE_FILEMODE = (1 << 17),
+
+        /// <summary>
+        /// Even with GIT_DIFF_INCLUDE_IGNORED, an entire ignored directory
+        /// will be marked with only a single entry in the diff list; this flag
+        /// adds all files under the directory as IGNORED entries, too.
+        /// </summary>
+        GIT_DIFF_RECURSE_IGNORED_DIRS = (1 << 18),
     }
 
     internal delegate int diff_notify_cb(

--- a/LibGit2Sharp/Diff.cs
+++ b/LibGit2Sharp/Diff.cs
@@ -38,7 +38,8 @@ namespace LibGit2Sharp
 
             if (diffOptions.HasFlag(DiffModifiers.IncludeIgnored))
             {
-                options.Flags |= GitDiffOptionFlags.GIT_DIFF_INCLUDE_IGNORED;
+                options.Flags |= GitDiffOptionFlags.GIT_DIFF_INCLUDE_IGNORED |
+                GitDiffOptionFlags.GIT_DIFF_RECURSE_IGNORED_DIRS;
             }
 
             if (diffOptions.HasFlag(DiffModifiers.IncludeUnmodified))


### PR DESCRIPTION
If a directory is ignored and you attempt to stage a file beneath that directory, the file is not staged.  By having diff return files beneath that ignored dir, we can add that file.
