### PR TITLE
RewriteHistory.OnComplete

### DIFF
--- a/LibGit2Sharp/RewriteHistoryOptions.cs
+++ b/LibGit2Sharp/RewriteHistoryOptions.cs
@@ -49,5 +49,33 @@ namespace LibGit2Sharp
         /// Empty commits should be removed while rewriting.
         /// </summary>
         public bool PruneEmptyCommits { get; set; }
+
+        /// <summary>
+        /// Action to exectute after rewrite succeeds,
+        /// but before it is finalized.
+        /// <para>
+        /// An exception thrown here will rollback the operation.
+        /// This is useful to inspect the new state of the repository
+        /// and throw if you need to adjust and try again.
+        /// </para>
+        /// </summary>
+        public Action OnSucceeding { get; set; }
+
+        /// <summary>
+        /// Action to execute if an error occurred during rewrite,
+        /// before rollback of rewrite progress.
+        /// Does not fire for exceptions thrown in <see cref="OnSucceeding" />.
+        /// <para>
+        /// This is useful to inspect the state of the repository
+        /// at the time of the exception for troubleshooting.
+        /// It is not meant to be used for general error handling;
+        /// for that use <code>try</code>/<code>catch</code>.
+        /// </para>
+        /// <para>
+        /// An exception thrown here will replace the original exception.
+        /// You may want to pass the callback exception as an <code>innerException</code>.
+        /// </para>
+        /// </summary>
+        public Action<Exception> OnError { get; set; }
     }
 }


### PR DESCRIPTION
Had cause to actually use RewriteHistory tonight to purge some passwords that should never have been pushed. Two proposed enhancements came out of that hacking:
- `OnComplete` action: Until I was ready to pull the trigger on the actual rewrite, I found it quite handy to be able to verify that I was on the right track but then throw to rollback and continue development.
  
  Using this on every test case is probably overkill, but I couldn't decide where to stop.
- My desired behavior was essentially "inject cleansed file from a branch" into earlier trees. Without `TreeEntryDefinition.From(te)`, I have to do something like:
  
  ``` csharp
  var blob = (Blob)te.Target;
  td.Add(te.Path, blob, blob.Mode);
  ```
  
  Not a huge deal, but I resent the extra work. Things would get even more complicated if you're dealing with more than one type of `TreeEntry`.

For posterity, here's a simplified version of the rewrite code I ended up with:

``` csharp
var clean = repo.Branches["clean"];
var todo = new[]
{
    clean[@"file1"],
    clean[@"file2"],
    clean[@"file3"],
};

repo.Refs.RewriteHistory(
    new RewriteHistoryOptions
    {
        CommitTreeRewriter =
            c =>
            {
                var td = TreeDefinition.From(c);

                foreach (var te in todo)
                    if (td[te.Path] != null)
                        td.Add(te.Path, TreeEntryDefinition.From(te));

                return td;
            },
        PruneEmptyCommits = true,
        OnComplete =
            () =>
            {
                foreach (var te in todo)
                {
                    Console.WriteLine("=== {0} ===", te.Path);
                    Console.WriteLine(((Blob)repo.Head[te.Path].Target).ContentAsText());
                }

                throw new Exception("Forcing rollback");
            },
    }, repo.Commits.QueryBy(new CommitFilter { Since = repo.Refs }));
```
