### PR TITLE
Refactored Network.Fetch() with FetchOptions

### DIFF
--- a/LibGit2Sharp.Tests/FetchFixture.cs
+++ b/LibGit2Sharp.Tests/FetchFixture.cs
@@ -42,7 +42,7 @@ namespace LibGit2Sharp.Tests
                 }
 
                 // Perform the actual fetch
-                repo.Network.Fetch(remote, onUpdateTips: expectedFetchState.RemoteUpdateTipsHandler);
+                repo.Network.Fetch(remote, new FetchOptions { OnUpdateTips = expectedFetchState.RemoteUpdateTipsHandler });
 
                 // Verify the expected
                 expectedFetchState.CheckUpdatedReferences(repo);
@@ -62,11 +62,14 @@ namespace LibGit2Sharp.Tests
                 Remote remote = repo.Network.Remotes.Add(remoteName, Constants.PrivateRepoUrl);
 
                 // Perform the actual fetch
-                repo.Network.Fetch(remote, credentials: new Credentials
-                                              {
-                                                  Username = Constants.PrivateRepoUsername,
-                                                  Password = Constants.PrivateRepoPassword
-                                              });
+                repo.Network.Fetch(remote, new FetchOptions
+                {
+                    Credentials = new Credentials
+                        {
+                            Username = Constants.PrivateRepoUsername,
+                            Password = Constants.PrivateRepoPassword
+                        }
+                });
             }
         }
 
@@ -94,7 +97,10 @@ namespace LibGit2Sharp.Tests
                 }
 
                 // Perform the actual fetch
-                repo.Network.Fetch(remote, TagFetchMode.All, onUpdateTips: expectedFetchState.RemoteUpdateTipsHandler);
+                repo.Network.Fetch(remote, new FetchOptions { 
+                    TagFetchMode = TagFetchMode.All,
+                    OnUpdateTips = expectedFetchState.RemoteUpdateTipsHandler 
+                });
 
                 // Verify the expected
                 expectedFetchState.CheckUpdatedReferences(repo);

--- a/LibGit2Sharp.Tests/RepositoryFixture.cs
+++ b/LibGit2Sharp.Tests/RepositoryFixture.cs
@@ -186,13 +186,13 @@ namespace LibGit2Sharp.Tests
                 }
 
                 // Perform the actual fetch
-                repo.Fetch(remote.Name, onUpdateTips: expectedFetchState.RemoteUpdateTipsHandler);
+                repo.Fetch(remote.Name, new FetchOptions { OnUpdateTips = expectedFetchState.RemoteUpdateTipsHandler });
 
                 // Verify the expected state
                 expectedFetchState.CheckUpdatedReferences(repo);
 
                 // Now fetch the rest of the tags
-                repo.Fetch(remote.Name, tagFetchMode: TagFetchMode.All);
+                repo.Fetch(remote.Name, new FetchOptions { TagFetchMode = TagFetchMode.All });
 
                 // Verify that the "nearly-dangling" tag is now in the repo.
                 Tag nearlyDanglingTag = repo.Tags["nearly-dangling"];

--- a/LibGit2Sharp/FetchOptions.cs
+++ b/LibGit2Sharp/FetchOptions.cs
@@ -1,0 +1,46 @@
+﻿using LibGit2Sharp.Handlers;
+
+namespace LibGit2Sharp
+{
+    /// <summary>
+    /// Collection of parameters controlling Fetch behavior.
+    /// </summary>
+    public sealed class FetchOptions
+    {
+        /// <summary>
+        /// Specifies the tag-following behavior of the fetch operation.
+        /// <para>
+        /// If not set, the fetch operation will follow the default behavior for the <see cref="Remote"/>
+        /// based on the remote's <see cref="Remote.TagFetchMode"/> configuration.
+        /// </para>
+        /// <para>If neither this property nor the remote `tagopt` configuration is set,
+        /// this will default to <see cref="TagFetchMode.Auto"/> (i.e. tags that point to objects
+        /// retrieved during this fetch will be retrieved as well).</para>
+        /// </summary>
+        public TagFetchMode? TagFetchMode { get; set; }
+
+        /// <summary>
+        /// Delegate that progress updates of the network transfer portion of fetch
+        /// will be reported through.
+        /// </summary>
+        public ProgressHandler OnProgress { get; set; }
+
+        /// <summary>
+        /// Delegate that updates of remote tracking branches will be reported through.
+        /// </summary>
+        public UpdateTipsHandler OnUpdateTips { get; set; }
+
+        /// <summary>
+        /// Callback method that transfer progress will be reported through.
+        /// <para>
+        /// Reports the client's state regarding the received and processed (bytes, objects) from the server.
+        /// </para>
+        /// </summary>
+        public TransferProgressHandler OnTransferProgress { get; set; }
+
+        /// <summary>
+        /// Credentials to use for username/password authentication.
+        /// </summary>
+        public Credentials Credentials { get; set; }
+    }
+}

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -74,6 +74,7 @@
     <Compile Include="CommitFilter.cs" />
     <Compile Include="CommitSortStrategies.cs" />
     <Compile Include="CompareOptions.cs" />
