### PR TITLE
Conservative and liberal string encodings

### DIFF
--- a/LibGit2Sharp/BranchCollection.cs
+++ b/LibGit2Sharp/BranchCollection.cs
@@ -91,7 +91,7 @@ namespace LibGit2Sharp
         /// <returns>An <see cref="IEnumerator{T}"/> object that can be used to iterate through the collection.</returns>
         public virtual IEnumerator<Branch> GetEnumerator()
         {
-            return Proxy.git_branch_foreach(repo.Handle, GitBranchType.GIT_BRANCH_LOCAL | GitBranchType.GIT_BRANCH_REMOTE, branchToCanoncialName)
+            return Proxy.git_branch_foreach(repo.Handle, GitBranchType.GIT_BRANCH_LOCAL | GitBranchType.GIT_BRANCH_REMOTE, BranchToCanonicalName)
                 .Select(n => this[n])
                 .GetEnumerator();
         }
@@ -203,9 +203,9 @@ namespace LibGit2Sharp
                 referenceName.LooksLikeRemoteTrackingBranch();
         }
 
-        private static string branchToCanoncialName(IntPtr namePtr, GitBranchType branchType)
+        private static string BranchToCanonicalName(IntPtr namePtr, GitBranchType branchType)
         {
-            string shortName = Utf8Marshaler.FromNative(namePtr);
+            string shortName = LaxUtf8Marshaler.FromNative(namePtr);
 
             switch (branchType)
             {

--- a/LibGit2Sharp/CheckoutCallbacks.cs
+++ b/LibGit2Sharp/CheckoutCallbacks.cs
@@ -86,9 +86,9 @@ namespace LibGit2Sharp
             if (onCheckoutProgress != null)
             {
                 // Convert null strings into empty strings.
-                string path = (str != IntPtr.Zero) ? Utf8Marshaler.FromNative(str) : string.Empty;
+                FilePath path = LaxFilePathMarshaler.FromNative(str) ?? FilePath.Empty;
 
-                onCheckoutProgress(path, (int)completedSteps, (int)totalSteps);
+                onCheckoutProgress(path.Native, (int)completedSteps, (int)totalSteps);
             }
         }
 
@@ -103,9 +103,8 @@ namespace LibGit2Sharp
             int result = 0;
             if (this.onCheckoutNotify != null)
             {
-                string path = (pathPtr != IntPtr.Zero) ?
-                    ((FilePath)Utf8Marshaler.FromNative(pathPtr)).Native : string.Empty;
-                result = onCheckoutNotify(path, why) ? 0 : 1;
+                FilePath path = LaxFilePathMarshaler.FromNative(pathPtr) ?? FilePath.Empty;
+                result = onCheckoutNotify(path.Native, why) ? 0 : 1;
             }
 
             return result;

--- a/LibGit2Sharp/Configuration.cs
+++ b/LibGit2Sharp/Configuration.cs
@@ -282,8 +282,8 @@ namespace LibGit2Sharp
             {
                 var entry = (GitConfigEntry)Marshal.PtrToStructure(entryPtr, typeof(GitConfigEntry));
 
-                return new ConfigurationEntry<string>(Utf8Marshaler.FromNative(entry.namePtr),
-                                                      Utf8Marshaler.FromNative(entry.valuePtr),
+                return new ConfigurationEntry<string>(LaxUtf8Marshaler.FromNative(entry.namePtr),
+                                                      LaxUtf8Marshaler.FromNative(entry.valuePtr),
                                                       (ConfigurationLevel)entry.level);
             });
         }

