### PR TITLE
Network: allow downloading from a url

### DIFF
--- a/LibGit2Sharp.Tests/NetworkFixture.cs
+++ b/LibGit2Sharp.Tests/NetworkFixture.cs
@@ -43,6 +43,37 @@ namespace LibGit2Sharp.Tests
             }
         }
 
+        [Theory]
+        [InlineData("http://github.com/libgit2/TestGitRepository")]
+        [InlineData("https://github.com/libgit2/TestGitRepository")]
+        [InlineData("git://github.com/libgit2/TestGitRepository.git")]
+        public void CanListRemoteReferencesFromUrl(string url)
+        {
+            string repoPath = InitNewRepository();
+
+            using (var repo = new Repository(repoPath))
+            {
+                IList<DirectReference> references = repo.Network.ListReferences(url).ToList();
+
+                foreach (var directReference in references)
+                {
+                    // None of those references point to an existing
+                    // object in this brand new repository
+                    Assert.Null(directReference.Target);
+                }
+
+                List<Tuple<string, string>> actualRefs = references.
+                    Select(directRef => new Tuple<string, string>(directRef.CanonicalName, directRef.TargetIdentifier)).ToList();
+
+                Assert.Equal(ExpectedRemoteRefs.Count, actualRefs.Count);
+                for (int i = 0; i < ExpectedRemoteRefs.Count; i++)
+                {
+                    Assert.Equal(ExpectedRemoteRefs[i].Item2, actualRefs[i].Item2);
+                    Assert.Equal(ExpectedRemoteRefs[i].Item1, actualRefs[i].Item1);
+                }
+            }
+        }
+
         [Fact]
         public void CanListRemoteReferenceObjects()
         {

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -872,6 +872,13 @@ namespace LibGit2Sharp.Core
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string url);
 
         [DllImport(libgit2)]
+        internal static extern int git_remote_create_inmemory(
+            out RemoteSafeHandle remote,
+            RepositorySafeHandle repo,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string refspec,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string url);
+
+        [DllImport(libgit2)]
         internal static extern void git_remote_disconnect(RemoteSafeHandle remote);
 
         [DllImport(libgit2)]

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -1543,6 +1543,18 @@ namespace LibGit2Sharp.Core
             }
         }
 
+        public static RemoteSafeHandle git_remote_create_inmemory(RepositorySafeHandle repo, string url, string refspec)
+        {
+            using (ThreadAffinity())
+            {
+                RemoteSafeHandle handle;
+                int res = NativeMethods.git_remote_create_inmemory(out handle, repo, url, refspec);
+                Ensure.ZeroResult(res);
+
+                return handle;
+            }
+        }
+
         public static void git_remote_connect(RemoteSafeHandle remote, GitDirection direction)
         {
             using (ThreadAffinity())


### PR DESCRIPTION
This is our implementation of in-memory remotes. Ask the repository to
fetch/list from a url instead of a remote.

This still needs tests for fetching, but what do you think of the API?
