### PR TITLE
Allow push APIs to set packbuilder parallelism

### DIFF
--- a/LibGit2Sharp/Core/GitPushOptions.cs
+++ b/LibGit2Sharp/Core/GitPushOptions.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace LibGit2Sharp.Core
+{
+    [StructLayout(LayoutKind.Sequential)]
+    internal class GitPushOptions
+    {
+        public int Version = 1;
+        public int PackbuilderDegreeOfParallelism;
+    }
+}

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -617,6 +617,9 @@ namespace LibGit2Sharp.Core
         internal static extern int git_push_new(out PushSafeHandle push, RemoteSafeHandle remote);
 
         [DllImport(libgit2)]
+        internal static extern int git_push_set_options(PushSafeHandle push, GitPushOptions options);
+
+        [DllImport(libgit2)]
         internal static extern int git_push_add_refspec(
             PushSafeHandle push,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string pushRefSpec);

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -1111,6 +1111,15 @@ namespace LibGit2Sharp.Core
             }
         }
 
+        public static void git_push_set_options(PushSafeHandle push, GitPushOptions options)
+        {
+            using (ThreadAffinity())
+            {
+                int res = NativeMethods.git_push_set_options(push, options);
+                Ensure.ZeroResult(res);
+            }
+        }
+
         public static void git_push_status_foreach(PushSafeHandle push, NativeMethods.push_status_foreach_cb status_cb)
         {
             using (ThreadAffinity())

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -72,6 +72,7 @@
     <Compile Include="CommitSortStrategies.cs" />
     <Compile Include="CompareOptions.cs" />
     <Compile Include="Core\EncodingMarshaler.cs" />
+    <Compile Include="PushOptions.cs" />
     <Compile Include="UnbornBranchException.cs" />
     <Compile Include="LockedFileException.cs" />
     <Compile Include="Core\GitRepositoryInitOptions.cs" />
@@ -104,6 +105,7 @@
     <Compile Include="MatchedPathsAggregator.cs" />
     <Compile Include="Core\Handles\SubmoduleSafeHandle.cs" />
     <Compile Include="Core\SubmoduleLazyGroup.cs" />
+    <Compile Include="Core\GitPushOptions.cs" />
     <Compile Include="Network.cs" />
     <Compile Include="Core\GitRemoteHead.cs" />
     <Compile Include="ReflogEntry.cs" />

--- a/LibGit2Sharp/NetworkExtensions.cs
+++ b/LibGit2Sharp/NetworkExtensions.cs
@@ -17,15 +17,15 @@ namespace LibGit2Sharp
         /// <param name="network">The <see cref="Network"/> being worked with.</param>
         /// <param name="branch">The branch to push.</param>
         /// <param name="onPushStatusError">Handler for reporting failed push updates.</param>
-        /// <param name="credentials">Credentials to use for user/pass authentication.</param>
+        /// <param name="pushOptions"><see cref="PushOptions"/> controlling push behavior</param>
         /// <exception cref="LibGit2SharpException">Throws if either the Remote or the UpstreamBranchCanonicalName is not set.</exception>
         public static void Push(
             this Network network,
             Branch branch,
             PushStatusErrorHandler onPushStatusError = null,
-            Credentials credentials = null)
+            PushOptions pushOptions = null)
         {
-            network.Push(new[] { branch }, onPushStatusError, credentials);
+            network.Push(new[] { branch }, onPushStatusError, pushOptions);
         }
 
         /// <summary>
@@ -34,13 +34,13 @@ namespace LibGit2Sharp
         /// <param name="network">The <see cref="Network"/> being worked with.</param>
         /// <param name="branches">The branches to push.</param>
         /// <param name="onPushStatusError">Handler for reporting failed push updates.</param>
-        /// <param name="credentials">Credentials to use for user/pass authentication.</param>
+        /// <param name="pushOptions"><see cref="PushOptions"/> controlling push behavior</param>
         /// <exception cref="LibGit2SharpException">Throws if either the Remote or the UpstreamBranchCanonicalName is not set.</exception>
         public static void Push(
             this Network network,
             IEnumerable<Branch> branches,
             PushStatusErrorHandler onPushStatusError = null,
-            Credentials credentials = null)
+            PushOptions pushOptions = null)
         {
             var enumeratedBranches = branches as IList<Branch> ?? branches.ToList();
 
@@ -55,7 +55,7 @@ namespace LibGit2Sharp
 
             foreach (var branch in enumeratedBranches)
             {
-                network.Push(branch.Remote, string.Format("{0}:{1}", branch.CanonicalName, branch.UpstreamBranchCanonicalName), onPushStatusError, credentials);
+                network.Push(branch.Remote, string.Format("{0}:{1}", branch.CanonicalName, branch.UpstreamBranchCanonicalName), onPushStatusError, pushOptions);
             }
         }
 
