### PR TITLE
Extension methods for NoteCollection using user from config 

### DIFF
--- a/LibGit2Sharp.Tests/TestHelpers/BaseFixture.cs
+++ b/LibGit2Sharp.Tests/TestHelpers/BaseFixture.cs
@@ -265,6 +265,27 @@ namespace LibGit2Sharp.Tests.TestHelpers
             };
         }
 
+        /// <summary>
+        /// Creates a configuration file with user.name and user.email set to signature
+        /// </summary>
+        /// <remarks>The configuration file will be removed automatically when the tests are finished</remarks>
+        /// <param name="signature">The signature to use for user.name and user.email</param>
+        /// <returns>The path to the configuration file</returns>
+        protected string CreateConfigurationWithDummyUser(Signature signature)
+        {
+            SelfCleaningDirectory scd = BuildSelfCleaningDirectory();
+            Directory.CreateDirectory(scd.DirectoryPath);
+            string configFilePath = Path.Combine(scd.DirectoryPath, "global-config");
+
+            using (Configuration config = new Configuration(configFilePath))
+            {
+                config.Set("user.name", signature.Name, ConfigurationLevel.Global);
+                config.Set("user.email", signature.Email, ConfigurationLevel.Global);
+            }
+
+            return configFilePath;
+        }
+
         protected static string Touch(string parent, string file, string content = null, Encoding encoding = null)
         {
             string filePath = Path.Combine(parent, file);

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Core\GitBuf.cs" />
     <Compile Include="FilteringOptions.cs" />
     <Compile Include="ResetMode.cs" />
+    <Compile Include="NoteCollectionExtensions.cs" />
     <Compile Include="UnbornBranchException.cs" />
     <Compile Include="LockedFileException.cs" />
     <Compile Include="Core\GitRepositoryInitOptions.cs" />

--- a/LibGit2Sharp/NoteCollection.cs
+++ b/LibGit2Sharp/NoteCollection.cs
@@ -16,7 +16,7 @@ namespace LibGit2Sharp
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class NoteCollection : IEnumerable<Note>
     {
-        private readonly Repository repo;
+        internal readonly Repository repo;
         private readonly Lazy<string> defaultNamespace;
 
         /// <summary>

--- a/LibGit2Sharp/NoteCollectionExtensions.cs
+++ b/LibGit2Sharp/NoteCollectionExtensions.cs
@@ -1,0 +1,40 @@
+﻿using System;
+
+namespace LibGit2Sharp
+{
+    /// <summary>
+    /// Provides helper overloads to a <see cref="NoteCollection"/>.
+    /// </summary>
+    public static class NoteCollectionExtensions
+    {
+        /// <summary>
+        /// Creates or updates a <see cref="Note"/> on the specified object, and for the given namespace.
+        /// <para>Both the Author and Committer will be guessed from the Git configuration. An exception will be raised if no configuration is reachable.</para>
+        /// </summary>
+        /// <param name="collection">The <see cref="NoteCollection"/></param>
+        /// <param name="targetId">The target <see cref="ObjectId"/>, for which the note will be created.</param>
+        /// <param name="message">The note message.</param>
+        /// <param name="namespace">The namespace on which the note will be created. It can be either a canonical namespace or an abbreviated namespace ('refs/notes/myNamespace' or just 'myNamespace').</param>
+        /// <returns>The note which was just saved.</returns>
+        public static Note Add(this NoteCollection collection, ObjectId targetId, string message, string @namespace)
+        {
+            Signature author = collection.repo.Config.BuildSignatureFromGlobalConfiguration(DateTimeOffset.Now, true);
+
+            return collection.Add(targetId, message, author, author, @namespace);
+        }
+
+        /// <summary>
+        /// Deletes the note on the specified object, and for the given namespace.
+        /// <para>Both the Author and Committer will be guessed from the Git configuration. An exception will be raised if no configuration is reachable.</para>
+        /// </summary>
+        /// <param name="collection">The <see cref="NoteCollection"/></param>
+        /// <param name="targetId">The target <see cref="ObjectId"/>, for which the note will be created.</param>
+        /// <param name="namespace">The namespace on which the note will be removed. It can be either a canonical namespace or an abbreviated namespace ('refs/notes/myNamespace' or just 'myNamespace').</param>
+        public static void Remove(this NoteCollection collection, ObjectId targetId, string @namespace)
+        {
+            Signature author = collection.repo.Config.BuildSignatureFromGlobalConfiguration(DateTimeOffset.Now, true);
+
+            collection.Remove(targetId, author, author, @namespace);
+        }
+    }
+}


### PR DESCRIPTION
Similar to `Repository.Commit`, `NoteCollectionExtensions.Add`/`Remove` guesses the committer and author signature from the global git config user.name / user.email. This allows modifying notes without specifying the commiter explicitly.
