### PR TITLE
fix spell mistake for argument pre-inspection.

### DIFF
--- a/LibGit2Sharp/ConfigurationExtensions.cs
+++ b/LibGit2Sharp/ConfigurationExtensions.cs
@@ -63,7 +63,7 @@ namespace LibGit2Sharp
         {
             Ensure.ArgumentNotNullOrEmptyString(firstKeyPart, "firstKeyPart");
             Ensure.ArgumentNotNullOrEmptyString(secondKeyPart, "secondKeyPart");
-            Ensure.ArgumentNotNullOrEmptyString(thirdKeyPart, "secondKeyPart");
+            Ensure.ArgumentNotNullOrEmptyString(thirdKeyPart, "thirdKeyPart");
 
             return config.Get<T>(new[] { firstKeyPart, secondKeyPart, thirdKeyPart });
         }


### PR DESCRIPTION
orig:
Ensure.ArgumentNotNullOrEmptyString(thirdKeyPart, "secondKeyPart");
now:
Ensure.ArgumentNotNullOrEmptyString(thirdKeyPart, "thirdKeyPart");
