### PR TITLE
Status with renames

### DIFF
--- a/LibGit2Sharp.Tests/IgnoreFixture.cs
+++ b/LibGit2Sharp.Tests/IgnoreFixture.cs
@@ -16,15 +16,15 @@ namespace LibGit2Sharp.Tests
             {
                 Touch(repo.Info.WorkingDirectory, "Foo.cs", "Bar");
 
-                Assert.True(repo.Index.RetrieveStatus().Untracked.Contains("Foo.cs"));
+                Assert.True(repo.Index.RetrieveStatus().Untracked.Select(s => s.FilePath).Contains("Foo.cs"));
 
                 repo.Ignore.AddTemporaryRules(new[] { "*.cs" });
 
-                Assert.False(repo.Index.RetrieveStatus().Untracked.Contains("Foo.cs"));
+                Assert.False(repo.Index.RetrieveStatus().Untracked.Select(s => s.FilePath).Contains("Foo.cs"));
 
                 repo.Ignore.ResetAllTemporaryRules();
 
-                Assert.True(repo.Index.RetrieveStatus().Untracked.Contains("Foo.cs"));
+                Assert.True(repo.Index.RetrieveStatus().Untracked.Select(s => s.FilePath).Contains("Foo.cs"));
             }
         }
 

--- a/LibGit2Sharp.Tests/ResetIndexFixture.cs
+++ b/LibGit2Sharp.Tests/ResetIndexFixture.cs
@@ -93,7 +93,7 @@ namespace LibGit2Sharp.Tests
                     "deleted_unstaged_file.txt", "modified_staged_file.txt", "modified_unstaged_file.txt" };
 
                 Assert.Equal(expected.Length, newStatus.Where(IsStaged).Count());
-                Assert.Equal(expected, newStatus.Removed);
+                Assert.Equal(expected, newStatus.Removed.Select(s => s.FilePath));
             }
         }
 
@@ -111,7 +111,7 @@ namespace LibGit2Sharp.Tests
                     "deleted_unstaged_file.txt", "modified_staged_file.txt", "modified_unstaged_file.txt" };
 
                 Assert.Equal(expected.Length, newStatus.Where(IsStaged).Count());
-                Assert.Equal(expected, newStatus.Removed);
+                Assert.Equal(expected, newStatus.Removed.Select(s => s.FilePath));
             }
         }
 

--- a/LibGit2Sharp/Core/GitStatusEntry.cs
+++ b/LibGit2Sharp/Core/GitStatusEntry.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace LibGit2Sharp.Core
+{
+    /// <summary>
+    /// A status entry from libgit2.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    internal class GitStatusEntry
+    {
+        /// <summary>
+        /// Calculated status of a filepath in the working directory considering the current <see cref = "Repository.Index" /> and the <see cref="Repository.Head" />.
+        /// </summary>
+        public FileStatus Status;
+
+        /// <summary>
+        /// The difference between the <see cref="Repository.Head" /> and <see cref = "Repository.Index" />.
+        /// </summary>
+        public IntPtr HeadToIndexPtr;
+
+        /// <summary>
+        /// The difference between the <see cref = "Repository.Index" /> and the working directory.
+        /// </summary>
+        public IntPtr IndexToWorkDirPtr;
+    }
+}

--- a/LibGit2Sharp/Core/GitStatusOptions.cs
+++ b/LibGit2Sharp/Core/GitStatusOptions.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace LibGit2Sharp.Core
+{
+    [StructLayout(LayoutKind.Sequential)]
+    internal class GitStatusOptions : IDisposable
+    {
+        public uint Version = 1;
+
+        public GitStatusShow Show;
+        public GitStatusOptionFlags Flags;
+
+        GitStrArrayIn PathSpec;
+
+        public void Dispose()
+        {
+            if (PathSpec == null)
+            {
+                return;
+            }
+
+            PathSpec.Dispose();
+        }
+    }
+
+    internal enum GitStatusShow
+    {
+        IndexAndWorkDir = 0,
+        IndexOnly = 1,
+        WorkDirOnly = 2,
+    }
+
+    [Flags]
+    internal enum GitStatusOptionFlags
+    {
+        IncludeUntracked = (1 << 0),
+        IncludeIgnored = (1 << 1),
+        IncludeUnmodified = (1 << 2),
+        ExcludeSubmodules = (1 << 3),
+        RecurseUntrackedDirs = (1 << 4),
+        DisablePathspecMatch = (1 << 5),
+        RecurseIgnoredDirs = (1 << 6),
+        RenamesHeadToIndex = (1 << 7),
+        RenamesIndexToWorkDir = (1 << 8),
+        SortCaseSensitively = (1 << 9),
+        SortCaseInsensitively = (1 << 10),
+        RenamesFromRewrites = (1 << 11),
+    }
+}

