### PR TITLE
Don't load a remote's refspecs lazily

### DIFF
--- a/LibGit2Sharp/Remote.cs
+++ b/LibGit2Sharp/Remote.cs
@@ -27,22 +27,18 @@ namespace LibGit2Sharp
         protected Remote()
         { }
 
-        private Remote(Repository repository, string name, string url, TagFetchMode tagFetchMode)
+        private Remote(RemoteSafeHandle handle, Repository repository)
         {
             this.repository = repository;
-            Name = name;
-            Url = url;
-            TagFetchMode = tagFetchMode;
-            refSpecs = new RefSpecCollection(this);
+            Name = Proxy.git_remote_name(handle);
+            Url = Proxy.git_remote_url(handle);
+            TagFetchMode = Proxy.git_remote_autotag(handle);
+            refSpecs = new RefSpecCollection(handle);
         }
 
         internal static Remote BuildFromPtr(RemoteSafeHandle handle, Repository repo)
         {
-            string name = Proxy.git_remote_name(handle);
-            string url = Proxy.git_remote_url(handle);
-            TagFetchMode tagFetchMode = Proxy.git_remote_autotag(handle);
-
-            var remote = new Remote(repo, name, url, tagFetchMode);
+            var remote = new Remote(handle, repo);
 
             return remote;
         }


### PR DESCRIPTION
We already have the refspecs parsed the git_remote, and loading them
lazily means we'll be parsing them again, and possibly parse a different
set from the ones we used to have loaded.

Make the loading eager, and pass the RemoteSafeHandle to more places, as
we need to use it in order to provide a single snapshot of the data.
