### PR TITLE
Enumerate refspecs

### DIFF
--- a/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
+++ b/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
@@ -59,6 +59,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CheckoutFixture.cs" />
+    <Compile Include="RefSpecFixture.cs" />
     <Compile Include="EqualityFixture.cs" />
     <Compile Include="SignatureFixture.cs" />
     <Compile Include="FilterBranchFixture.cs" />

--- a/LibGit2Sharp.Tests/RefSpecFixture.cs
+++ b/LibGit2Sharp.Tests/RefSpecFixture.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Linq;
+using LibGit2Sharp.Tests.TestHelpers;
+using Xunit;
+
+namespace LibGit2Sharp.Tests
+{
+    public class RefSpecFixture : BaseFixture
+    {
+        [Fact]
+        public void CanCountRefSpecs()
+        {
+            var path = CloneStandardTestRepo();
+            using (var repo = new Repository(path))
+            {
+                var remote = repo.Network.Remotes["origin"];
+                Assert.Equal(1, remote.RefSpecs.Count());
+            }
+        }
+
+        [Fact]
+        public void CanIterateOverRefSpecs()
+        {
+            var path = CloneStandardTestRepo();
+            using (var repo = new Repository(path))
+            {
+                var remote = repo.Network.Remotes["origin"];
+                int count = 0;
+                foreach (RefSpec refSpec in remote.RefSpecs)
+                {
+                    Assert.NotNull(refSpec);
+                    count++;
+                }
+                Assert.Equal(1, count);
+            }
+        }
+
+        [Fact]
+        public void CanReadRefSpecDetails()
+        {
+            var path = CloneStandardTestRepo();
+            using (var repo = new Repository(path))
+            {
+                var remote = repo.Network.Remotes["origin"];
+
+                RefSpec refSpec = remote.RefSpecs.First();
+                Assert.NotNull(refSpec);
+
+                Assert.Equal("refs/heads/*", refSpec.Source);
+                Assert.Equal("refs/remotes/origin/*", refSpec.Destination);
+                Assert.Equal(true, refSpec.ForceUpdate);
+            }
+        }
+    }
+}

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -800,6 +800,27 @@ namespace LibGit2Sharp.Core
             UIntPtr outlen,
             GitRefSpecHandle refSpec,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name);
+  
+        [DllImport(libgit2)]
+        [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))]
+        internal static extern string git_refspec_string(
+            GitRefSpecHandle refSpec);
+
+        [DllImport(libgit2)]
+        internal static extern RefSpecDirection git_refspec_direction(GitRefSpecHandle refSpec);
+
+        [DllImport(libgit2)]
+        [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))]
+        internal static extern string git_refspec_dst(
+            GitRefSpecHandle refSpec);
+
+        [DllImport(libgit2)]
+        [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))]
+        internal static extern string git_refspec_src(
+            GitRefSpecHandle refSpec);
+
+        [DllImport(libgit2)]
+        internal static extern bool git_refspec_force(GitRefSpecHandle refSpec);
 
         [DllImport(libgit2)]
         internal static extern int git_remote_autotag(RemoteSafeHandle remote);
@@ -826,6 +847,9 @@ namespace LibGit2Sharp.Core
 
         [DllImport(libgit2)]
         internal static extern GitRefSpecHandle git_remote_get_refspec(RemoteSafeHandle remote, UIntPtr n);
+
+        [DllImport(libgit2)]
+        internal static extern UIntPtr git_remote_refspec_count(RemoteSafeHandle remote);
 
         [DllImport(libgit2)]
         internal static extern int git_remote_is_valid_name(

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -1462,6 +1462,31 @@ namespace LibGit2Sharp.Core
             }
         }
 
+        public static string git_refspec_string(GitRefSpecHandle refSpec)
+        {
+            return NativeMethods.git_refspec_string(refSpec);
+        }
+
+        public static string git_refspec_src(GitRefSpecHandle refSpec)
+        {
+            return NativeMethods.git_refspec_src(refSpec);
+        }
+
+        public static string git_refspec_dst(GitRefSpecHandle refSpec)
+        {
+            return NativeMethods.git_refspec_dst(refSpec);
+        }
+
+        public static RefSpecDirection git_refspec_direction(GitRefSpecHandle refSpec)
+        {
+            return NativeMethods.git_refspec_direction(refSpec);
+        }
+
+        public static bool git_refspec_force(GitRefSpecHandle refSpec)
+        {
+            return NativeMethods.git_refspec_force(refSpec);
+        }
+
         #endregion
 
         #region git_remote_
