### PR TITLE
Update error categories to match libgit2

### DIFF
--- a/LibGit2Sharp/Core/GitErrorCategory.cs
+++ b/LibGit2Sharp/Core/GitErrorCategory.cs
@@ -3,6 +3,7 @@ namespace LibGit2Sharp.Core
     internal enum GitErrorCategory
     {
         Unknown = -1,
+        None,
         NoMemory,
         Os,
         Invalid,
@@ -27,5 +28,7 @@ namespace LibGit2Sharp.Core
         Merge,
         Ssh,
         Filter,
+        Revert,
+        Callback,
     }
 }


### PR DESCRIPTION
I noticed that our client was returning some error messages that didn't make sense, turns out that libgit2 inserted a None = 0 error category and we did not update to reflect when we took that build.  Thus we were off by one!
