### PR TITLE
Extended RemoteUpdater to update refspecs

### DIFF
--- a/LibGit2Sharp.Tests/RefSpecFixture.cs
+++ b/LibGit2Sharp.Tests/RefSpecFixture.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using LibGit2Sharp.Tests.TestHelpers;
 using Xunit;
+using Xunit.Extensions;
 
 namespace LibGit2Sharp.Tests
 {
@@ -36,6 +37,20 @@ namespace LibGit2Sharp.Tests
         }
 
         [Fact]
+        public void FetchAndPushRefSpecsComposeRefSpecs()
+        {
+            var path = CloneStandardTestRepo();
+            using (var repo = new Repository(path))
+            {
+                var remote = repo.Network.Remotes["origin"];
+
+                var totalRefSpecs = remote.FetchRefSpecs.Concat(remote.PushRefSpecs);
+                var orderedRefSpecs = remote.RefSpecs.OrderBy(r => r.Direction == RefSpecDirection.Fetch ? 0 : 1);
+                Assert.Equal(orderedRefSpecs, totalRefSpecs);
+            }
+        }
+
+        [Fact]
         public void CanReadRefSpecDetails()
         {
             var path = CloneStandardTestRepo();
@@ -49,6 +64,131 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal("refs/heads/*", refSpec.Source);
                 Assert.Equal("refs/remotes/origin/*", refSpec.Destination);
                 Assert.Equal(true, refSpec.ForceUpdate);
+            }
+        }
+
+        [Theory]
+        [InlineData(new string[] { "+refs/tags/*:refs/tags/*" }, new string[] { "refs/heads/*:refs/remotes/test/*", "+refs/abc:refs/def" })]
+        [InlineData(new string[] { "+refs/abc/x:refs/def/x", "refs/def:refs/ghi" }, new string[0])]
+        [InlineData(new string[0], new string[] { "refs/ghi:refs/jkl/mno" })]
+        public void CanReplaceRefSpecs(string[] newFetchRefSpecs, string[] newPushRefSpecs)
+        {
+            var path = CloneStandardTestRepo();
+            using (var repo = new Repository(path))
+            {
+                var remote = repo.Network.Remotes["origin"];
+                var oldRefSpecs = remote.RefSpecs.ToList();
+
+                var newRemote = repo.Network.Remotes.Update(remote,
+                    r => r.FetchRefSpecs = newFetchRefSpecs, r => r.PushRefSpecs = newPushRefSpecs);
+
+                Assert.Equal(oldRefSpecs, remote.RefSpecs.ToList());
+
+                var actualNewFetchRefSpecs = newRemote.RefSpecs
+                    .Where(s => s.Direction == RefSpecDirection.Fetch)
+                    .Select(r => r.Specification)
+                    .ToArray();
+                Assert.Equal(newFetchRefSpecs, actualNewFetchRefSpecs);
+
+                var actualNewPushRefSpecs = newRemote.RefSpecs
+                    .Where(s => s.Direction == RefSpecDirection.Push)
+                    .Select(r => r.Specification)
+                    .ToArray();
+                Assert.Equal(newPushRefSpecs, actualNewPushRefSpecs);
+            }
+        }
+
+        [Fact]
+        public void RemoteUpdaterSavesRefSpecsPermanently()
+        {
+            var fetchRefSpecs = new string[] { "refs/their/heads/*:refs/my/heads/*", "+refs/their/tag:refs/my/tag" };
+
+            var path = CloneStandardTestRepo();
+            using (var repo = new Repository(path))
+            {
+                var remote = repo.Network.Remotes["origin"];
+                repo.Network.Remotes.Update(remote, r => r.FetchRefSpecs = fetchRefSpecs);
+            }
+
+            using (var repo = new Repository(path))
+            {
+                var remote = repo.Network.Remotes["origin"];
+                var actualRefSpecs = remote.RefSpecs
+                    .Where(r => r.Direction == RefSpecDirection.Fetch)
+                    .Select(r => r.Specification)
+                    .ToArray();
+                Assert.Equal(fetchRefSpecs, actualRefSpecs);
+            }
+        }
+
+        [Fact]
+        public void CanAddAndRemoveRefSpecs()
+        {
+            string newRefSpec = "+refs/heads/test:refs/heads/other-test";
+
+            var path = CloneStandardTestRepo();
+            using (var repo = new Repository(path))
+            {
+                var remote = repo.Network.Remotes["origin"];
+
+                remote = repo.Network.Remotes.Update(remote,
+                    r => r.FetchRefSpecs.Add(newRefSpec),
+                    r => r.PushRefSpecs.Add(newRefSpec));
+
+                Assert.Contains(newRefSpec, remote.FetchRefSpecs.Select(r => r.Specification));
+                Assert.Contains(newRefSpec, remote.PushRefSpecs.Select(r => r.Specification));
+
+                remote = repo.Network.Remotes.Update(remote,
+                    r => r.FetchRefSpecs.Remove(newRefSpec),
+                    r => r.PushRefSpecs.Remove(newRefSpec));
+
+                Assert.DoesNotContain(newRefSpec, remote.FetchRefSpecs.Select(r => r.Specification));
+                Assert.DoesNotContain(newRefSpec, remote.PushRefSpecs.Select(r => r.Specification));
+            }
+        }
+
+        [Fact]
+        public void CanClearRefSpecs()
+        {
+            var path = CloneStandardTestRepo();
+            using (var repo = new Repository(path))
+            {
+                var remote = repo.Network.Remotes["origin"];
+
+                // Push refspec does not exist in cloned repository
+                remote = repo.Network.Remotes.Update(remote, r => r.PushRefSpecs.Add("+refs/test:refs/test"));
+
+                remote = repo.Network.Remotes.Update(remote,
+                    r => r.FetchRefSpecs.Clear(),
+                    r => r.PushRefSpecs.Clear());
+
+                Assert.Empty(remote.FetchRefSpecs);
+                Assert.Empty(remote.PushRefSpecs);
+                Assert.Empty(remote.RefSpecs);
+            }
+        }
+
+        [Theory]
+        [InlineData("refs/test:refs//double-slash")]
+        [InlineData("refs/trailing-slash/:refs/test")]
+        [InlineData("refs/.dotfile:refs/test")]
+        [InlineData("refs/.:refs/dotdir")]
+        [InlineData("refs/asterix:refs/not-matching/*")]
+        [InlineData("refs/double/*/asterix/*:refs/double/*asterix/*")]
+        [InlineData("refs/ whitespace:refs/test")]
+        public void SettingInvalidRefSpecsThrows(string refSpec)
+        {
+            var path = CloneStandardTestRepo();
+            using (var repo = new Repository(path))
+            {
+                var remote = repo.Network.Remotes["origin"];
+                var oldRefSpecs = remote.RefSpecs.Select(r => r.Specification).ToList();
+
+                Assert.Throws<LibGit2SharpException>(() =>
+                    repo.Network.Remotes.Update(remote, r => r.FetchRefSpecs.Add(refSpec)));
+
+                var newRemote = repo.Network.Remotes["origin"];
+                Assert.Equal(oldRefSpecs, newRemote.RefSpecs.Select(r => r.Specification).ToList());
             }
         }
     }

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -883,6 +883,12 @@ namespace LibGit2Sharp.Core
         internal static extern UIntPtr git_remote_refspec_count(RemoteSafeHandle remote);
 
         [DllImport(libgit2)]