--- a/LibGit2Sharp/ContentChanges.cs
+++ b/LibGit2Sharp/ContentChanges.cs
@@ -82,7 +82,7 @@ namespace LibGit2Sharp
 
         private int HunkCallback(GitDiffDelta delta, GitDiffRange range, IntPtr header, UIntPtr headerlen, IntPtr payload)
         {
-            string decodedContent = Utf8Marshaler.FromNative(header, (int)headerlen);
+            string decodedContent = LaxUtf8Marshaler.FromNative(header, (int)headerlen);
 
             AppendToPatch(decodedContent);
             return 0;
@@ -90,7 +90,7 @@ namespace LibGit2Sharp
 
         private int LineCallback(GitDiffDelta delta, GitDiffRange range, GitDiffLineOrigin lineorigin, IntPtr content, UIntPtr contentlen, IntPtr payload)
         {
-            string decodedContent = Utf8Marshaler.FromNative(content, (int)contentlen);
+            string decodedContent = LaxUtf8Marshaler.FromNative(content, (int)contentlen);
 
             string prefix;
 

--- a/LibGit2Sharp/Core/EncodingMarshaler.cs
+++ b/LibGit2Sharp/Core/EncodingMarshaler.cs
@@ -88,7 +88,7 @@ namespace LibGit2Sharp.Core
             Marshal.FreeHGlobal(pNativeData);
         }
 
-        public static unsafe String FromNative(Encoding encoding, IntPtr pNativeData)
+        public static unsafe string FromNative(Encoding encoding, IntPtr pNativeData)
         {
             if (pNativeData == IntPtr.Zero)
             {
@@ -112,7 +112,7 @@ namespace LibGit2Sharp.Core
             return new String((sbyte*)pNativeData.ToPointer(), 0, (int)(walk - start), encoding);
         }
 
-        public static unsafe String FromNative(Encoding encoding, IntPtr pNativeData, int length)
+        public static unsafe string FromNative(Encoding encoding, IntPtr pNativeData, int length)
         {
             if (pNativeData == IntPtr.Zero)
             {
@@ -127,7 +127,7 @@ namespace LibGit2Sharp.Core
             return new String((sbyte*)pNativeData.ToPointer(), 0, length, encoding);
         }
 
-        public static String FromBuffer(Encoding encoding, byte[] buffer)
+        public static string FromBuffer(Encoding encoding, byte[] buffer)
         {
             if (buffer == null)
             {

--- a/LibGit2Sharp/Core/Ensure.cs
+++ b/LibGit2Sharp/Core/Ensure.cs
@@ -96,7 +96,7 @@ namespace LibGit2Sharp.Core
             }
             else
             {
-                errorMessage = Utf8Marshaler.FromNative(error.Message);
+                errorMessage = LaxUtf8Marshaler.FromNative(error.Message);
             }
 
             Func<string, GitErrorCode, GitErrorCategory, LibGit2SharpException> exceptionBuilder;

--- a/LibGit2Sharp/Core/GitRepositoryInitOptions.cs
+++ b/LibGit2Sharp/Core/GitRepositoryInitOptions.cs
@@ -28,7 +28,7 @@ namespace LibGit2Sharp.Core
             {
                 Debug.Assert(!isBare);
 
-                opts.WorkDirPath = FilePathMarshaler.FromManaged(workdirPath);
+                opts.WorkDirPath = StrictFilePathMarshaler.FromManaged(workdirPath);
             }
 
             if (isBare)

--- a/LibGit2Sharp/Core/GitStrArrayIn.cs
+++ b/LibGit2Sharp/Core/GitStrArrayIn.cs
@@ -20,7 +20,7 @@ namespace LibGit2Sharp.Core
             for (int i = 0; i < nbOfPaths; i++)
             {
                 var s = paths[i].Posix;
-                pathPtrs[i] = FilePathMarshaler.FromManaged(s);
+                pathPtrs[i] = StrictFilePathMarshaler.FromManaged(s);
             }
 
             int dim = IntPtr.Size * nbOfPaths;

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -110,13 +110,13 @@ namespace LibGit2Sharp.Core
         internal static extern int git_blob_create_fromdisk(
             ref GitOid id,
             RepositorySafeHandle repo,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(FilePathMarshaler))] FilePath path);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath path);
 
         [DllImport(libgit2)]
         internal static extern int git_blob_create_fromworkdir(
             ref GitOid id,
             RepositorySafeHandle repo,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(FilePathMarshaler))] FilePath relative_path);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath relative_path);
 
         internal delegate int source_callback(
             IntPtr content,
@@ -127,7 +127,7 @@ namespace LibGit2Sharp.Core
         internal static extern int git_blob_create_fromchunks(
             ref GitOid oid,
             RepositorySafeHandle repositoryPtr,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(FilePathMarshaler))] FilePath hintpath,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath hintpath,
             source_callback fileCallback,
             IntPtr data);
 
@@ -141,7 +141,7 @@ namespace LibGit2Sharp.Core
         internal static extern int git_branch_create(
             out ReferenceSafeHandle ref_out,
             RepositorySafeHandle repo,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string branch_name,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string branch_name,
             GitObjectSafeHandle target, // TODO: GitCommitSafeHandle?
             [MarshalAs(UnmanagedType.Bool)] bool force);
 
@@ -165,7 +165,7 @@ namespace LibGit2Sharp.Core
         internal static extern int git_branch_move(
             out ReferenceSafeHandle ref_out,
             ReferenceSafeHandle reference,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string new_branch_name,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string new_branch_name,
             [MarshalAs(UnmanagedType.Bool)] bool force);
 
         [DllImport(libgit2)]
@@ -173,14 +173,14 @@ namespace LibGit2Sharp.Core
             byte[] remote_name_out,
             UIntPtr buffer_size,
             RepositorySafeHandle repo,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string canonical_branch_name);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string canonical_branch_name);
 
         [DllImport(libgit2)]
         internal static extern int git_branch_upstream_name(
             byte[] tracking_branch_name_out, // NB: This is more properly a StringBuilder, but it's UTF8
             UIntPtr buffer_size,
             RepositorySafeHandle repo,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string referenceName);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string referenceName);
 
         [DllImport(libgit2)]
         internal static extern int git_checkout_tree(
@@ -197,8 +197,8 @@ namespace LibGit2Sharp.Core
         [DllImport(libgit2)]
         internal static extern int git_clone(
             out RepositorySafeHandle repo,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string origin_url,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(FilePathMarshaler))] FilePath workdir_path,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string origin_url,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath workdir_path,
             GitCloneOptions opts);
 
         [DllImport(libgit2)]
@@ -211,21 +211,21 @@ namespace LibGit2Sharp.Core
         internal static extern int git_commit_create_from_oids(
             out GitOid id,
             RepositorySafeHandle repo,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string updateRef,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string updateRef,
             SignatureSafeHandle author,
             SignatureSafeHandle committer,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string encoding,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string message,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string encoding,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string message,
             ref GitOid tree,
             int parentCount,
             [MarshalAs(UnmanagedType.LPArray)] [In] IntPtr[] parents);
 
         [DllImport(libgit2)]
-        [return : MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8NoCleanupMarshaler))]
+        [return : MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))]
         internal static extern string git_commit_message(GitObjectSafeHandle commit);
 
         [DllImport(libgit2)]
-        [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8NoCleanupMarshaler))]
+        [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))]
         internal static extern string git_commit_message_encoding(GitObjectSafeHandle commit);
 
         [DllImport(libgit2)]
@@ -256,12 +256,12 @@ namespace LibGit2Sharp.Core
         internal static extern int git_config_get_entry(
             out GitConfigEntryHandle entry,
             ConfigurationSafeHandle cfg,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string name);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name);
 
         [DllImport(libgit2)]
         internal static extern int git_config_add_file_ondisk(
             ConfigurationSafeHandle cfg,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(FilePathMarshaler))] FilePath path,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath path,
             uint level,
             bool force);
 
