### PR TITLE
Clearified documentation of BranchTrackingDetails

### DIFF
--- a/LibGit2Sharp/BranchTrackingDetails.cs
+++ b/LibGit2Sharp/BranchTrackingDetails.cs
@@ -31,7 +31,8 @@ namespace LibGit2Sharp
         /// <summary>
         /// Gets the number of commits that exist in this local branch but don't exist in the tracked one.
         /// <para>
-        ///   This property will return null if there is no tracked branch linked to this local branch.
+        ///   This property will return <c>null</c> if this local branch has no upstream configuration
+        ///   or if the upstream branch does not exist
         /// </para>
         /// </summary>
         public virtual int? AheadBy
@@ -42,7 +43,8 @@ namespace LibGit2Sharp
         /// <summary>
         /// Gets the number of commits that exist in the tracked branch but don't exist in this local one.
         /// <para>
-        ///   This property will return null if there is no tracked branch linked to this local branch.
+        ///   This property will return <c>null</c> if this local branch has no upstream configuration
+        ///   or if the upstream branch does not exist
         /// </para>
         /// </summary>
         public virtual int? BehindBy
@@ -53,8 +55,8 @@ namespace LibGit2Sharp
         /// <summary>
         /// Gets the common ancestor of the local branch and its tracked remote branch.
         /// <para>
-        ///   This property will return null if there is no tracked branch linked to this local branch,
-        ///   or if either branch is an orphan.
+        ///   This property will return <c>null</c> if this local branch has no upstream configuration,
+        ///   the upstream branch does not exist, or either branch is an orphan.
         /// </para>
         /// </summary>
         public virtual Commit CommonAncestor


### PR DESCRIPTION
The properties AheadBy, BehindBy and CommonAncestor are not only null if there is no tracking branch; they are also null if the tracking branch is empty (e.g. after cloning an empty repository)

fixes #513
