### PR TITLE
Fix Remotes.Add(name, url, refspec) implementation

### DIFF
--- a/LibGit2Sharp.Tests/RemoteFixture.cs
+++ b/LibGit2Sharp.Tests/RemoteFixture.cs
@@ -170,5 +170,27 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(1, remotes.Count(r => r.Name == "no_url"));
             }
         }
+
+        [Fact]
+        public void CreatingARemoteAddsADefaultFetchRefSpec()
+        {
+            var path = CloneStandardTestRepo();
+            using (var repo = new Repository(path))
+            {
+                var remote = repo.Network.Remotes.Add("one", "http://github.com/up/stream");
+                Assert.Equal("+refs/heads/*:refs/remotes/one/*", remote.RefSpecs.Single().Specification);
+            }
+        }
+
+        [Fact]
+        public void CanCreateARemoteWithASpecifiedFetchRefSpec()
+        {
+            var path = CloneStandardTestRepo();
+            using (var repo = new Repository(path))
+            {
+                var remote = repo.Network.Remotes.Add("two", "http://github.com/up/stream", "+refs/heads/*:refs/remotes/grmpf/*");
+                Assert.Equal("+refs/heads/*:refs/remotes/grmpf/*", remote.RefSpecs.Single().Specification);
+            }
+        }
     }
 }

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -953,6 +953,15 @@ namespace LibGit2Sharp.Core
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string refspec,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string url);
 
+
+        [DllImport(libgit2)]
+        internal static extern int git_remote_create_with_fetchspec(
+            out RemoteSafeHandle remote,
+            RepositorySafeHandle repo,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string url,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string refspec);
+
         [DllImport(libgit2)]
         internal static extern void git_remote_disconnect(RemoteSafeHandle remote);
 
@@ -1008,11 +1017,6 @@ namespace LibGit2Sharp.Core
         internal static extern int git_remote_set_callbacks(
             RemoteSafeHandle remote,
             ref GitRemoteCallbacks callbacks);
-
-        [DllImport(libgit2)]
-        internal static extern int git_remote_add_fetch(
-            RemoteSafeHandle remote,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof (StrictUtf8Marshaler))] string refspec);
 
         internal delegate int remote_progress_callback(IntPtr str, int len, IntPtr data);
 

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -1679,6 +1679,18 @@ namespace LibGit2Sharp.Core
             }
         }
 
+        public static RemoteSafeHandle git_remote_create_with_fetchspec(RepositorySafeHandle repo, string name, string url, string refspec)
+        {
+            using (ThreadAffinity())
+            {
+                RemoteSafeHandle handle;
+                int res = NativeMethods.git_remote_create_with_fetchspec(out handle, repo, name, url, refspec);
+                Ensure.ZeroResult(res);
+
+                return handle;
+            }
+        }
+
         public static RemoteSafeHandle git_remote_create_inmemory(RepositorySafeHandle repo, string url, string refspec)
         {
             using (ThreadAffinity())
@@ -1860,15 +1872,6 @@ namespace LibGit2Sharp.Core
         public static void git_remote_set_autotag(RemoteSafeHandle remote, TagFetchMode value)
         {
             NativeMethods.git_remote_set_autotag(remote, value);
-        }
-
-        public static void git_remote_add_fetch(RemoteSafeHandle remote, string refspec)
-        {
-            using (ThreadAffinity())
-            {
-                int res = NativeMethods.git_remote_add_fetch(remote, refspec);
-                Ensure.ZeroResult(res);
-            }
         }
 
         public static void git_remote_set_callbacks(RemoteSafeHandle remote, ref GitRemoteCallbacks callbacks)

--- a/LibGit2Sharp/RemoteCollection.cs
+++ b/LibGit2Sharp/RemoteCollection.cs
@@ -120,10 +120,8 @@ namespace LibGit2Sharp
             Ensure.ArgumentNotNull(url, "url");
             Ensure.ArgumentNotNull(fetchRefSpec, "fetchRefSpec");
 
-            using (RemoteSafeHandle handle = Proxy.git_remote_create(repository.Handle, name, url))
+            using (RemoteSafeHandle handle = Proxy.git_remote_create_with_fetchspec(repository.Handle, name, url, fetchRefSpec))
             {
-                Proxy.git_remote_add_fetch(handle, fetchRefSpec);
-                Proxy.git_remote_save(handle);
                 return Remote.BuildFromPtr(handle, this.repository);
             }
         }


### PR DESCRIPTION
Prevents the creation of a default fetch refspec beside the passed in one.