@@ -277,41 +277,41 @@ namespace LibGit2Sharp.Core
         [DllImport(libgit2)]
         internal static extern int git_config_parse_bool(
             [MarshalAs(UnmanagedType.Bool)] out bool value,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string valueToParse);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string valueToParse);
 
         [DllImport(libgit2)]
         internal static extern int git_config_parse_int32(
             [MarshalAs(UnmanagedType.I4)] out int value,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string valueToParse);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string valueToParse);
 
         [DllImport(libgit2)]
         internal static extern int git_config_parse_int64(
             [MarshalAs(UnmanagedType.I8)] out long value,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string valueToParse);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string valueToParse);
 
         [DllImport(libgit2)]
         internal static extern int git_config_set_bool(
             ConfigurationSafeHandle cfg,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string name,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name,
             [MarshalAs(UnmanagedType.Bool)] bool value);
 
         [DllImport(libgit2)]
         internal static extern int git_config_set_int32(
             ConfigurationSafeHandle cfg,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string name,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name,
             int value);
 
         [DllImport(libgit2)]
         internal static extern int git_config_set_int64(
             ConfigurationSafeHandle cfg,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string name,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name,
             long value);
 
         [DllImport(libgit2)]
         internal static extern int git_config_set_string(
             ConfigurationSafeHandle cfg,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string name,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string value);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string value);
 
         internal delegate int config_foreach_callback(
             IntPtr entry,
@@ -323,10 +323,10 @@ namespace LibGit2Sharp.Core
             config_foreach_callback callback,
             IntPtr payload);
 
-        // Ordinarily we would decorate the `url` parameter with the Utf8Marshaler like we do everywhere
+        // Ordinarily we would decorate the `url` parameter with the StrictUtf8Marshaler like we do everywhere
         // else, but apparently doing a native->managed callback with the 64-bit version of CLR 2.0 can
         // sometimes vomit when using a custom IMarshaler.  So yeah, don't do that.  If you need the url,
-        // call Utf8Marshaler.FromNative manually.  See the discussion here:
+        // call StrictUtf8Marshaler.FromNative manually.  See the discussion here:
         // http://social.msdn.microsoft.com/Forums/en-US/netfx64bit/thread/1eb746c6-d695-4632-8a9e-16c4fa98d481
         internal delegate int git_cred_acquire_cb(
             out IntPtr cred,
@@ -338,8 +338,8 @@ namespace LibGit2Sharp.Core
         [DllImport(libgit2)]
         internal static extern int git_cred_userpass_plaintext_new(
             out IntPtr cred,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof (Utf8Marshaler))] string username,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof (Utf8Marshaler))] string password);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof (StrictUtf8Marshaler))] string username,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof (StrictUtf8Marshaler))] string password);
 
         [DllImport(libgit2)]
         internal static extern void git_diff_list_free(IntPtr diff);
@@ -408,9 +408,9 @@ namespace LibGit2Sharp.Core
         [DllImport(libgit2)]
         internal static extern int git_diff_blobs(
             GitObjectSafeHandle oldBlob,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(FilePathMarshaler))] FilePath old_as_path,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath old_as_path,
             GitObjectSafeHandle newBlob,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(FilePathMarshaler))] FilePath new_as_path,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath new_as_path,
             GitDiffOptions options,
             git_diff_file_cb fileCallback,
             git_diff_hunk_cb hunkCallback,
@@ -431,7 +431,7 @@ namespace LibGit2Sharp.Core
         [DllImport(libgit2)]
         internal static extern int git_ignore_add_rule(
             RepositorySafeHandle repo,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof (Utf8Marshaler))] string rules);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof (StrictUtf8Marshaler))] string rules);
 
         [DllImport(libgit2)]
         internal static extern int git_ignore_clear_internal_rules(RepositorySafeHandle repo);
@@ -440,12 +440,12 @@ namespace LibGit2Sharp.Core
         internal static extern int git_ignore_path_is_ignored(
             out int ignored,
             RepositorySafeHandle repo,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(FilePathMarshaler))] FilePath path);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath path);
 
         [DllImport(libgit2)]
         internal static extern int git_index_add_bypath(
             IndexSafeHandle index,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(FilePathMarshaler))] FilePath path);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath path);
 
         [DllImport(libgit2)]
         internal static extern int git_index_add(
@@ -458,7 +458,7 @@ namespace LibGit2Sharp.Core
             out IndexEntrySafeHandle ours,
             out IndexEntrySafeHandle theirs,
             IndexSafeHandle index,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(FilePathMarshaler))] FilePath path);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath path);
 
         [DllImport(libgit2)]
         internal static extern UIntPtr git_index_entrycount(IndexSafeHandle index);
@@ -470,7 +470,7 @@ namespace LibGit2Sharp.Core
         internal static extern int git_index_find(
             out UIntPtr pos,
             IndexSafeHandle index,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(FilePathMarshaler))] FilePath path);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath path);
 
         [DllImport(libgit2)]
         internal static extern void git_index_free(IntPtr index);
@@ -481,7 +481,7 @@ namespace LibGit2Sharp.Core
         [DllImport(libgit2)]
         internal static extern IndexEntrySafeHandle git_index_get_bypath(
             IndexSafeHandle index,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(FilePathMarshaler))] FilePath path,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath path,
             int stage);
 
         [DllImport(libgit2)]
@@ -490,7 +490,7 @@ namespace LibGit2Sharp.Core
         [DllImport(libgit2)]
         internal static extern int git_index_open(
             out IndexSafeHandle index,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(FilePathMarshaler))] FilePath indexpath);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath indexpath);
 
         [DllImport(libgit2)]
         internal static extern int git_index_read(IndexSafeHandle index);
@@ -498,7 +498,7 @@ namespace LibGit2Sharp.Core
         [DllImport(libgit2)]
         internal static extern int git_index_remove_bypath(
             IndexSafeHandle index,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(FilePathMarshaler))] FilePath path);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath path);
 
         [DllImport(libgit2)]
         internal static extern int git_index_write(IndexSafeHandle index);