--- a/LibGit2Sharp/Core/Handles/StatusEntrySafeHandle.cs
+++ b/LibGit2Sharp/Core/Handles/StatusEntrySafeHandle.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace LibGit2Sharp.Core.Handles
+{
+    internal class StatusEntrySafeHandle : NotOwnedSafeHandleBase
+    {
+        public StatusEntrySafeHandle()
+            : base()
+        {
+        }
+
+        public StatusEntrySafeHandle(IntPtr handle)
+            : base()
+        {
+            this.SetHandle(handle);
+        }
+
+        public GitStatusEntry MarshalAsGitStatusEntry()
+        {
+            return (GitStatusEntry)Marshal.PtrToStructure(handle, typeof(GitStatusEntry));
+        }
+    }
+}

--- a/LibGit2Sharp/Core/Handles/StatusListSafeHandle.cs
+++ b/LibGit2Sharp/Core/Handles/StatusListSafeHandle.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace LibGit2Sharp.Core.Handles
+{
+    internal class StatusListSafeHandle : SafeHandleBase
+    {
+        protected override bool ReleaseHandleImpl()
+        {
+            Proxy.git_status_list_free(handle);
+            return true;
+        }
+    }
+}

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -1127,13 +1127,25 @@ namespace LibGit2Sharp.Core
             RepositorySafeHandle repo,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath filepath);
 
-        internal delegate int git_status_cb(
-            IntPtr path,
-            uint statusflags,
-            IntPtr payload);
 
         [DllImport(libgit2)]
-        internal static extern int git_status_foreach(RepositorySafeHandle repo, git_status_cb cb, IntPtr payload);
+        internal static extern int git_status_list_new(
+            out StatusListSafeHandle git_status_list,
+            RepositorySafeHandle repo,
+            GitStatusOptions options);
+
+        [DllImport(libgit2)]
+        internal static extern int git_status_list_entrycount(
+            StatusListSafeHandle statusList);
+
+        [DllImport(libgit2)]
+        internal static extern StatusEntrySafeHandle git_status_byindex(
+            StatusListSafeHandle list,
+            UIntPtr idx);
+
+        [DllImport(libgit2)]
+        internal static extern void git_status_list_free(
+            IntPtr statusList);
 
         [DllImport(libgit2)]
         internal static extern int git_submodule_lookup(

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -2178,9 +2178,35 @@ namespace LibGit2Sharp.Core
             }
         }
 
-        public static ICollection<TResult> git_status_foreach<TResult>(RepositorySafeHandle repo, Func<IntPtr, uint, TResult> resultSelector)
+        public static StatusListSafeHandle git_status_list_new(RepositorySafeHandle repo, GitStatusOptions options)
         {
-            return git_foreach(resultSelector, c => NativeMethods.git_status_foreach(repo, (x, y, p) => c(x, y, p), IntPtr.Zero));
+            using (ThreadAffinity())
+            {
+                StatusListSafeHandle handle;
+                int res = NativeMethods.git_status_list_new(out handle, repo, options);
+                Ensure.ZeroResult(res);
+                return handle;
+            }
+        }
+
+        public static int git_status_list_entrycount(StatusListSafeHandle list)
+        {
+            using (ThreadAffinity())
+            {
+                int res = NativeMethods.git_status_list_entrycount(list);
+                Ensure.Int32Result(res);
+                return res;
+            }
+        }
+
+        public static StatusEntrySafeHandle git_status_byindex(StatusListSafeHandle list, long idx)
+        {
+            return NativeMethods.git_status_byindex(list, (UIntPtr)idx);
+        }
+
+        public static void git_status_list_free(IntPtr statusList)
+        {
+            NativeMethods.git_status_list_free(statusList);
         }
 
         #endregion

