### PR TITLE
Tests create global config stub if required

### DIFF
--- a/LibGit2Sharp.Tests/CommitFixture.cs
+++ b/LibGit2Sharp.Tests/CommitFixture.cs
@@ -507,19 +507,18 @@ namespace LibGit2Sharp.Tests
             }
         }
 
-        [SkippableFact]
+        [Fact]
         public void CanCommitWithSignatureFromConfig()
         {
             string repoPath = InitNewRepository();
+            string configPath = CreateConfigurationWithDummyUser(Constants.Signature);
+            var options = new RepositoryOptions { GlobalConfigurationLocation = configPath };
 
-            using (var repo = new Repository(repoPath))
+            using (var repo = new Repository(repoPath, options))
             {
                 string dir = repo.Info.Path;
                 Assert.True(Path.IsPathRooted(dir));
                 Assert.True(Directory.Exists(dir));
-
-                InconclusiveIf(() => !repo.Config.HasConfig(ConfigurationLevel.Global),
-                    "No Git global configuration available");
 
                 const string relativeFilepath = "new.txt";
                 string filePath = Touch(repo.Info.WorkingDirectory, relativeFilepath, "null");
@@ -535,12 +534,7 @@ namespace LibGit2Sharp.Tests
                 AssertBlobContent(repo.Head[relativeFilepath], "nulltoken\n");
                 AssertBlobContent(commit[relativeFilepath], "nulltoken\n");
 
-                var name = repo.Config.Get<string>("user.name");
-                var email = repo.Config.Get<string>("user.email");
-                Assert.Equal(commit.Author.Name, name.Value);
-                Assert.Equal(commit.Author.Email, email.Value);
-                Assert.Equal(commit.Committer.Name, name.Value);
-                Assert.Equal(commit.Committer.Email, email.Value);
+                AssertCommitSignaturesAre(commit, Constants.Signature);
             }
         }
 

--- a/LibGit2Sharp.Tests/ConfigurationFixture.cs
+++ b/LibGit2Sharp.Tests/ConfigurationFixture.cs
@@ -186,17 +186,20 @@ namespace LibGit2Sharp.Tests
             }
         }
 
-        [SkippableFact]
+        [Fact]
         public void CanEnumerateGlobalConfig()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            string configPath = CreateConfigurationWithDummyUser(Constants.Signature);
+            var options = new RepositoryOptions { GlobalConfigurationLocation = configPath };
+
+            using (var repo = new Repository(StandardTestRepoPath, options))
             {
                 InconclusiveIf(() => !repo.Config.HasConfig(ConfigurationLevel.Global),
                     "No Git global configuration available");
 
                 var entry = repo.Config.FirstOrDefault<ConfigurationEntry<string>>(e => e.Key == "user.name");
                 Assert.NotNull(entry);
-                Assert.NotNull(entry.Value);
+                Assert.Equal(Constants.Signature.Name, entry.Value);
             }
         }
 

--- a/LibGit2Sharp.Tests/NoteFixture.cs
+++ b/LibGit2Sharp.Tests/NoteFixture.cs
@@ -154,7 +154,7 @@ namespace LibGit2Sharp.Tests
         public void CanAddANoteWithSignatureFromConfig()
         {
             string configPath = CreateConfigurationWithDummyUser(Constants.Signature);
-            RepositoryOptions options = new RepositoryOptions() { GlobalConfigurationLocation = configPath };
+            var options = new RepositoryOptions { GlobalConfigurationLocation = configPath };
             string path = CloneBareTestRepo();
 
             using (var repo = new Repository(path, options))
@@ -168,7 +168,7 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal("I'm batman!\n", newNote.Message);
                 Assert.Equal("batmobile", newNote.Namespace);
 
-                AssertCommitSignaturesAre(repo, "refs/notes/batmobile", Constants.Signature);
+                AssertCommitSignaturesAre(repo.Lookup<Commit>("refs/notes/batmobile"), Constants.Signature);
             }
         }
 
@@ -265,7 +265,7 @@ namespace LibGit2Sharp.Tests
 
                 Assert.Empty(notes);
 
-                AssertCommitSignaturesAre(repo, "refs/notes/" + repo.Notes.DefaultNamespace, Constants.Signature);
+                AssertCommitSignaturesAre(repo.Lookup<Commit>("refs/notes/" + repo.Notes.DefaultNamespace), Constants.Signature);
             }
         }
 
@@ -287,22 +287,6 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(expectedNotes,
                              SortedNotes(repo.Notes, n => new { Blob = n.BlobId.Sha, Target = n.TargetObjectId.Sha }));
             }
-        }
-
-        /// <summary>
-        /// Verifies that the commit has been authored and committed by the specified signature
-        /// </summary>
-        /// <param name="repo">The repository</param>
-        /// <param name="commitish">The commit whose author and commiter properties to verify</param>
-        /// <param name="signature">The signature to compare author and commiter to</param>
-        private void AssertCommitSignaturesAre(Repository repo, string commitish, Signature signature)
-        {
-            Commit commit = repo.Lookup<Commit>(commitish);
-            Assert.NotNull(commit);
-            Assert.Equal(signature.Name, commit.Author.Name);
-            Assert.Equal(signature.Email, commit.Author.Email);
-            Assert.Equal(signature.Name, commit.Committer.Name);
-            Assert.Equal(signature.Email, commit.Committer.Email);
         }
 
         private static T[] SortedNotes<T>(IEnumerable<Note> notes, Func<Note, T> selector)

--- a/LibGit2Sharp.Tests/TestHelpers/BaseFixture.cs
+++ b/LibGit2Sharp.Tests/TestHelpers/BaseFixture.cs
@@ -286,6 +286,19 @@ namespace LibGit2Sharp.Tests.TestHelpers
             return configFilePath;
         }
 
+        /// <summary>
+        /// Asserts that the commit has been authored and committed by the specified signature
+        /// </summary>
+        /// <param name="commit">The commit</param>
+        /// <param name="signature">The signature to compare author and commiter to</param>
+        protected void AssertCommitSignaturesAre(Commit commit, Signature signature)
+        {
+            Assert.Equal(signature.Name, commit.Author.Name);
+            Assert.Equal(signature.Email, commit.Author.Email);
+            Assert.Equal(signature.Name, commit.Committer.Name);
+            Assert.Equal(signature.Email, commit.Committer.Email);
+        }
+
         protected static string Touch(string parent, string file, string content = null, Encoding encoding = null)
         {
             string filePath = Path.Combine(parent, file);


### PR DESCRIPTION
Instead of relying on the global configuration and skipping the test if
Git is not installed, the following tests create a configuration file
containing user.name and user.email using
BaseFixture.CreateConfigurationWithDummyUser(Signature):
- CommitFixture.CanCommitWithSignatureFromConfig()
- ConfigurationFixture.CanEnumerateGlobalConfig()

Fixes #561