@@ -517,7 +517,7 @@ namespace LibGit2Sharp.Core
         internal static extern int git_message_prettify(
             byte[] message_out, // NB: This is more properly a StringBuilder, but it's UTF8
             UIntPtr buffer_size,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string message,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string message,
             bool strip_comments);
 
         [DllImport(libgit2)]
@@ -526,16 +526,16 @@ namespace LibGit2Sharp.Core
             RepositorySafeHandle repo,
             SignatureSafeHandle author,
             SignatureSafeHandle committer,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string notes_ref,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string notes_ref,
             ref GitOid oid,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string note,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string note,
             int force);
 
         [DllImport(libgit2)]
         internal static extern void git_note_free(IntPtr note);
 
         [DllImport(libgit2)]
-        [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8NoCleanupMarshaler))]
+        [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))]
         internal static extern string git_note_message(NoteSafeHandle note);
 
         [DllImport(libgit2)]
@@ -545,20 +545,20 @@ namespace LibGit2Sharp.Core
         internal static extern int git_note_read(
             out NoteSafeHandle note,
             RepositorySafeHandle repo,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string notes_ref,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string notes_ref,
             ref GitOid oid);
 
         [DllImport(libgit2)]
         internal static extern int git_note_remove(
             RepositorySafeHandle repo,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string notes_ref,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string notes_ref,
             SignatureSafeHandle author,
             SignatureSafeHandle committer,
             ref GitOid oid);
 
         [DllImport(libgit2)]
         internal static extern int git_note_default_ref(
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8NoCleanupMarshaler))] out string notes_ref,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))] out string notes_ref,
             RepositorySafeHandle repo);
 
         internal delegate int git_note_foreach_cb(
@@ -569,7 +569,7 @@ namespace LibGit2Sharp.Core
         [DllImport(libgit2)]
         internal static extern int git_note_foreach(
             RepositorySafeHandle repo,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string notes_ref,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string notes_ref,
             git_note_foreach_cb cb,
             IntPtr payload);
 
@@ -619,7 +619,7 @@ namespace LibGit2Sharp.Core
         [DllImport(libgit2)]
         internal static extern int git_push_add_refspec(
             PushSafeHandle push,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string pushRefSpec);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string pushRefSpec);
 
         [DllImport(libgit2)]
         internal static extern int git_push_finish(PushSafeHandle push);
@@ -648,7 +648,7 @@ namespace LibGit2Sharp.Core
         internal static extern int git_reference_create(
             out ReferenceSafeHandle reference,
             RepositorySafeHandle repo,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string name,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name,
             ref GitOid oid,
             [MarshalAs(UnmanagedType.Bool)] bool force);
 
@@ -656,8 +656,8 @@ namespace LibGit2Sharp.Core
         internal static extern int git_reference_symbolic_create(
             out ReferenceSafeHandle reference,
             RepositorySafeHandle repo,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string name,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string target,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string target,
             [MarshalAs(UnmanagedType.Bool)] bool force);
 
         [DllImport(libgit2)]
@@ -670,7 +670,7 @@ namespace LibGit2Sharp.Core
         [DllImport(libgit2)]
         internal static extern int git_reference_foreach_glob(
             RepositorySafeHandle repo,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string glob,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string glob,
             ref_glob_callback callback,
             IntPtr payload);
 
@@ -679,16 +679,16 @@ namespace LibGit2Sharp.Core
 
         [DllImport(libgit2)]
         internal static extern int git_reference_is_valid_name(
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string refname);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string refname);
 
         [DllImport(libgit2)]
         internal static extern int git_reference_lookup(
             out ReferenceSafeHandle reference,
             RepositorySafeHandle repo,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string name);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name);
 
         [DllImport(libgit2)]
-        [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8NoCleanupMarshaler))]
+        [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))]
         internal static extern string git_reference_name(ReferenceSafeHandle reference);
 
         [DllImport(libgit2)]
@@ -698,7 +698,7 @@ namespace LibGit2Sharp.Core
         internal static extern int git_reference_rename(
             out ReferenceSafeHandle ref_out,
             ReferenceSafeHandle reference,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string newName,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string newName,
             [MarshalAs(UnmanagedType.Bool)] bool force);
 
         [DllImport(libgit2)]
@@ -708,10 +708,10 @@ namespace LibGit2Sharp.Core
         internal static extern int git_reference_symbolic_set_target(
             out ReferenceSafeHandle ref_out,
             ReferenceSafeHandle reference,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string target);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string target);
 
         [DllImport(libgit2)]
-        [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8NoCleanupMarshaler))]
+        [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))]
         internal static extern string git_reference_symbolic_target(ReferenceSafeHandle reference);
 
         [DllImport(libgit2)]
@@ -752,13 +752,13 @@ namespace LibGit2Sharp.Core
             ReflogSafeHandle reflog,
             ref GitOid id,
             SignatureSafeHandle committer,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string msg);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string msg);
 
         [DllImport(libgit2)]
         internal static extern int git_reflog_write(ReflogSafeHandle reflog);
 
         [DllImport(libgit2)]
-        [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8NoCleanupMarshaler))]
+        [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))]
         internal static extern string git_reflog_entry_message(SafeHandle entry);
 
         [DllImport(libgit2)]
@@ -766,7 +766,7 @@ namespace LibGit2Sharp.Core
             byte[] target,
             UIntPtr outlen,
             GitRefSpecHandle refSpec,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string name);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name);
 
         [DllImport(libgit2)]
         internal static extern int git_remote_autotag(RemoteSafeHandle remote);
@@ -778,8 +778,8 @@ namespace LibGit2Sharp.Core
         internal static extern int git_remote_create(
             out RemoteSafeHandle remote,
             RepositorySafeHandle repo,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string name,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string url);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string url);
 
         [DllImport(libgit2)]
         internal static extern void git_remote_disconnect(RemoteSafeHandle remote);