@@ -1503,6 +1528,11 @@ namespace LibGit2Sharp.Core
         public static GitRefSpecHandle git_remote_get_refspec(RemoteSafeHandle remote, int n)
         {
             return NativeMethods.git_remote_get_refspec(remote, (UIntPtr)n);
+        }
+
+        public static int git_remote_refspec_count(RemoteSafeHandle remote)
+        {
+            return (int)NativeMethods.git_remote_refspec_count(remote);
         }
 
         public static void git_remote_download(RemoteSafeHandle remote)

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -71,6 +71,8 @@
     <Compile Include="CommitFilter.cs" />
     <Compile Include="CommitSortStrategies.cs" />
     <Compile Include="CompareOptions.cs" />
+    <Compile Include="RefSpec.cs" />
+    <Compile Include="RefSpecCollection.cs" />
     <Compile Include="Core\EncodingMarshaler.cs" />
     <Compile Include="Core\Handles\BranchIteratorSafeHandle.cs" />
     <Compile Include="Core\PushTransferProgressCallbacks.cs" />
@@ -80,6 +82,7 @@
     <Compile Include="FilteringOptions.cs" />
     <Compile Include="ResetMode.cs" />
     <Compile Include="NoteCollectionExtensions.cs" />
+    <Compile Include="RefSpecDirection.cs" />
     <Compile Include="UnbornBranchException.cs" />
     <Compile Include="LockedFileException.cs" />
     <Compile Include="Core\GitRepositoryInitOptions.cs" />

--- a/LibGit2Sharp/RefSpec.cs
+++ b/LibGit2Sharp/RefSpec.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using LibGit2Sharp.Core;
+using LibGit2Sharp.Core.Handles;
+
+namespace LibGit2Sharp
+{
+    /// <summary>
+    /// A push or fetch reference specification
+    /// </summary>
+    public class RefSpec
+    {
+        private RefSpec(string refSpec, RefSpecDirection direction, string source, string destination, bool forceUpdate)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(refSpec, "refSpec");
+            Ensure.ArgumentNotNull(source, "source");
+            Ensure.ArgumentNotNull(destination, "destination");
+
+            Specification = refSpec;
+            Direction = direction;
+            Source = source;
+            Destination = destination;
+            ForceUpdate = forceUpdate;
+        }
+
+        /// <summary>
+        /// Needed for mocking purposes.
+        /// </summary>
+        protected RefSpec()
+        { }
+
+        internal static RefSpec BuildFromPtr(GitRefSpecHandle handle)
+        {
+            Ensure.ArgumentNotNull(handle, "handle");
+
+            return new RefSpec(Proxy.git_refspec_string(handle), Proxy.git_refspec_direction(handle),
+                Proxy.git_refspec_src(handle), Proxy.git_refspec_dst(handle), Proxy.git_refspec_force(handle));
+        }
+
+        /// <summary>
+        /// Gets the pattern describing the mapping between remote and local references
+        /// </summary>
+        public virtual string Specification { get; private set; }
+
+        /// <summary>
+        /// Indicates whether this <see cref="RefSpec"/> is intended to be used during a Push or Fetch operation
+        /// </summary>
+        public virtual RefSpecDirection Direction { get; private set; }
+
+        /// <summary>
+        /// The source reference specifier
+        /// </summary>
+        public virtual string Source { get; private set; }
+
+        /// <summary>
+        /// The target reference specifier
+        /// </summary>
+        public virtual string Destination { get; private set; }
+
+        /// <summary>
+        /// Indicates whether the destination will be force-updated if fast-forwarding is not possible
+        /// </summary>
+        public virtual bool ForceUpdate { get; private set; }
+    }
+}