--- a/LibGit2Sharp/FileStatus.cs
+++ b/LibGit2Sharp/FileStatus.cs
@@ -36,7 +36,7 @@ namespace LibGit2Sharp
         /// <summary>
         /// The renaming of a file has been promoted from the working directory to the Index. A previous version exists in the Head.
         /// </summary>
-        Renamed = (1 << 3), /* GIT_STATUS_INDEX_RENAMED */
+        RenamedInIndex = (1 << 3), /* GIT_STATUS_INDEX_RENAMED */
 
         /// <summary>
         /// A change in type for a file has been promoted from the working directory to the Index. A previous version exists in the Head.
@@ -62,6 +62,11 @@ namespace LibGit2Sharp
         /// The file type has been changed in the working directory. A previous version exists in the Index.
         /// </summary>
         TypeChanged = (1 << 10), /* GIT_STATUS_WT_TYPECHANGE */
+
+        /// <summary>
+        /// The file has been renamed in the working directory.  The previous version at the previous name exists in the Index.
+        /// </summary>
+        RenamedInWorkDir = (1 << 11), /* GIT_STATUS_WT_RENAMED */
 
         /// <summary>
         /// The file is <see cref="Untracked"/> but its name and/or path matches an exclude pattern in a <c>gitignore</c> file.

--- a/LibGit2Sharp/Index.cs
+++ b/LibGit2Sharp/Index.cs
@@ -498,11 +498,13 @@ namespace LibGit2Sharp
         /// <summary>
         /// Retrieves the state of all files in the working directory, comparing them against the staging area and the latest commmit.
         /// </summary>
+        /// <param name="options">If set, the options that control the status investigation.</param>
         /// <returns>A <see cref="RepositoryStatus"/> holding the state of all the files.</returns>
-        public virtual RepositoryStatus RetrieveStatus()
+        public virtual RepositoryStatus RetrieveStatus(StatusOptions options = null)
         {
             ReloadFromDisk();
-            return new RepositoryStatus(repo);
+
+            return new RepositoryStatus(repo, options);
         }
 
         internal void Reset(TreeChanges changes)

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -89,6 +89,12 @@
     <Compile Include="ResetMode.cs" />
     <Compile Include="NoteCollectionExtensions.cs" />
     <Compile Include="RefSpecDirection.cs" />
+    <Compile Include="Core\GitStatusEntry.cs" />
+    <Compile Include="Core\GitStatusOptions.cs" />
+    <Compile Include="Core\Handles\StatusEntrySafeHandle.cs" />
+    <Compile Include="Core\Handles\StatusListSafeHandle.cs" />
+    <Compile Include="RenameDetails.cs" />
+    <Compile Include="StatusOptions.cs" />
     <Compile Include="UnbornBranchException.cs" />
     <Compile Include="LockedFileException.cs" />
     <Compile Include="Core\GitRepositoryInitOptions.cs" />

