### PR TITLE
Update usage of diff APIs

### DIFF
--- a/LibGit2Sharp/Configuration.cs
+++ b/LibGit2Sharp/Configuration.cs
@@ -305,7 +305,7 @@ namespace LibGit2Sharp
 
         private static ConfigurationEntry<string> BuildConfigEntry(IntPtr entryPtr)
         {
-            var entry = (GitConfigEntry)Marshal.PtrToStructure(entryPtr, typeof(GitConfigEntry));
+            var entry = entryPtr.MarshalAs<GitConfigEntry>();
 
             return new ConfigurationEntry<string>(LaxUtf8Marshaler.FromNative(entry.namePtr),
                                                   LaxUtf8Marshaler.FromNative(entry.valuePtr),

--- a/LibGit2Sharp/Core/Handles/GitConfigEntryHandle.cs
+++ b/LibGit2Sharp/Core/Handles/GitConfigEntryHandle.cs
@@ -6,7 +6,7 @@ namespace LibGit2Sharp.Core.Handles
     {
         public GitConfigEntry MarshalAsGitConfigEntry()
         {
-            return (GitConfigEntry)Marshal.PtrToStructure(handle, typeof(GitConfigEntry));
+            return handle.MarshalAs<GitConfigEntry>();
         }
     }
 }

--- a/LibGit2Sharp/Core/Handles/GitErrorSafeHandle.cs
+++ b/LibGit2Sharp/Core/Handles/GitErrorSafeHandle.cs
@@ -15,7 +15,7 @@ namespace LibGit2Sharp.Core.Handles
                 return null;
             }
 
-            return (GitError)Marshal.PtrToStructure(handle, typeof(GitError));
+            return handle.MarshalAs<GitError>();
         }
     }
 }

--- a/LibGit2Sharp/Core/Handles/IndexEntrySafeHandle.cs
+++ b/LibGit2Sharp/Core/Handles/IndexEntrySafeHandle.cs
@@ -6,7 +6,7 @@ namespace LibGit2Sharp.Core.Handles
     {
         public GitIndexEntry MarshalAsGitIndexEntry()
         {
-            return (GitIndexEntry)Marshal.PtrToStructure(handle, typeof(GitIndexEntry));
+            return handle.MarshalAs<GitIndexEntry>();
         }
     }
 }

--- a/LibGit2Sharp/Core/Handles/OidSafeHandle.cs
+++ b/LibGit2Sharp/Core/Handles/OidSafeHandle.cs
@@ -6,7 +6,7 @@ namespace LibGit2Sharp.Core.Handles
     {
         private GitOid? MarshalAsGitOid()
         {
-            return IsInvalid ? null : (GitOid?)Marshal.PtrToStructure(handle, typeof(GitOid));
+            return IsInvalid ? null : (GitOid?)handle.MarshalAs<GitOid>();
         }
 
         public ObjectId MarshalAsObjectId()

--- a/LibGit2Sharp/Core/Handles/StatusEntrySafeHandle.cs
+++ b/LibGit2Sharp/Core/Handles/StatusEntrySafeHandle.cs
@@ -21,7 +21,7 @@ namespace LibGit2Sharp.Core.Handles
 
         public GitStatusEntry MarshalAsGitStatusEntry()
         {
-            return (GitStatusEntry)Marshal.PtrToStructure(handle, typeof(GitStatusEntry));
+            return handle.MarshalAs<GitStatusEntry>();
         }
     }
 }

