### PR TITLE
Rename methods of Blob and BlobExtensions

### DIFF
--- a/LibGit2Sharp.Tests/AttributesFixture.cs
+++ b/LibGit2Sharp.Tests/AttributesFixture.cs
@@ -40,7 +40,7 @@ namespace LibGit2Sharp.Tests
             var blob = repo.Lookup<Blob>(entry.Id);
             Assert.NotNull(blob);
 
-            Assert.Equal(!shouldHaveBeenNormalized, blob.ContentAsText().Contains("\r"));
+            Assert.Equal(!shouldHaveBeenNormalized, blob.GetContentText().Contains("\r"));
         }
 
         private static void CreateAttributesFile(Repository repo)

--- a/LibGit2Sharp.Tests/CommitFixture.cs
+++ b/LibGit2Sharp.Tests/CommitFixture.cs
@@ -480,7 +480,7 @@ namespace LibGit2Sharp.Tests
                 var blob = commit["1/branch_file.txt"].Target as Blob;
                 Assert.NotNull(blob);
 
-                Assert.Equal("hi\n", blob.ContentAsText());
+                Assert.Equal("hi\n", blob.GetContentText());
             }
         }
 
@@ -694,7 +694,7 @@ namespace LibGit2Sharp.Tests
         private static void AssertBlobContent(TreeEntry entry, string expectedContent)
         {
             Assert.Equal(TreeEntryTargetType.Blob, entry.TargetType);
-            Assert.Equal(expectedContent, ((Blob)(entry.Target)).ContentAsText());
+            Assert.Equal(expectedContent, ((Blob)(entry.Target)).GetContentText());
         }
 
         private static void AddCommitToRepo(string path)

--- a/LibGit2Sharp.Tests/DiffTreeToTreeFixture.cs
+++ b/LibGit2Sharp.Tests/DiffTreeToTreeFixture.cs
@@ -466,7 +466,10 @@ namespace LibGit2Sharp.Tests
                 // Recreate the file in the workdir without the executable bit
                 string fullpath = Path.Combine(repo.Info.WorkingDirectory, file);
                 File.Delete(fullpath);
-                File.WriteAllBytes(fullpath, ((Blob)(entry.Target)).Content);
+                using (var stream = ((Blob)(entry.Target)).GetContentStream())
+                {
+                    Touch(repo.Info.WorkingDirectory, file, stream);
+                }
 
                 // Unset the local core.filemode, if any.
                 repo.Config.Unset("core.filemode");

--- a/LibGit2Sharp.Tests/DiffWorkdirToIndexFixture.cs
+++ b/LibGit2Sharp.Tests/DiffWorkdirToIndexFixture.cs
@@ -114,7 +114,10 @@ namespace LibGit2Sharp.Tests
                 // Recreate the file in the workdir without the executable bit
                 string fullpath = Path.Combine(repo.Info.WorkingDirectory, file);
                 File.Delete(fullpath);
-                File.WriteAllBytes(fullpath, ((Blob)(entry.Target)).Content);
+                using (var stream = ((Blob)(entry.Target)).GetContentStream())
+                {
+                    Touch(repo.Info.WorkingDirectory, file, stream);
+                }
 
                 // Unset the local core.filemode, if any.
                 repo.Config.Unset("core.filemode", ConfigurationLevel.Local);

--- a/LibGit2Sharp.Tests/ObjectDatabaseFixture.cs
+++ b/LibGit2Sharp.Tests/ObjectDatabaseFixture.cs
@@ -69,7 +69,7 @@ namespace LibGit2Sharp.Tests
 
                 Assert.NotNull(blob);
                 Assert.Equal("dc53d4c6b8684c21b0b57db29da4a2afea011565", blob.Sha);
-                Assert.Equal("I'm a new file\n", blob.ContentAsText());
+                Assert.Equal("I'm a new file\n", blob.GetContentText());
 
                 var fetchedBlob = repo.Lookup<Blob>(blob.Id);
                 Assert.Equal(blob, fetchedBlob);

--- a/LibGit2Sharp.Tests/TestHelpers/BaseFixture.cs
+++ b/LibGit2Sharp.Tests/TestHelpers/BaseFixture.cs
@@ -270,6 +270,25 @@ namespace LibGit2Sharp.Tests.TestHelpers
             return filePath;
         }
 
+        protected static string Touch(string parent, string file, Stream stream)
+        {
+            Debug.Assert(stream != null);
+
+            string filePath = Path.Combine(parent, file);
+            string dir = Path.GetDirectoryName(filePath);
+            Debug.Assert(dir != null);
+
+            Directory.CreateDirectory(dir);
+
+            using (var fs = File.Open(filePath, FileMode.Create))
+            {
+                CopyStream(stream, fs);
+                fs.Flush();
+            }
+
+            return filePath;
+        }
+
         protected string Expected(string filename)
         {
             return File.ReadAllText(Path.Combine(ResourcesDirectory.FullName, "expected/" + filename));
@@ -304,6 +323,32 @@ namespace LibGit2Sharp.Tests.TestHelpers
         protected static void EnableRefLog(Repository repository, bool enable = true)
         {
             repository.Config.Set("core.logAllRefUpdates", enable);
+        }
+
+        public static void CopyStream(Stream input, Stream output)
+        {
+            // Reused from the following Stack Overflow post with permission
+            // of Jon Skeet (obtained on 25 Feb 2013)
+            // http://stackoverflow.com/questions/411592/how-do-i-save-a-stream-to-a-file/411605#411605
+            var buffer = new byte[8 * 1024];
+            int len;
+            while ((len = input.Read(buffer, 0, buffer.Length)) > 0)
+            {
+                output.Write(buffer, 0, len);
+            }
+        }
+
+        public static bool StreamEquals(Stream one, Stream two)
+        {
+            int onebyte, twobyte;
+
+            while ((onebyte = one.ReadByte()) >= 0 && (twobyte = two.ReadByte()) >= 0)
+            {
+                if (onebyte != twobyte)
+                    return false;
+            }
+
+            return true;
         }
     }
 }