@@ -796,13 +796,13 @@ namespace LibGit2Sharp.Core
 
         [DllImport(libgit2)]
         internal static extern int git_remote_is_valid_name(
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string remote_name);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string remote_name);
 
         [DllImport(libgit2)]
         internal static extern int git_remote_load(
             out RemoteSafeHandle remote,
             RepositorySafeHandle repo,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string name);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name);
 
         internal delegate int git_headlist_cb(ref GitRemoteHead remoteHeadPtr, IntPtr payload);
 
@@ -810,14 +810,14 @@ namespace LibGit2Sharp.Core
         internal static extern int git_remote_ls(RemoteSafeHandle remote, git_headlist_cb headlist_cb, IntPtr payload);
 
         [DllImport(libgit2)]
-        [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8NoCleanupMarshaler))]
+        [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))]
         internal static extern string git_remote_name(RemoteSafeHandle remote);
 
         [DllImport(libgit2)]
         internal static extern int git_remote_save(RemoteSafeHandle remote);
 
         [DllImport(libgit2)]
-        [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8NoCleanupMarshaler))]
+        [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))]
         internal static extern string git_remote_url(RemoteSafeHandle remote);
 
         [DllImport(libgit2)]
@@ -831,7 +831,7 @@ namespace LibGit2Sharp.Core
         [DllImport(libgit2)]
         internal static extern int git_remote_add_fetch(
             RemoteSafeHandle remote,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof (Utf8Marshaler))] string refspec);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof (StrictUtf8Marshaler))] string refspec);
 
         internal delegate void remote_progress_callback(IntPtr str, int len, IntPtr data);
 
@@ -850,9 +850,9 @@ namespace LibGit2Sharp.Core
         internal static extern int git_repository_discover(
             byte[] repository_path, // NB: This is more properly a StringBuilder, but it's UTF8
             UIntPtr size,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(FilePathMarshaler))] FilePath start_path,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath start_path,
             [MarshalAs(UnmanagedType.Bool)] bool across_fs,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(FilePathMarshaler))] FilePath ceiling_dirs);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath ceiling_dirs);
 
         internal delegate int git_repository_fetchhead_foreach_cb(
             IntPtr remote_name,
@@ -882,7 +882,7 @@ namespace LibGit2Sharp.Core
         [DllImport(libgit2)]
         internal static extern int git_repository_init_ext(
             out RepositorySafeHandle repository,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(FilePathMarshaler))] FilePath path,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath path,
             GitRepositoryInitOptions options);
 
         [DllImport(libgit2)]
@@ -919,17 +919,17 @@ namespace LibGit2Sharp.Core
         [DllImport(libgit2)]
         internal static extern int git_repository_open(
             out RepositorySafeHandle repository,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(FilePathMarshaler))] FilePath path);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath path);
 
         [DllImport(libgit2)]
         internal static extern int git_repository_open_ext(
             NullRepositorySafeHandle repository,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(FilePathMarshaler))] FilePath path,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath path,
             RepositoryOpenFlags flags,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(FilePathMarshaler))] FilePath ceilingDirs);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath ceilingDirs);
 
         [DllImport(libgit2)]
-        [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(FilePathNoCleanupMarshaler))]
+        [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxFilePathNoCleanupMarshaler))]
         internal static extern FilePath git_repository_path(RepositorySafeHandle repository);
 
         [DllImport(libgit2)]
@@ -945,7 +945,7 @@ namespace LibGit2Sharp.Core
         [DllImport(libgit2)]
         internal static extern int git_repository_set_workdir(
             RepositorySafeHandle repository,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(FilePathMarshaler))] FilePath workdir,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath workdir,
             bool update_gitlink);
 
         [DllImport(libgit2)]
@@ -953,7 +953,7 @@ namespace LibGit2Sharp.Core
             RepositorySafeHandle repository);
 
         [DllImport(libgit2)]
-        [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(FilePathNoCleanupMarshaler))]
+        [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxFilePathNoCleanupMarshaler))]
         internal static extern FilePath git_repository_workdir(RepositorySafeHandle repository);
 
         [DllImport(libgit2)]
@@ -967,7 +967,7 @@ namespace LibGit2Sharp.Core
             out GitObjectSafeHandle obj,
             out ReferenceSafeHandle reference,
             RepositorySafeHandle repo,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string spec);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string spec);
 
         [DllImport(libgit2)]
         internal static extern void git_revwalk_free(IntPtr walker);
@@ -996,8 +996,8 @@ namespace LibGit2Sharp.Core
         [DllImport(libgit2)]
         internal static extern int git_signature_new(
             out SignatureSafeHandle signature,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string name,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string email,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string email,
             long time,
             int offset);
 
@@ -1006,7 +1006,7 @@ namespace LibGit2Sharp.Core
             out GitOid id,
             RepositorySafeHandle repo,
             SignatureSafeHandle stasher,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string message,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string message,
             StashModifiers flags);
 
         internal delegate int git_stash_cb(
@@ -1028,7 +1028,7 @@ namespace LibGit2Sharp.Core
         internal static extern int git_status_file(
             out FileStatus statusflags,
             RepositorySafeHandle repo,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(FilePathMarshaler))] FilePath filepath);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath filepath);
 
         internal delegate int git_status_cb(
             IntPtr path,
@@ -1042,7 +1042,7 @@ namespace LibGit2Sharp.Core
         internal static extern int git_submodule_lookup(
             out SubmoduleSafeHandle reference,
             RepositorySafeHandle repo,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(FilePathMarshaler))] FilePath name);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath name);
 
         internal delegate int submodule_callback(
             IntPtr sm,
@@ -1065,12 +1065,12 @@ namespace LibGit2Sharp.Core
             SubmoduleSafeHandle submodule);
 
         [DllImport(libgit2)]
