### PR TITLE
CommitFilter: add simplify-by-first-parent option

### DIFF
--- a/LibGit2Sharp.Tests/CommitFixture.cs
+++ b/LibGit2Sharp.Tests/CommitFixture.cs
@@ -177,6 +177,18 @@ namespace LibGit2Sharp.Tests
         }
 
         [Fact]
+        public void CanSimplifyByFirstParent()
+        {
+            AssertEnumerationOfCommits(
+                repo => new CommitFilter { Since = repo.Head, FirstParent = true },
+            new[]
+            {
+                "4c062a6", "be3563a", "9fd738e",
+                "4a202b3", "5b5b025", "8496071",
+            });
+        }
+
+        [Fact]
         public void CanGetParentsCount()
         {
             using (var repo = new Repository(BareTestRepoPath))

--- a/LibGit2Sharp/CommitFilter.cs
+++ b/LibGit2Sharp/CommitFilter.cs
@@ -16,6 +16,7 @@ namespace LibGit2Sharp
         {
             SortBy = CommitSortStrategies.Time;
             Since = "HEAD";
+            FirstParent = false;
         }
 
         /// <summary>
@@ -56,6 +57,11 @@ namespace LibGit2Sharp
         {
             get { return ToList(Until); }
         }
+
+        /// <summary>
+        /// Whether to limit the walk to each commit's first parent, instead of all of them
+        /// </summary>
+        public bool FirstParent { get; set; }
 
         private static IList<object> ToList(object obj)
         {

--- a/LibGit2Sharp/CommitLog.cs
+++ b/LibGit2Sharp/CommitLog.cs
@@ -154,6 +154,7 @@ namespace LibGit2Sharp
                 Sort(filter.SortBy);
                 Push(filter.SinceList);
                 Hide(filter.UntilList);
+                FirstParent(filter.FirstParent);
             }
 
             #region IEnumerator<Commit> Members
@@ -232,6 +233,13 @@ namespace LibGit2Sharp
                 Proxy.git_revwalk_sorting(handle, options);
             }
 
+            private void FirstParent(bool firstParent)
+            {
+                if (firstParent)
+                {
+                    Proxy.git_revwalk_simplify_first_parent(handle);
+                }
+            }
         }
     }
 }

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -1097,6 +1097,9 @@ namespace LibGit2Sharp.Core
         internal static extern void git_revwalk_sorting(RevWalkerSafeHandle walk, CommitSortStrategies sort);
 
         [DllImport(libgit2)]
+        internal static extern void git_revwalk_simplify_first_parent(RevWalkerSafeHandle walk);
+
+        [DllImport(libgit2)]
         internal static extern void git_signature_free(IntPtr signature);
 
         [DllImport(libgit2)]

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -2101,6 +2101,11 @@ namespace LibGit2Sharp.Core
             NativeMethods.git_revwalk_sorting(walker, options);
         }
 
+        public static void git_revwalk_simplify_first_parent(RevWalkerSafeHandle walker)
+        {
+            NativeMethods.git_revwalk_simplify_first_parent(walker);
+        }
+
         #endregion
 
         #region git_signature_


### PR DESCRIPTION
Now that this is doable directly inside the revision walker, let's
expose it as a possible filter option.

This fixes #258.