+        internal static extern int git_remote_set_fetch_refspecs(RemoteSafeHandle remote, GitStrArrayIn array);
+
+        [DllImport(libgit2)]
+        internal static extern int git_remote_set_push_refspecs(RemoteSafeHandle remote, GitStrArrayIn array);
+
+        [DllImport(libgit2)]
         internal static extern int git_remote_is_valid_name(
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string remote_name);
 

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -1561,6 +1561,50 @@ namespace LibGit2Sharp.Core
             return (int)NativeMethods.git_remote_refspec_count(remote);
         }
 
+        public static IList<string> git_remote_get_fetch_refspecs(RemoteSafeHandle remote)
+        {
+            using (ThreadAffinity())
+            {
+                UnSafeNativeMethods.git_strarray arr;
+                int res = UnSafeNativeMethods.git_remote_get_fetch_refspecs(out arr, remote);
+                Ensure.ZeroResult(res);
+
+                return Libgit2UnsafeHelper.BuildListOf(arr);
+            }
+        }
+
+        public static IList<string> git_remote_get_push_refspecs(RemoteSafeHandle remote)
+        {
+            using (ThreadAffinity())
+            {
+                UnSafeNativeMethods.git_strarray arr;
+                int res = UnSafeNativeMethods.git_remote_get_push_refspecs(out arr, remote);
+                Ensure.ZeroResult(res);
+
+                return Libgit2UnsafeHelper.BuildListOf(arr);
+            }
+        }
+
+        public static void git_remote_set_fetch_refspecs(RemoteSafeHandle remote, IEnumerable<string> refSpecs)
+        {
+            using (ThreadAffinity())
+            using (GitStrArrayIn array = GitStrArrayIn.BuildFrom(refSpecs.ToArray()))
+            {
+                int res = NativeMethods.git_remote_set_fetch_refspecs(remote, array);
+                Ensure.ZeroResult(res);
+            }
+        }
+
+        public static void git_remote_set_push_refspecs(RemoteSafeHandle remote, IEnumerable<string> refSpecs)
+        {
+            using (ThreadAffinity())
+            using (GitStrArrayIn array = GitStrArrayIn.BuildFrom(refSpecs.ToArray()))
+            {
+                int res = NativeMethods.git_remote_set_push_refspecs(remote, array);
+                Ensure.ZeroResult(res);
+            }
+        }
+
         public static void git_remote_download(RemoteSafeHandle remote)
         {
             using (ThreadAffinity())

--- a/LibGit2Sharp/Core/UnSafeNativeMethods.cs
+++ b/LibGit2Sharp/Core/UnSafeNativeMethods.cs
@@ -20,6 +20,12 @@ namespace LibGit2Sharp.Core
         [DllImport(libgit2)]
         internal static extern void git_strarray_free(ref git_strarray array);
 
+        [DllImport(libgit2)]
+        internal static extern int git_remote_get_fetch_refspecs(out git_strarray array, RemoteSafeHandle remote);
+
+        [DllImport(libgit2)]
+        internal static extern int git_remote_get_push_refspecs(out git_strarray array, RemoteSafeHandle remote);
+
         #region Nested type: git_strarray
 
         internal struct git_strarray

--- a/LibGit2Sharp/Remote.cs
+++ b/LibGit2Sharp/Remote.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Diagnostics;
 using System.Globalization;
 using LibGit2Sharp.Core;
@@ -65,6 +66,24 @@ namespace LibGit2Sharp
         /// Gets the list of <see cref="RefSpec"/>s defined for this <see cref="Remote"/>
         /// </summary>
         public virtual IEnumerable<RefSpec> RefSpecs { get { return refSpecs; } }
+
+        /// <summary>
+        /// Gets the list of <see cref="RefSpec"/>s defined for this <see cref="Remote"/>
+        /// that are intended to be used during a Fetch operation
+        /// </summary>
+        public virtual IEnumerable<RefSpec> FetchRefSpecs
+        {
+            get { return refSpecs.Where(r => r.Direction == RefSpecDirection.Fetch); }
+        }
+
+        /// <summary>
+        /// Gets the list of <see cref="RefSpec"/>s defined for this <see cref="Remote"/>
+        /// that are intended to be used during a Push operation
+        /// </summary>
+        public virtual IEnumerable<RefSpec> PushRefSpecs
+        {
+            get { return refSpecs.Where(r => r.Direction == RefSpecDirection.Push); }
+        }
 
         /// <summary>
         /// Transform a reference to its source reference using the <see cref="Remote"/>'s default fetchspec.

--- a/LibGit2Sharp/RemoteUpdater.cs
+++ b/LibGit2Sharp/RemoteUpdater.cs
@@ -1,5 +1,8 @@
-﻿using LibGit2Sharp.Core;
+﻿using System;
+using System.Collections.Generic;
+using LibGit2Sharp.Core;
 using LibGit2Sharp.Core.Handles;
+using LibGit2Sharp.Core.Compat;
 
 namespace LibGit2Sharp
 {
@@ -10,6 +13,8 @@ namespace LibGit2Sharp
     {
         private readonly Repository repo;
         private readonly Remote remote;
+        private readonly UpdatingCollection<string> fetchRefSpecs;
+        private readonly UpdatingCollection<string> pushRefSpecs;
 
         /// <summary>
         /// Needed for mocking purposes.
@@ -24,6 +29,43 @@ namespace LibGit2Sharp
 
             this.repo = repo;
             this.remote = remote;
+
+            fetchRefSpecs = new UpdatingCollection<string>(GetFetchRefSpecs, SetFetchRefSpecs);
+            pushRefSpecs = new UpdatingCollection<string>(GetPushRefSpecs, SetPushRefSpecs);
+        }
+
+        private IEnumerable<string> GetFetchRefSpecs()
+        {
+            using (RemoteSafeHandle remoteHandle = Proxy.git_remote_load(repo.Handle, remote.Name, true))
+            {
+                return Proxy.git_remote_get_fetch_refspecs(remoteHandle);
+            }
+        }
+
+        private void SetFetchRefSpecs(IEnumerable<string> value)
+        {
+            using (RemoteSafeHandle remoteHandle = Proxy.git_remote_load(repo.Handle, remote.Name, true))
+            {
+                Proxy.git_remote_set_fetch_refspecs(remoteHandle, value);
+                Proxy.git_remote_save(remoteHandle);
+            }
+        }
+
+        private IEnumerable<string> GetPushRefSpecs()
+        {
+            using (RemoteSafeHandle remoteHandle = Proxy.git_remote_load(repo.Handle, remote.Name, true))
+            {
+                return Proxy.git_remote_get_push_refspecs(remoteHandle);
+            }
+        }
+
+        private void SetPushRefSpecs(IEnumerable<string> value)
+        {
+            using (RemoteSafeHandle remoteHandle = Proxy.git_remote_load(repo.Handle, remote.Name, true))
+            {
+                Proxy.git_remote_set_push_refspecs(remoteHandle, value);
+                Proxy.git_remote_save(remoteHandle);
+            }
         }
 
         /// <summary>
@@ -38,6 +80,107 @@ namespace LibGit2Sharp
                     Proxy.git_remote_set_autotag(remoteHandle, value);
                     Proxy.git_remote_save(remoteHandle);
                 }
+            }
+        }
+
+        /// <summary>
+        /// Sets the list of <see cref="RefSpec"/>s defined for this <see cref="Remote"/> that are intended to
+        /// be used during a Fetch operation
+        /// </summary>
+        /// <remarks>Changing the list updates the <see cref="Remote" />.</remarks>
+        public virtual ICollection<string> FetchRefSpecs
+        {
+            get { return fetchRefSpecs; }
+            set { fetchRefSpecs.ReplaceAll(value); }
+        }
+
+        /// <summary>
+        /// Sets or gets the list of <see cref="RefSpec"/>s defined for this <see cref="Remote"/> that are intended to
+        /// be used during a Push operation
+        /// </summary>
+        /// <remarks>Changing the list updates the <see cref="Remote" />.</remarks>
+        public virtual ICollection<string> PushRefSpecs 
+        { 
+            get { return pushRefSpecs; }
+            set { pushRefSpecs.ReplaceAll(value); } 
+        }
+
+        private class UpdatingCollection<T> : ICollection<T>
+        {
+            private readonly Lazy<List<T>> list;
+            private readonly Action<IEnumerable<T>> setter;
+
+            public UpdatingCollection(Func<IEnumerable<T>> getter,
+                Action<IEnumerable<T>> setter)
+            {
+                list = new Lazy<List<T>>(() => new List<T>(getter()));
+                this.setter = setter;
+            }
+
+            public void Add(T item)
+            {
+                list.Value.Add(item);
+                Save();
+            }
+
+            public void Clear()
+            {
+                list.Value.Clear();
+                Save();
+            }
+
+            public bool Contains(T item)
+            {
+                return list.Value.Contains(item);
+            }
+
+            public void CopyTo(T[] array, int arrayIndex)
+            {
+                list.Value.CopyTo(array, arrayIndex);
+            }
+
+            public int Count
+            {
+                get { return list.Value.Count; }
+            }
+
+            public bool IsReadOnly
+            {
+                get { return false; }
+            }
+
+            public bool Remove(T item)
+            {
+                if (!list.Value.Remove(item))
+                {
+                    return false;
+                }
+
+                Save();
+                return true;
+            }
+
+            public IEnumerator<T> GetEnumerator()
+            {
+                return list.Value.GetEnumerator();
+            }
+
+            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+            {
+                return list.Value.GetEnumerator();
+            }
+
+            public void ReplaceAll(IEnumerable<T> newValues)
+            {
+                Ensure.ArgumentNotNull(newValues, "newValues");
+                list.Value.Clear();
+                list.Value.AddRange(newValues);
+                Save();
+            }
+
+            private void Save()
+            {
+                setter(list.Value);
             }
         }
     }


### PR DESCRIPTION
Push/Pull Ref Specs can be updated via Remotes.Update(). The collections
can either be manipulated or replaced completely. Any changes are saved
immediately.

This is the place for a discussion about the API to manipulate push/fetch refspecs. In the end, there should be two options:
- Manipulate the git config, i.e. write the changes to disk
- Create a temporary remote based on an existing one, change some refspecs, and use that for a push/pull operation. (will be addressed in #572)

The second option requires a lot of changes, because libgit2sharp currently creates a `RemoteSafeHandle` based on a remote name in many places (e.g. in `Network.Fetch`).

As the first option should be relatively simple to implement, I only addressed this one.

I extended the `RemoteUpdater` instead of `RefSpecCollection` because that way, the `Remote`s and its `RefSpecs` properties stay immutable.