-        [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8NoCleanupMarshaler))]
+        [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))]
         internal static extern string git_submodule_path(
             SubmoduleSafeHandle submodule);
 
         [DllImport(libgit2)]
-        [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8NoCleanupMarshaler))]
+        [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))]
         internal static extern string git_submodule_url(
             SubmoduleSafeHandle submodule);
 
@@ -1111,19 +1111,19 @@ namespace LibGit2Sharp.Core
         internal static extern int git_tag_annotation_create(
             out GitOid oid,
             RepositorySafeHandle repo,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string name,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name,
             GitObjectSafeHandle target,
             SignatureSafeHandle signature,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string message);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string message);
 
         [DllImport(libgit2)]
         internal static extern int git_tag_create(
             out GitOid oid,
             RepositorySafeHandle repo,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string name,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name,
             GitObjectSafeHandle target,
             SignatureSafeHandle signature,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string message,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string message,
             [MarshalAs(UnmanagedType.Bool)]
             bool force);
 
@@ -1131,7 +1131,7 @@ namespace LibGit2Sharp.Core
         internal static extern int git_tag_create_lightweight(
             out GitOid oid,
             RepositorySafeHandle repo,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string name,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name,
             GitObjectSafeHandle target,
             [MarshalAs(UnmanagedType.Bool)]
             bool force);
@@ -1139,14 +1139,14 @@ namespace LibGit2Sharp.Core
         [DllImport(libgit2)]
         internal static extern int git_tag_delete(
             RepositorySafeHandle repo,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string tagName);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string tagName);
 
         [DllImport(libgit2)]
-        [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8NoCleanupMarshaler))]
+        [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))]
         internal static extern string git_tag_message(GitObjectSafeHandle tag);
 
         [DllImport(libgit2)]
-        [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8NoCleanupMarshaler))]
+        [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))]
         internal static extern string git_tag_name(GitObjectSafeHandle tag);
 
         [DllImport(libgit2)]
@@ -1176,7 +1176,7 @@ namespace LibGit2Sharp.Core
         internal static extern int git_tree_entry_bypath(
             out TreeEntrySafeHandle_Owned tree,
             GitObjectSafeHandle root,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(FilePathMarshaler))] FilePath treeentry_path);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath treeentry_path);
 
         [DllImport(libgit2)]
         internal static extern void git_tree_entry_free(IntPtr treeEntry);
@@ -1185,7 +1185,7 @@ namespace LibGit2Sharp.Core
         internal static extern OidSafeHandle git_tree_entry_id(SafeHandle entry);
 
         [DllImport(libgit2)]
-        [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8NoCleanupMarshaler))]
+        [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))]
         internal static extern string git_tree_entry_name(SafeHandle entry);
 
         [DllImport(libgit2)]
@@ -1201,7 +1201,7 @@ namespace LibGit2Sharp.Core
         internal static extern int git_treebuilder_insert(
             IntPtr entry_out,
             TreeBuilderSafeHandle builder,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(Utf8Marshaler))] string treeentry_name,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string treeentry_name,
             ref GitOid id,
             uint attributes);
 

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -158,7 +158,7 @@ namespace LibGit2Sharp.Core
                 int res = NativeMethods.git_branch_remote_name(buffer, (UIntPtr)buffer.Length, repo, canonical_branch_name);
                 Ensure.Int32Result(res);
 
-                return Utf8Marshaler.Utf8FromBuffer(buffer) ?? string.Empty;
+                return LaxUtf8Marshaler.FromBuffer(buffer) ?? string.Empty;
             }
         }
 
@@ -182,7 +182,7 @@ namespace LibGit2Sharp.Core
                     buffer, (UIntPtr)buffer.Length, handle, canonicalReferenceName);
                 Ensure.Int32Result(res);
 
-                return Utf8Marshaler.Utf8FromBuffer(buffer);
+                return LaxUtf8Marshaler.FromBuffer(buffer);
             }
         }
 
@@ -335,17 +335,17 @@ namespace LibGit2Sharp.Core
             }
         }
 
-        public static string git_config_find_global()
+        public static FilePath git_config_find_global()
         {
             return ConvertPath(NativeMethods.git_config_find_global);
         }
 
-        public static string git_config_find_system()
+        public static FilePath git_config_find_system()
         {
             return ConvertPath(NativeMethods.git_config_find_system);
         }
 
-        public static string git_config_find_xdg()
+        public static FilePath git_config_find_xdg()
         {
             return ConvertPath(NativeMethods.git_config_find_xdg);
         }
@@ -377,8 +377,8 @@ namespace LibGit2Sharp.Core
 
             GitConfigEntry entry = handle.MarshalAsGitConfigEntry();
 
-            return new ConfigurationEntry<T>(Utf8Marshaler.FromNative(entry.namePtr),
-                (T)configurationParser[typeof(T)](Utf8Marshaler.FromNative(entry.valuePtr)),
+            return new ConfigurationEntry<T>(LaxUtf8Marshaler.FromNative(entry.namePtr),
+                (T)configurationParser[typeof(T)](LaxUtf8Marshaler.FromNative(entry.valuePtr)),
                 (ConfigurationLevel)entry.level);
         }
 
@@ -855,7 +855,7 @@ namespace LibGit2Sharp.Core
                 int res = NativeMethods.git_message_prettify(buffer, (UIntPtr)buffer.Length, message, false);
                 Ensure.Int32Result(res);
 
-                return Utf8Marshaler.Utf8FromBuffer(buffer) ?? string.Empty;
+                return LaxUtf8Marshaler.FromBuffer(buffer) ?? string.Empty;
             }
         }
 
