### PR TITLE
Speed up postbuild xcopy

### DIFF
--- a/nuget.package/Tools/GetLibGit2SharpPostBuildCmd.ps1
+++ b/nuget.package/Tools/GetLibGit2SharpPostBuildCmd.ps1
@@ -8,6 +8,6 @@ $x64 = $(Join-Path $NativeAssembliesDir "amd64\*.*")
 $LibGit2SharpPostBuildCmd = "
 if not exist `"`$(TargetDir)NativeBinaries`" md `"`$(TargetDir)NativeBinaries`"
 if not exist `"`$(TargetDir)NativeBinaries\x86`" md `"`$(TargetDir)NativeBinaries\x86`"
-xcopy /s /y `"$x86`" `"`$(TargetDir)NativeBinaries\x86`"
+xcopy /s /y /d `"$x86`" `"`$(TargetDir)NativeBinaries\x86`"
 if not exist `"`$(TargetDir)NativeBinaries\amd64`" md `"`$(TargetDir)NativeBinaries\amd64`"
-xcopy /s /y `"$x64`" `"`$(TargetDir)NativeBinaries\amd64`""
+xcopy /s /y /d `"$x64`" `"`$(TargetDir)NativeBinaries\amd64`""


### PR DESCRIPTION
Added `/d` to xcopy so that files are only copied if newer, saving a few seconds of unnecessary I/O on build.