--- a/LibGit2Sharp/RenameDetails.cs
+++ b/LibGit2Sharp/RenameDetails.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Diagnostics;
+using LibGit2Sharp.Core;
+
+namespace LibGit2Sharp
+{
+    /// <summary>
+    /// Holds the rename details of a particular file.
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class RenameDetails : IEquatable<RenameDetails>
+    {
+        private readonly string oldFilePath;
+        private readonly string newFilePath;
+        private readonly int similarity;
+
+        private static readonly LambdaEqualityHelper<RenameDetails> equalityHelper =
+            new LambdaEqualityHelper<RenameDetails>(x => x.OldFilePath, x => x.NewFilePath, x => x.Similarity);
+
+        /// <summary>
+        /// Needed for mocking purposes.
+        /// </summary>
+        protected RenameDetails()
+        { }
+
+        internal RenameDetails(string oldFilePath, string newFilePath, int similarity)
+        {
+            this.oldFilePath = oldFilePath;
+            this.newFilePath = newFilePath;
+            this.similarity = similarity;
+        }
+
+        /// <summary>
+        /// Gets the relative filepath to the working directory of the old file (the rename source).
+        /// </summary>
+        public virtual string OldFilePath
+        {
+            get { return oldFilePath; }
+        }
+
+        /// <summary>
+        /// Gets the relative filepath to the working directory of the new file (the rename target).
+        /// </summary>
+        public virtual string NewFilePath
+        {
+            get { return newFilePath; }
+        }
+
+        /// <summary>
+        /// Gets the similarity between the old file an the new file (0-100).
+        /// </summary>
+        public virtual int Similarity
+        {
+            get { return similarity; }
+        }
+
+        /// <summary>
+        /// Determines whether the specified <see cref="Object"/> is equal to the current <see cref="RenameDetails"/>.
+        /// </summary>
+        /// <param name="obj">The <see cref="Object"/> to compare with the current <see cref="RenameDetails"/>.</param>
+        /// <returns>True if the specified <see cref="Object"/> is equal to the current <see cref="RenameDetails"/>; otherwise, false.</returns>
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as RenameDetails);
+        }
+
+        /// <summary>
+        /// Determines whether the specified <see cref="RenameDetails"/> is equal to the current <see cref="RenameDetails"/>.
+        /// </summary>
+        /// <param name="other">The <see cref="RenameDetails"/> to compare with the current <see cref="RenameDetails"/>.</param>
+        /// <returns>True if the specified <see cref="RenameDetails"/> is equal to the current <see cref="RenameDetails"/>; otherwise, false.</returns>
+        public bool Equals(RenameDetails other)
+        {
+            return equalityHelper.Equals(this, other);
+        }
+
+        /// <summary>
+        /// Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A 32-bit signed integer hash code.</returns>
+        public override int GetHashCode()
+        {
+            return equalityHelper.GetHashCode(this);
+        }
+
+        /// <summary>
+        /// Tests if two <see cref="RenameDetails"/> are equal.
+        /// </summary>
+        /// <param name="left">First <see cref="RenameDetails"/> to compare.</param>
+        /// <param name="right">Second <see cref="RenameDetails"/> to compare.</param>
+        /// <returns>True if the two objects are equal; false otherwise.</returns>
+        public static bool operator ==(RenameDetails left, RenameDetails right)
+        {
+            return Equals(left, right);
+        }
+
+        /// <summary>
+        /// Tests if two <see cref="RenameDetails"/> are different.
+        /// </summary>
+        /// <param name="left">First <see cref="RenameDetails"/> to compare.</param>
+        /// <param name="right">Second <see cref="RenameDetails"/> to compare.</param>
+        /// <returns>True if the two objects are different; false otherwise.</returns>
+        public static bool operator !=(RenameDetails left, RenameDetails right)
+        {
+            return !Equals(left, right);
+        }
+
+        private string DebuggerDisplay
+        {
+            get
+            {
+                return string.Format("{0} -> {1} [{2}%]", OldFilePath, NewFilePath, Similarity);
+            }
+        }
+    }
+}