@@ -1368,7 +1368,7 @@ namespace LibGit2Sharp.Core
                 int res = NativeMethods.git_refspec_rtransform(buffer, (UIntPtr)buffer.Length, refSpecPtr, name);
                 Ensure.ZeroResult(res);
 
-                return Utf8Marshaler.Utf8FromBuffer(buffer) ?? string.Empty;
+                return LaxUtf8Marshaler.FromBuffer(buffer) ?? string.Empty;
             }
         }
 
@@ -1549,7 +1549,7 @@ namespace LibGit2Sharp.Core
                 c => NativeMethods.git_repository_fetchhead_foreach(
                     repo,
                     (IntPtr w, IntPtr x, ref GitOid y, bool z, IntPtr p)
-                        => c(Utf8Marshaler.FromNative(w), Utf8Marshaler.FromNative(x), y, z, p), IntPtr.Zero),
+                        => c(LaxUtf8Marshaler.FromNative(w), LaxUtf8Marshaler.FromNative(x), y, z, p), IntPtr.Zero),
                     GitErrorCode.NotFound);
         }
 
@@ -1647,7 +1647,7 @@ namespace LibGit2Sharp.Core
                     throw new LibGit2SharpException("Repository message file changed as we were reading it");
                 }
 
-                return Utf8Marshaler.Utf8FromBuffer(buf);
+                return LaxUtf8Marshaler.FromBuffer(buf);
             }
         }
 
@@ -2400,7 +2400,7 @@ namespace LibGit2Sharp.Core
                     var list = new List<string>(numberOfEntries);
                     for (uint i = 0; i < numberOfEntries; i++)
                     {
-                        var name = Utf8Marshaler.FromNative((IntPtr)gitStrArray->strings[i]);
+                        var name = LaxUtf8Marshaler.FromNative((IntPtr)gitStrArray->strings[i]);
                         list.Add(name);
                     }
 
@@ -2424,7 +2424,7 @@ namespace LibGit2Sharp.Core
             }
         }
 
-        private static string ConvertPath(Func<byte[], UIntPtr, int> pathRetriever)
+        private static FilePath ConvertPath(Func<byte[], UIntPtr, int> pathRetriever)
         {
             using (ThreadAffinity())
             {
@@ -2439,7 +2439,7 @@ namespace LibGit2Sharp.Core
 
                 Ensure.ZeroResult(result);
 
-                return Utf8Marshaler.Utf8FromBuffer(buffer);
+                return LaxFilePathMarshaler.FromBuffer(buffer);
             }
         }
 

--- a/LibGit2Sharp/Index.cs
+++ b/LibGit2Sharp/Index.cs
@@ -549,7 +549,7 @@ namespace LibGit2Sharp
             {
                 Mode = (uint)treeEntryChanges.OldMode,
                 oid = treeEntryChanges.OldOid.Oid,
-                Path = FilePathMarshaler.FromManaged(treeEntryChanges.OldPath),
+                Path = StrictFilePathMarshaler.FromManaged(treeEntryChanges.OldPath),
             };
 
             Proxy.git_index_add(handle, indexEntry);

--- a/LibGit2Sharp/IndexEntry.cs
+++ b/LibGit2Sharp/IndexEntry.cs
@@ -44,7 +44,7 @@ namespace LibGit2Sharp
 
             GitIndexEntry entry = handle.MarshalAsGitIndexEntry();
 
