### PR TITLE
Run mono with the --debug option

### DIFF
--- a/build.libgit2sharp.sh
+++ b/build.libgit2sharp.sh
@@ -21,6 +21,8 @@ export DYLD_LIBRARY_PATH=$_BINPATH:$DYLD_LIBRARY_PATH
 
 popd
 
+export MONO_OPTIONS=--debug
+
 echo $DYLD_LIBRARY_PATH
 echo $LD_LIBRARY_PATH
 xbuild CI-build.msbuild /t:Deploy


### PR DESCRIPTION
This tells mono to load the debug information and lets the unit testing
framework show stack traces with line numbers in them, which is quite
handy.