--- a/LibGit2Sharp/StatusEntry.cs
+++ b/LibGit2Sharp/StatusEntry.cs
@@ -12,9 +12,11 @@ namespace LibGit2Sharp
     {
         private readonly string filePath;
         private readonly FileStatus state;
+        private readonly RenameDetails headToIndexRenameDetails;
+        private readonly RenameDetails indexToWorkDirRenameDetails;
 
         private static readonly LambdaEqualityHelper<StatusEntry> equalityHelper =
-            new LambdaEqualityHelper<StatusEntry>(x => x.FilePath, x => x.State);
+            new LambdaEqualityHelper<StatusEntry>(x => x.FilePath, x => x.State, x => x.HeadToIndexRenameDetails, x => x.IndexToWorkDirRenameDetails);
 
         /// <summary>
         /// Needed for mocking purposes.
@@ -22,10 +24,12 @@ namespace LibGit2Sharp
         protected StatusEntry()
         { }
 
-        internal StatusEntry(string filePath, FileStatus state)
+        internal StatusEntry(string filePath, FileStatus state, RenameDetails headToIndexRenameDetails = null, RenameDetails indexToWorkDirRenameDetails = null)
         {
             this.filePath = filePath;
             this.state = state;
+            this.headToIndexRenameDetails = headToIndexRenameDetails;
+            this.indexToWorkDirRenameDetails = indexToWorkDirRenameDetails;
         }
 
         /// <summary>
@@ -37,11 +41,27 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
-        /// Gets the relative filepath to the working directory of the file.
+        /// Gets the relative new filepath to the working directory of the file.
         /// </summary>
         public virtual string FilePath
         {
             get { return filePath; }
+        }
+
+        /// <summary>
+        /// Gets the rename details from the HEAD to the Index, if this <see cref="FileStatus"/> contains <see cref="FileStatus.RenamedInIndex"/>
+        /// </summary>
+        public virtual RenameDetails HeadToIndexRenameDetails
+        {
+            get { return headToIndexRenameDetails; }
+        }
+
+        /// <summary>
+        /// Gets the rename details from the Index to the working directory, if this <see cref="FileStatus"/> contains <see cref="FileStatus.RenamedInWorkDir"/>
+        /// </summary>
+        public virtual RenameDetails IndexToWorkDirRenameDetails
+        {
+            get { return indexToWorkDirRenameDetails; }
         }
 
         /// <summary>
@@ -97,7 +117,19 @@ namespace LibGit2Sharp
 
         private string DebuggerDisplay
         {
-            get { return string.Format("{0}: {1}", State, FilePath); }
+            get
+            {
+                if ((State & FileStatus.RenamedInIndex) == FileStatus.RenamedInIndex ||
+                    (State & FileStatus.RenamedInWorkDir) == FileStatus.RenamedInWorkDir)
+                {
+                    string oldFilePath = ((State & FileStatus.RenamedInIndex) == FileStatus.RenamedInIndex) ?
+                        HeadToIndexRenameDetails.OldFilePath : IndexToWorkDirRenameDetails.OldFilePath;
+
+                    return string.Format("{0}: {1} -> {2}", State, oldFilePath, FilePath);
+                }
+
+                return string.Format("{0}: {1}", State, FilePath);
+            }
         }
     }
 }

--- a/LibGit2Sharp/StatusOptions.cs
+++ b/LibGit2Sharp/StatusOptions.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace LibGit2Sharp
+{
+    /// <summary>
+    /// Flags controlling what files are reported by status.
+    /// </summary>
+    public enum StatusShowOption
+    {
+        /// <summary>
+        /// Both the index and working directory are examined for changes
+        /// </summary>
+        IndexAndWorkDir = 0,
+
+        /// <summary>
+        /// Only the index is examined for changes
+        /// </summary>
+        IndexOnly = 1,
+
+        /// <summary>
+        /// Only the working directory is examined for changes
+        /// </summary>
+        WorkDirOnly = 2
+    }
+
+    /// <summary>
+    /// Options controlling the status behavior.
+    /// </summary>
+    public sealed class StatusOptions
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StatusOptions"/> class.
+        /// By default, both the index and the working directory will be scanned
+        /// for status, and renames will be detected from changes staged in the
+        /// index only.
+        /// </summary>
+        public StatusOptions()
+        {
+            DetectRenamesInIndex = true;
+        }
+
+        /// <summary>
+        /// Which files should be scanned and returned
+        /// </summary>
+        public StatusShowOption Show { get; set; }
+
+        /// <summary>
+        /// Examine the staged changes for renames.
+        /// </summary>
+        public bool DetectRenamesInIndex { get; set; }
+
+        /// <summary>
+        /// Examine unstaged changes in the working directory for renames.
+        /// </summary>
+        public bool DetectRenamesInWorkDir { get; set; }
+
+        /// <summary>
+        /// Exclude submodules from being scanned for status
+        /// </summary>
+        public bool ExcludeSubmodules { get; set; }
+    }
+}


### PR DESCRIPTION
Move `RepositoryStatus` to the new `git_status_list_new` API, which allows us to find similar renames in the index.

By default, detect similarity in staged changes (only) and account for rewrites, however we provide an additional flag to detect unstaged renames in the working directory.  I did not wire up any of the other status options.

Big thanks to Rick Potts for all the work here, this is really his PR, I just rebased it on latest and fixed some things up.