--- a/LibGit2Sharp/RefSpecCollection.cs
+++ b/LibGit2Sharp/RefSpecCollection.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Diagnostics;
+using System.Globalization;
+using LibGit2Sharp.Core;
+using LibGit2Sharp.Core.Handles;
+using LibGit2Sharp.Core.Compat;
+
+namespace LibGit2Sharp
+{
+    /// <summary>
+    /// The collection of <see cref="RefSpec"/>s in a <see cref="Remote"/>
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class RefSpecCollection : IEnumerable<RefSpec>
+    {
+        private readonly Lazy<IList<RefSpec>> refSpecsLazy;
+
+        /// <summary>
+        /// Needed for mocking purposes.
+        /// </summary>
+        protected RefSpecCollection()
+        { }
+
+        internal RefSpecCollection(Remote remote)
+        {
+            Ensure.ArgumentNotNull(remote, "remote");
+
+            refSpecsLazy = new Lazy<IList<RefSpec>>(() => RetrieveRefSpecs(remote));
+        }
+
+        private static IList<RefSpec> RetrieveRefSpecs(Remote remote)
+        {
+            using (RemoteSafeHandle remoteHandle = Proxy.git_remote_load(remote.repository.Handle, remote.Name, true))
+            {
+                int count = Proxy.git_remote_refspec_count(remoteHandle);
+                List<RefSpec> refSpecs = new List<RefSpec>();
+
+                for (int i = 0; i < count; i++)
+                {
+                    using (GitRefSpecHandle handle = Proxy.git_remote_get_refspec(remoteHandle, i))
+                    {
+                        refSpecs.Add(RefSpec.BuildFromPtr(handle));
+                    }
+                }
+
+                return refSpecs;
+            }
+        }
+
+        /// <summary>
+        /// Returns an enumerator that iterates through the collection.
+        /// </summary>
+        /// <returns>An <see cref="IEnumerator{T}"/> object that can be used to iterate through the collection.</returns>
+        public virtual IEnumerator<RefSpec> GetEnumerator()
+        {
+            return refSpecsLazy.Value.GetEnumerator();
+        }
+
+        /// <summary>
+        /// Returns an enumerator that iterates through the collection.
+        /// </summary>
+        /// <returns>An <see cref="IEnumerator"/> object that can be used to iterate through the collection.</returns>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        private string DebuggerDisplay
+        {
+            get
+            {
+                return string.Format(CultureInfo.InvariantCulture,
+                    "Count = {0}", this.Count());
+            }
+        }
+    }
+}

--- a/LibGit2Sharp/RefSpecDirection.cs
+++ b/LibGit2Sharp/RefSpecDirection.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace LibGit2Sharp
+{
+    /// <summary>
+    /// Indicates whether a refspec is a push refspec or a fetch refspec
+    /// </summary>
+    public enum RefSpecDirection
+    {
+        /// <summary>
+        /// Indicates that the refspec is a fetch refspec
+        /// </summary>
+        Fetch,
+
+        /// <summary>
+        /// Indicates that the refspec is a push refspec
+        /// </summary>
+        Push
+    }
+}

--- a/LibGit2Sharp/Remote.cs
+++ b/LibGit2Sharp/Remote.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using LibGit2Sharp.Core;
@@ -15,7 +16,9 @@ namespace LibGit2Sharp
         private static readonly LambdaEqualityHelper<Remote> equalityHelper =
             new LambdaEqualityHelper<Remote>(x => x.Name, x => x.Url);
 
-        private readonly Repository repository;
+        internal readonly Repository repository;
+
+        private readonly RefSpecCollection refSpecs;
 
         /// <summary>
         /// Needed for mocking purposes.
@@ -29,6 +32,7 @@ namespace LibGit2Sharp
             Name = name;
             Url = url;
             TagFetchMode = tagFetchMode;
+            refSpecs = new RefSpecCollection(this);
         }
 
         internal static Remote BuildFromPtr(RemoteSafeHandle handle, Repository repo)
@@ -56,6 +60,11 @@ namespace LibGit2Sharp
         /// Gets the Tag Fetch Mode of the remote - indicating how tags are fetched.
         /// </summary>
         public virtual TagFetchMode TagFetchMode { get; private set; }
+
+        /// <summary>
+        /// Gets the list of <see cref="RefSpec"/>s defined for this <see cref="Remote"/>
+        /// </summary>
+        public virtual IEnumerable<RefSpec> RefSpecs { get { return refSpecs; } }
 
         /// <summary>
         /// Transform a reference to its source reference using the <see cref="Remote"/>'s default fetchspec.


### PR DESCRIPTION
The Remote.RefSpecs property allows to enumerate over all refspecs defined for a specific remote.

~~The intention of this extension actually is to fetch git notes. As libgit2 does not allow to fetch a specified refspec, you have to add it to the configuration. But libgit2 does not support `config --add` either, so I decided to choose the proper way.~~

This pull request has been shrunken to only include read access. Write access will be discussed and implementet later (see [this branch](https://github.com/Yogu/libgit2sharp/compare/refspec-collection-updating) for the version containing updating features discussed here).

What do you think of it? I am eager for any feedback / suggestions.
