### PR TITLE
Fix off-by-one error in BlameHunk debugger display

### DIFF
--- a/LibGit2Sharp/BlameHunk.cs
+++ b/LibGit2Sharp/BlameHunk.cs
@@ -113,7 +113,7 @@ namespace LibGit2Sharp
                 return string.Format(CultureInfo.InvariantCulture,
                                      "{0}-{1} ({2})",
                                      FinalStartLineNumber,
-                                     FinalStartLineNumber+LineCount,
+                                     FinalStartLineNumber+LineCount-1,
                                      FinalCommit.ToString().Substring(0,7));
             }
         }


### PR DESCRIPTION
As mentioned in [#552](https://github.com/libgit2/libgit2sharp/pull/552#issuecomment-29179379).