--- a/LibGit2Sharp/Core/IntPtrExtensions.cs
+++ b/LibGit2Sharp/Core/IntPtrExtensions.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace LibGit2Sharp.Core
+{
+    internal static class IntPtrExtensions
+    {
+        public static T MarshalAs<T>(this IntPtr ptr, bool throwWhenNull = true)
+        {
+            if (!throwWhenNull && ptr == IntPtr.Zero)
+            {
+                return default(T);
+            }
+            return (T)Marshal.PtrToStructure(ptr, typeof(T));
+        }
+    }
+}

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -13,15 +13,6 @@ namespace LibGit2Sharp.Core
 {
     internal class Proxy
     {
-        private static T MarshalAs<T>(IntPtr ptr)
-        {
-            if (ptr == IntPtr.Zero)
-            {
-                return default(T);
-            }
-            return (T)Marshal.PtrToStructure(ptr, typeof(T));
-        }
-
         #region giterr_
 
         public static void giterr_set_str(GitErrorCategory error_class, Exception exception)
@@ -61,7 +52,7 @@ namespace LibGit2Sharp.Core
 
         public static GitBlameHunk git_blame_get_hunk_byindex(BlameSafeHandle blame, uint idx)
         {
-            return MarshalAs<GitBlameHunk>(NativeMethods.git_blame_get_hunk_byindex(blame, idx));
+            return NativeMethods.git_blame_get_hunk_byindex(blame, idx).MarshalAs<GitBlameHunk>(false);
         }
 
         public static void git_blame_free(IntPtr blame)
@@ -741,7 +732,7 @@ namespace LibGit2Sharp.Core
 
         public static GitDiffDelta git_diff_get_delta(DiffSafeHandle diff, int idx)
         {
-            return MarshalAs<GitDiffDelta>(NativeMethods.git_diff_get_delta(diff, (UIntPtr) idx));
+            return NativeMethods.git_diff_get_delta(diff, (UIntPtr) idx).MarshalAs<GitDiffDelta>(false);
         }
 
         #endregion
@@ -2796,7 +2787,7 @@ namespace LibGit2Sharp.Core
                 var list = new List<GitRemoteHead>(count);
                 for (int i = 0; i < count; i++)
                 {
-                    list.Add(MarshalAs<GitRemoteHead>(rawHeads[i]));
+                    list.Add(rawHeads[i].MarshalAs<GitRemoteHead>());
                 }
                 return list;
             }

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -76,6 +76,7 @@
     <Compile Include="CommitSortStrategies.cs" />
     <Compile Include="CompareOptions.cs" />
     <Compile Include="Core\Handles\PatchSafeHandle.cs" />
+    <Compile Include="Core\IntPtrExtensions.cs" />
     <Compile Include="FetchOptions.cs" />
     <Compile Include="RefSpec.cs" />
     <Compile Include="RefSpecCollection.cs" />

--- a/LibGit2Sharp/ObjectDatabase.cs
+++ b/LibGit2Sharp/ObjectDatabase.cs
@@ -43,7 +43,7 @@ namespace LibGit2Sharp
         public virtual IEnumerator<GitObject> GetEnumerator()
         {
             ICollection<GitOid> oids = Proxy.git_odb_foreach(handle,
-                ptr => (GitOid) Marshal.PtrToStructure(ptr, typeof (GitOid)));
+                ptr => ptr.MarshalAs<GitOid>());
 
             return oids
                 .Select(gitOid => repo.Lookup<GitObject>(new ObjectId(gitOid)))

--- a/LibGit2Sharp/RepositoryStatus.cs
+++ b/LibGit2Sharp/RepositoryStatus.cs
@@ -73,11 +73,11 @@ namespace LibGit2Sharp
 
                     if (entry.HeadToIndexPtr != IntPtr.Zero)
                     {
-                        deltaHeadToIndex = (GitDiffDelta)Marshal.PtrToStructure(entry.HeadToIndexPtr, typeof(GitDiffDelta));
+                        deltaHeadToIndex = entry.HeadToIndexPtr.MarshalAs<GitDiffDelta>();
                     }
                     if (entry.IndexToWorkDirPtr != IntPtr.Zero)
                     {
-                        deltaIndexToWorkDir = (GitDiffDelta)Marshal.PtrToStructure(entry.IndexToWorkDirPtr, typeof(GitDiffDelta));
+                        deltaIndexToWorkDir = entry.IndexToWorkDirPtr.MarshalAs<GitDiffDelta>();
                     }
 
                     AddStatusEntryForDelta(entry.Status, deltaHeadToIndex, deltaIndexToWorkDir);

--- a/LibGit2Sharp/Signature.cs
+++ b/LibGit2Sharp/Signature.cs
@@ -19,8 +19,7 @@ namespace LibGit2Sharp
 
         internal Signature(IntPtr signaturePtr)
         {
-            var handle = new GitSignature();
-            Marshal.PtrToStructure(signaturePtr, handle);
+            var handle = signaturePtr.MarshalAs<GitSignature>();
 
             name = LaxUtf8Marshaler.FromNative(handle.Name);
             email = LaxUtf8Marshaler.FromNative(handle.Email);


### PR DESCRIPTION
I might be doing this wrong, but it appears that the method libgit2sharp is using for generating patches is incorrect. This PR aims to simplify the usage of native diff apis so as to close this gap.
- [x] Write failing tests
- [x] Use `git_diff_patch` for `Patch`'s content