-            FilePath path = Utf8Marshaler.FromNative(entry.Path);
+            FilePath path = LaxFilePathMarshaler.FromNative(entry.Path);
 
             return new IndexEntry
                        {

--- a/LibGit2Sharp/MatchedPathsAggregator.cs
+++ b/LibGit2Sharp/MatchedPathsAggregator.cs
@@ -19,7 +19,7 @@ namespace LibGit2Sharp
         internal int OnGitDiffNotify(IntPtr diffListSoFar, IntPtr deltaToAdd, IntPtr matchedPathspec, IntPtr payload)
         {
             // Convert null strings into empty strings.
-            var path = (matchedPathspec != IntPtr.Zero) ? FilePathMarshaler.FromNative(matchedPathspec) : FilePath.Empty;
+            var path = LaxFilePathMarshaler.FromNative(matchedPathspec) ?? FilePath.Empty;
 
             if (matchedPaths.Contains(path))
             {

--- a/LibGit2Sharp/Network.cs
+++ b/LibGit2Sharp/Network.cs
@@ -77,7 +77,7 @@ namespace LibGit2Sharp
                     }
 
                     ObjectId oid = remoteHead.Oid;
-                    string name = Utf8Marshaler.FromNative(remoteHead.NamePtr);
+                    string name = LaxUtf8Marshaler.FromNative(remoteHead.NamePtr);
                     directReferences.Add(new DirectReference(name, this.repository, oid));
 
                     return 0;
@@ -281,8 +281,8 @@ namespace LibGit2Sharp
                 // that there was an error.
                 if (msgPtr != IntPtr.Zero)
                 {
-                    string referenceName = Utf8Marshaler.FromNative(referenceNamePtr);
-                    string msg = Utf8Marshaler.FromNative(msgPtr);
+                    string referenceName = LaxUtf8Marshaler.FromNative(referenceNamePtr);
+                    string msg = LaxUtf8Marshaler.FromNative(msgPtr);
                     onError(new PushStatusError(referenceName, msg));
                 }
 

--- a/LibGit2Sharp/Patch.cs
+++ b/LibGit2Sharp/Patch.cs
@@ -45,7 +45,7 @@ namespace LibGit2Sharp
 
         private void AddFileChange(GitDiffDelta delta)
         {
-            var newFilePath = FilePathMarshaler.FromNative(delta.NewFile.Path);
+            var newFilePath = LaxFilePathMarshaler.FromNative(delta.NewFile.Path);
 
             changes.Add(newFilePath, new ContentChanges(delta.IsBinary()));
         }
@@ -53,7 +53,7 @@ namespace LibGit2Sharp
         private int DataCallback(GitDiffDelta delta, GitDiffRange range, GitDiffLineOrigin lineOrigin, IntPtr content,
             UIntPtr contentLen, IntPtr payload)
         {
-            var filePath = FilePathMarshaler.FromNative(delta.NewFile.Path);
+            var filePath = LaxFilePathMarshaler.FromNative(delta.NewFile.Path);
             AddLineChange(this[filePath], lineOrigin);
 
             return 0;
@@ -77,8 +77,8 @@ namespace LibGit2Sharp
 
         private int PrintCallBack(GitDiffDelta delta, GitDiffRange range, GitDiffLineOrigin lineorigin, IntPtr content, UIntPtr contentlen, IntPtr payload)
         {
-            string formattedoutput = Utf8Marshaler.FromNative(content, (int)contentlen);
-            var filePath = FilePathMarshaler.FromNative(delta.NewFile.Path);
+            string formattedoutput = LaxUtf8Marshaler.FromNative(content, (int)contentlen);
+            var filePath = LaxFilePathMarshaler.FromNative(delta.NewFile.Path);
 
             fullPatchBuilder.Append(formattedoutput);
             this[filePath].AppendToPatch(formattedoutput);

--- a/LibGit2Sharp/ReferenceCollection.cs
+++ b/LibGit2Sharp/ReferenceCollection.cs
@@ -267,7 +267,7 @@ namespace LibGit2Sharp
         {
             Ensure.ArgumentNotNullOrEmptyString(pattern, "pattern");
 
-            return Proxy.git_reference_foreach_glob(repo.Handle, pattern, Utf8Marshaler.FromNative)
+            return Proxy.git_reference_foreach_glob(repo.Handle, pattern, LaxUtf8Marshaler.FromNative)
                 .Select(n => this[n]);
         }
 

--- a/LibGit2Sharp/RemoteCallbacks.cs
+++ b/LibGit2Sharp/RemoteCallbacks.cs
@@ -104,7 +104,7 @@ namespace LibGit2Sharp
 
             if (onProgress != null)
             {
-                string message = Utf8Marshaler.FromNative(str, len);
+                string message = LaxUtf8Marshaler.FromNative(str, len);
                 onProgress(message);
             }
         }
@@ -126,7 +126,7 @@ namespace LibGit2Sharp
 
             if (onUpdateTips != null)
             {
-                string refName = Utf8Marshaler.FromNative(str);
+                string refName = LaxUtf8Marshaler.FromNative(str);
                 result = onUpdateTips(refName, oldId, newId);
             }
 

--- a/LibGit2Sharp/RepositoryStatus.cs
+++ b/LibGit2Sharp/RepositoryStatus.cs
@@ -56,7 +56,7 @@ namespace LibGit2Sharp
 
         private StatusEntry StateChanged(IntPtr filePathPtr, uint state)
         {
-            FilePath filePath = Utf8Marshaler.FromNative(filePathPtr);
+            FilePath filePath = LaxFilePathMarshaler.FromNative(filePathPtr);
             var gitStatus = (FileStatus)state;
 
             foreach (KeyValuePair<FileStatus, Action<RepositoryStatus, string>> kvp in dispatcher)

--- a/LibGit2Sharp/Signature.cs
+++ b/LibGit2Sharp/Signature.cs
@@ -22,8 +22,8 @@ namespace LibGit2Sharp
             var handle = new GitSignature();
             Marshal.PtrToStructure(signaturePtr, handle);
 
-            name = Utf8Marshaler.FromNative(handle.Name);
-            email = Utf8Marshaler.FromNative(handle.Email);
+            name = LaxUtf8Marshaler.FromNative(handle.Name);
+            email = LaxUtf8Marshaler.FromNative(handle.Email);
             when = Epoch.ToDateTimeOffset(handle.When.Time, handle.When.Offset);
         }
 

--- a/LibGit2Sharp/SubmoduleCollection.cs
+++ b/LibGit2Sharp/SubmoduleCollection.cs
@@ -54,7 +54,7 @@ namespace LibGit2Sharp
         /// <returns>An <see cref="IEnumerator{T}"/> object that can be used to iterate through the collection.</returns>
         public IEnumerator<Submodule> GetEnumerator()
         {
-            return Proxy.git_submodule_foreach(repo.Handle, (h, n) => Utf8Marshaler.FromNative(n))
+            return Proxy.git_submodule_foreach(repo.Handle, (h, n) => LaxUtf8Marshaler.FromNative(n))
                         .Select(n => this[n])
                         .GetEnumerator();
         }

--- a/LibGit2Sharp/TreeChanges.cs
+++ b/LibGit2Sharp/TreeChanges.cs
@@ -57,9 +57,9 @@ namespace LibGit2Sharp
 
         private void AddFileChange(GitDiffDelta delta)
         {
-            var newFilePath = FilePathMarshaler.FromNative(delta.NewFile.Path);
+            var newFilePath = LaxFilePathMarshaler.FromNative(delta.NewFile.Path);
 
-            var oldFilePath = FilePathMarshaler.FromNative(delta.OldFile.Path);
+            var oldFilePath = LaxFilePathMarshaler.FromNative(delta.OldFile.Path);
             var newMode = (Mode)delta.NewFile.Mode;
             var oldMode = (Mode)delta.OldFile.Mode;
             var newOid = delta.NewFile.Oid;


### PR DESCRIPTION
This PR started as an attempt to deal with #530.

Eventually, honoring i18n.commitEncoding turned out to be unnecessary while crafting a commit. This PR morphed into segregating the Marshalers into Strict and Lax categories.
- Strict encoding will be used when passing data to libgit2 (and throw when the passed in string cannot be converted into UTF-8 bytes)
- Lax encoding will be used when retrieving data from libgit2 (and convert (mangle) the data without throwing)