--- a/LibGit2Sharp/Blob.cs
+++ b/LibGit2Sharp/Blob.cs
@@ -38,6 +38,7 @@ namespace LibGit2Sharp
         /// <summary>
         /// Gets the blob content in a <see cref="byte"/> array.
         /// </summary>
+        [Obsolete("This property will be removed in the next release. Please use one of the GetContentStream() overloads instead.")]
         public virtual byte[] Content
         {
             get
@@ -49,7 +50,7 @@ namespace LibGit2Sharp
         /// <summary>
         /// Gets the blob content in a <see cref="Stream"/>.
         /// </summary>
-        public virtual Stream ContentStream()
+        public virtual Stream GetContentStream()
         {
             return Proxy.git_blob_rawcontent_stream(repo.Handle, Id, Size);
         }
@@ -59,10 +60,22 @@ namespace LibGit2Sharp
         /// checked out to the working directory.
         /// <param name="filteringOptions">Parameter controlling content filtering behavior</param>
         /// </summary>
-        public virtual Stream ContentStream(FilteringOptions filteringOptions)
+        public virtual Stream GetContentStream(FilteringOptions filteringOptions)
         {
             Ensure.ArgumentNotNull(filteringOptions, "filteringOptions");
             return Proxy.git_blob_filtered_content_stream(repo.Handle, Id, filteringOptions.HintPath, false);
+        }
+
+        /// <summary>
+        /// Gets the blob content in a <see cref="Stream"/>.
+        /// </summary>
+        [Obsolete("This property will be removed in the next release. Please use one of the GetContentStream() overloads instead.")]
+        public virtual Stream ContentStream
+        {
+            get
+            {
+                return GetContentStream();
+            }
         }
     }
 }

--- a/LibGit2Sharp/BlobExtensions.cs
+++ b/LibGit2Sharp/BlobExtensions.cs
@@ -18,11 +18,11 @@ namespace LibGit2Sharp
         /// <param name="blob">The blob for which the content will be returned.</param>
         /// <param name="encoding">The encoding of the text. (default: detected or UTF8)</param>
         /// <returns>Blob content as text.</returns>
-        public static string ContentAsText(this Blob blob, Encoding encoding = null)
+        public static string GetContentText(this Blob blob, Encoding encoding = null)
         {
             Ensure.ArgumentNotNull(blob, "blob");
 
-            using (var reader = new StreamReader(blob.ContentStream(), encoding ?? Encoding.UTF8, encoding == null))
+            using (var reader = new StreamReader(blob.GetContentStream(), encoding ?? Encoding.UTF8, encoding == null))
             {
                 return reader.ReadToEnd();
             }
@@ -38,15 +38,45 @@ namespace LibGit2Sharp
         /// <param name="filteringOptions">Parameter controlling content filtering behavior</param>
         /// <param name="encoding">The encoding of the text. (default: detected or UTF8)</param>
         /// <returns>Blob content as text.</returns>
-        public static string ContentAsText(this Blob blob, FilteringOptions filteringOptions, Encoding encoding = null)
+        public static string GetContentText(this Blob blob, FilteringOptions filteringOptions, Encoding encoding = null)
         {
             Ensure.ArgumentNotNull(blob, "blob");
             Ensure.ArgumentNotNull(filteringOptions, "filteringOptions");
 
-            using(var reader = new StreamReader(blob.ContentStream(filteringOptions), encoding ?? Encoding.UTF8, encoding == null))
+            using (var reader = new StreamReader(blob.GetContentStream(filteringOptions), encoding ?? Encoding.UTF8, encoding == null))
             {
                 return reader.ReadToEnd();
             }
+        }
+
+        /// <summary>
+        /// Gets the blob content decoded with the specified encoding,
+        /// or according to byte order marks, with UTF8 as fallback,
+        /// if <paramref name="encoding"/> is null.
+        /// </summary>
+        /// <param name="blob">The blob for which the content will be returned.</param>
+        /// <param name="encoding">The encoding of the text. (default: detected or UTF8)</param>
+        /// <returns>Blob content as text.</returns>
+        [Obsolete("This method will be removed in the next release. Please use one of the GetContentText() overloads instead.")]
+        public static string ContentAsText(this Blob blob, Encoding encoding = null)
+        {
+            return GetContentText(blob, encoding);
+        }
+
+        /// <summary>
+        /// Gets the blob content as it would be checked out to the
+        /// working directory, decoded with the specified encoding,
+        /// or according to byte order marks, with UTF8 as fallback,
+        /// if <paramref name="encoding"/> is null.
+        /// </summary>
+        /// <param name="blob">The blob for which the content will be returned.</param>
+        /// <param name="filteringOptions">Parameter controlling content filtering behavior</param>
+        /// <param name="encoding">The encoding of the text. (default: detected or UTF8)</param>
+        /// <returns>Blob content as text.</returns>
+        [Obsolete("This method will be removed in the next release. Please use one of the GetContentText() overloads instead.")]
+        public static string ContentAsText(this Blob blob, FilteringOptions filteringOptions, Encoding encoding = null)
+        {
+            return GetContentText(blob, filteringOptions, encoding);
         }
     }
 }


### PR DESCRIPTION
Rename
1. `BlobExtensions` `ContentAsText()` -> `GetContentText()`
2. `Blob` `ContentStream` -> `GetContentStream()`

Obsolete
1. `Blob` `Content`