+    <Compile Include="FetchOptions.cs" />
     <Compile Include="RefSpec.cs" />
     <Compile Include="RefSpecCollection.cs" />
     <Compile Include="Core\EncodingMarshaler.cs" />

--- a/LibGit2Sharp/Network.cs
+++ b/LibGit2Sharp/Network.cs
@@ -96,12 +96,20 @@ namespace LibGit2Sharp
             }
         }
 
-        static void DoFetch(RemoteSafeHandle remoteHandle, GitRemoteCallbacks gitCallbacks, TagFetchMode? tagFetchMode)
+        static void DoFetch(RemoteSafeHandle remoteHandle, FetchOptions options)
         {
-            if (tagFetchMode.HasValue)
+            if (options == null)
             {
-                Proxy.git_remote_set_autotag(remoteHandle, tagFetchMode.Value);
+                options = new FetchOptions();
             }
+
+            if (options.TagFetchMode.HasValue)
+            {
+                Proxy.git_remote_set_autotag(remoteHandle, options.TagFetchMode.Value);
+            }
+
+            var callbacks = new RemoteCallbacks(options);
+            GitRemoteCallbacks gitCallbacks = callbacks.GenerateCallbacks();
 
             // It is OK to pass the reference to the GitCallbacks directly here because libgit2 makes a copy of
             // the data in the git_remote_callbacks structure. If, in the future, libgit2 changes its implementation
@@ -135,6 +143,7 @@ namespace LibGit2Sharp
         /// <param name="onTransferProgress">Callback method that transfer progress will be reported through.
         /// Reports the client's state regarding the received and processed (bytes, objects) from the server.</param>
         /// <param name="credentials">Credentials to use for username/password authentication.</param>
+        [Obsolete("This overload will be removed in the next release. Please use Fetch(Remote, FetchOptions) instead.")]
         public virtual void Fetch(
             Remote remote,
             TagFetchMode? tagFetchMode = null,
@@ -143,14 +152,39 @@ namespace LibGit2Sharp
             TransferProgressHandler onTransferProgress = null,
             Credentials credentials = null)
         {
+            Fetch(remote, new FetchOptions
+            {
+                TagFetchMode = tagFetchMode,
+                OnProgress = onProgress,
+                OnUpdateTips = onUpdateTips,
+                OnTransferProgress = onTransferProgress,
+                Credentials = credentials
+            });
+        }
+
+        /// <summary>
+        /// Fetch from the <see cref="Remote"/>.
+        /// </summary>
+        /// <param name="remote">The remote to fetch</param>
+        public virtual void Fetch(Remote remote)
+        {
+            // This overload is required as long as the obsolete overload exists.
+            // Otherwise, Fetch(Remote) is ambiguous.
+            Fetch(remote, (FetchOptions)null);
+        }
+
+        /// <summary>
+        /// Fetch from the <see cref="Remote"/>.
+        /// </summary>
+        /// <param name="remote">The remote to fetch</param>
+        /// <param name="options"><see cref="FetchOptions"/> controlling fetch behavior</param>
+        public virtual void Fetch(Remote remote, FetchOptions options = null)
+        {
             Ensure.ArgumentNotNull(remote, "remote");
 
             using (RemoteSafeHandle remoteHandle = Proxy.git_remote_load(repository.Handle, remote.Name, true))
             {
-                var callbacks = new RemoteCallbacks(onProgress, onTransferProgress, onUpdateTips, credentials);
-                GitRemoteCallbacks gitCallbacks = callbacks.GenerateCallbacks();
-
-                DoFetch(remoteHandle, gitCallbacks, tagFetchMode);
+                DoFetch(remoteHandle, options);
             }
         }
 
@@ -159,30 +193,20 @@ namespace LibGit2Sharp
         /// </summary>
         /// <param name="url">The url to fetch from</param>
         /// <param name="refspecs">The list of resfpecs to use</param>
-        /// <param name="tagFetchMode">Optional parameter indicating what tags to download.</param>
-        /// <param name="onProgress">Progress callback. Corresponds to libgit2 progress callback.</param>
-        /// <param name="onUpdateTips">UpdateTips callback. Corresponds to libgit2 update_tips callback.</param>
-        /// <param name="onTransferProgress">Callback method that transfer progress will be reported through.
-        /// Reports the client's state regarding the received and processed (bytes, objects) from the server.</param>
-        /// <param name="credentials">Credentials to use for username/password authentication.</param>
+        /// <param name="options"><see cref="FetchOptions"/> controlling fetch behavior</param>
         public virtual void Fetch(
             string url,
             IEnumerable<string> refspecs,
-            TagFetchMode? tagFetchMode = null,
-            ProgressHandler onProgress = null,
-            UpdateTipsHandler onUpdateTips = null,
-            TransferProgressHandler onTransferProgress = null,
-            Credentials credentials = null)
+            FetchOptions options = null)
         {
             Ensure.ArgumentNotNull(url, "url");
+            Ensure.ArgumentNotNull(refspecs, "refspecs");
 
             using (RemoteSafeHandle remoteHandle = Proxy.git_remote_create_inmemory(repository.Handle, null, url))
             {
                 Proxy.git_remote_set_fetch_refspecs(remoteHandle, refspecs);
-                var callbacks = new RemoteCallbacks(onProgress, onTransferProgress, onUpdateTips, credentials);
-                GitRemoteCallbacks gitCallbacks = callbacks.GenerateCallbacks();
 
-                DoFetch(remoteHandle, gitCallbacks, tagFetchMode);
+                DoFetch(remoteHandle, options);
             }
         }
 