@@ -66,21 +66,21 @@ namespace LibGit2Sharp
         /// <param name="remote">The <see cref="Remote"/> to push to.</param>
         /// <param name="objectish">The source objectish to push.</param>
         /// <param name="destinationSpec">The reference to update on the remote.</param>
-        /// <param name="credentials">Credentials to use for user/pass authentication</param>
+        /// <param name="pushOptions"><see cref="PushOptions"/> controlling push behavior</param>
         /// <returns>Results of the push operation.</returns>
         public static PushResult Push(
             this Network network,
             Remote remote,
             string objectish,
             string destinationSpec,
-            Credentials credentials = null)
+            PushOptions pushOptions = null)
         {
             Ensure.ArgumentNotNull(remote, "remote");
             Ensure.ArgumentNotNull(objectish, "objectish");
             Ensure.ArgumentNotNullOrEmptyString(destinationSpec, "destinationSpec");
 
             return network.Push(remote, string.Format(CultureInfo.InvariantCulture,
-                "{0}:{1}", objectish, destinationSpec), credentials);
+                "{0}:{1}", objectish, destinationSpec), pushOptions);
         }
 
         /// <summary>
@@ -89,14 +89,18 @@ namespace LibGit2Sharp
         /// <param name="network">The <see cref="Network"/> being worked with.</param>
         /// <param name="remote">The <see cref="Remote"/> to push to.</param>
         /// <param name="pushRefSpec">The pushRefSpec to push.</param>
-        /// <param name="credentials">Credentials to use for user/pass authentication</param>
+        /// <param name="pushOptions"><see cref="PushOptions"/> controlling push behavior</param>
         /// <returns>Results of the push operation.</returns>
-        public static PushResult Push(this Network network, Remote remote, string pushRefSpec, Credentials credentials = null)
+        public static PushResult Push(
+            this Network network,
+            Remote remote,
+            string pushRefSpec,
+            PushOptions pushOptions = null)
         {
             Ensure.ArgumentNotNull(remote, "remote");
             Ensure.ArgumentNotNullOrEmptyString(pushRefSpec, "pushRefSpec");
 
-            return network.Push(remote, new[] { pushRefSpec }, credentials);
+            return network.Push(remote, new string[] { pushRefSpec }, pushOptions);
         }
 
         /// <summary>
@@ -105,9 +109,13 @@ namespace LibGit2Sharp
         /// <param name="network">The <see cref="Network"/> being worked with.</param>
         /// <param name="remote">The <see cref="Remote"/> to push to.</param>
         /// <param name="pushRefSpecs">The pushRefSpecs to push.</param>
-        /// <param name="credentials">Credentials to use for user/pass authentication</param>
+        /// <param name="pushOptions"><see cref="PushOptions"/> controlling push behavior</param>
         /// <returns>Results of the push operation.</returns>
-        public static PushResult Push(this Network network, Remote remote, IEnumerable<string> pushRefSpecs, Credentials credentials = null)
+        public static PushResult Push(
+            this Network network,
+            Remote remote,
+            IEnumerable<string> pushRefSpecs,
+            PushOptions pushOptions = null)
         {
             Ensure.ArgumentNotNull(remote, "remote");
             Ensure.ArgumentNotNull(pushRefSpecs, "pushRefSpecs");
@@ -118,7 +126,7 @@ namespace LibGit2Sharp
                 remote,
                 pushRefSpecs,
                 failedRemoteUpdates.Add,
-                credentials);
+                pushOptions);
 
             return new PushResult(failedRemoteUpdates);
         }

--- a/LibGit2Sharp/PushOptions.cs
+++ b/LibGit2Sharp/PushOptions.cs
@@ -1,0 +1,24 @@
+﻿using LibGit2Sharp.Handlers;
+
+namespace LibGit2Sharp
+{
+    /// <summary>
+    /// Collection of parameters controlling Push behavior.
+    /// </summary>
+    public sealed class PushOptions
+    {
+        /// <summary>
+        /// The <see cref="Credentials"/> to authenticate with during the push.
+        /// </summary>
+        public Credentials Credentials { get; set; }
+
+        /// <summary>
+        /// If the transport being used to push to the remote requires the creation
+        /// of a pack file, this controls the number of worker threads used by
+        /// the packbuilder when creating that pack file to be sent to the remote.
+        /// The default is 0, which indicates that the packbuilder will auto-detect
+        /// the number of threads to create.
+        /// </summary>
+        public int PackbuilderDegreeOfParallelism { get; set; }
+    }
+}


### PR DESCRIPTION
We want to crank up the parallelism of the packbuilder when we do pushes!