--- a/LibGit2Sharp/RemoteCallbacks.cs
+++ b/LibGit2Sharp/RemoteCallbacks.cs
@@ -24,6 +24,15 @@ namespace LibGit2Sharp
             Credentials = credentials;
         }
 
+        internal RemoteCallbacks(FetchOptions fetchOptions)
+        {
+            Ensure.ArgumentNotNull(fetchOptions, "fetchOptions");
+            Progress = fetchOptions.OnProgress;
+            DownloadTransferProgress = fetchOptions.OnTransferProgress;
+            UpdateTips = fetchOptions.OnUpdateTips;
+            Credentials = fetchOptions.Credentials;
+        }
+
         #region Delegates
 
         /// <summary>

--- a/LibGit2Sharp/RepositoryExtensions.cs
+++ b/LibGit2Sharp/RepositoryExtensions.cs
@@ -246,6 +246,7 @@ namespace LibGit2Sharp
         /// <param name="onTransferProgress">Callback method that transfer progress will be reported through.
         /// Reports the client's state regarding the received and processed (bytes, objects) from the server.</param>
         /// <param name="credentials">Credentials to use for username/password authentication.</param>
+        [Obsolete("This overload will be removed in the next release. Please use Fetch(Remote, FetchOptions) instead.")]
         public static void Fetch(this IRepository repository, string remoteName,
             TagFetchMode tagFetchMode = TagFetchMode.Auto,
             ProgressHandler onProgress = null,
@@ -257,8 +258,41 @@ namespace LibGit2Sharp
             Ensure.ArgumentNotNullOrEmptyString(remoteName, "remoteName");
 
             Remote remote = repository.Network.Remotes.RemoteForName(remoteName, true);
-            repository.Network.Fetch(remote, tagFetchMode, onProgress, onUpdateTips,
-                onTransferProgress, credentials);
+            repository.Network.Fetch(remote, new FetchOptions
+            {
+                TagFetchMode = tagFetchMode,
+                OnProgress = onProgress,
+                OnUpdateTips = onUpdateTips,
+                OnTransferProgress = onTransferProgress,
+                Credentials = credentials
+            });
+        }
+
+        /// <summary>
+        /// Fetch from the specified remote.
+        /// </summary>
+        /// <param name="repository">The <see cref="Repository"/> being worked with.</param>
+        /// <param name="remoteName">The name of the <see cref="Remote"/> to fetch from.</param>
+        public static void Fetch(this IRepository repository, string remoteName)
+        {
+            // This overload is required as long as the obsolete overload exists.
+            // Otherwise, Fetch(string) is ambiguous.
+            Fetch(repository, remoteName, (FetchOptions)null);
+        }
+
+        /// <summary>
+        /// Fetch from the specified remote.
+        /// </summary>
+        /// <param name="repository">The <see cref="Repository"/> being worked with.</param>
+        /// <param name="remoteName">The name of the <see cref="Remote"/> to fetch from.</param>
+        /// <param name="options"><see cref="FetchOptions"/> controlling fetch behavior</param>
+        public static void Fetch(this IRepository repository, string remoteName, FetchOptions options = null)
+        {
+            Ensure.ArgumentNotNull(repository, "repository");
+            Ensure.ArgumentNotNullOrEmptyString(remoteName, "remoteName");
+
+            Remote remote = repository.Network.Remotes.RemoteForName(remoteName, true);
+            repository.Network.Fetch(remote, options);
         }
 
         /// <summary>


### PR DESCRIPTION
Changed the signature to `Network.Fetch(Remote, FetchOptions)`.

As of #536,

> optional parameters should be grouped in a `xxxOptions` type.

`Network.Fetch()` has currently 5 optional parameters, and a sixth one (`RefSpecs`) will be introduced in #572. I think a `FetchOptions` class is by far more clear.

I'm not sure if we should keep tests for the obsolete syntax.
