### PR TITLE
Allow notes retrieval by namespace and ObjectId

### DIFF
--- a/LibGit2Sharp.Tests/NoteFixture.cs
+++ b/LibGit2Sharp.Tests/NoteFixture.cs
@@ -66,6 +66,16 @@ namespace LibGit2Sharp.Tests
         }
 
         [Fact]
+        public void CanRetrieveASpecificNoteFromAKnownNamespace()
+        {
+            using (var repo = new Repository(BareTestRepoPath))
+            {
+                var singleNote = repo.Notes["answer", new ObjectId("4a202b346bb0fb0db7eff3cffeb3c70babbd2045")];
+                Assert.Equal("Nope\n", singleNote.Message);
+            }
+        }
+
+        [Fact]
         public void CanGetListOfNotesNamespaces()
         {
             var expectedNamespaces = new[] { "answer", "answer2", "commits", };

--- a/LibGit2Sharp/NoteCollection.cs
+++ b/LibGit2Sharp/NoteCollection.cs
@@ -94,7 +94,7 @@ namespace LibGit2Sharp
                 Ensure.ArgumentNotNull(id, "id");
 
                 return NamespaceRefs
-                    .Select(ns => RetrieveNote(id, ns))
+                    .Select(ns => this[ns, id])
                     .Where(n => n != null);
             }
         }
@@ -112,16 +112,28 @@ namespace LibGit2Sharp
                 string canonicalNamespace = NormalizeToCanonicalName(@namespace);
 
                 return Proxy.git_note_foreach(repo.Handle, canonicalNamespace,
-                    (blobId,annotatedObjId) => RetrieveNote(annotatedObjId, canonicalNamespace));
+                    (blobId,annotatedObjId) => this[canonicalNamespace, annotatedObjId]);
             }
         }
 
-        internal Note RetrieveNote(ObjectId targetObjectId, string canonicalNamespace)
+        /// <summary>
+        /// Gets the <see cref="Note"/> associated with the specified objectId and the specified namespace.
+        /// </summary>
+        public virtual Note this[string @namespace, ObjectId id]
         {
-            using (NoteSafeHandle noteHandle = Proxy.git_note_read(repo.Handle, canonicalNamespace, targetObjectId))
+            get
             {
-                return noteHandle == null ? null :
-                    Note.BuildFromPtr(noteHandle, UnCanonicalizeName(canonicalNamespace), targetObjectId);
+                Ensure.ArgumentNotNull(id, "id");
+                Ensure.ArgumentNotNull(@namespace, "@namespace");
+
+                string canonicalNamespace = NormalizeToCanonicalName(@namespace);
+
+                using (NoteSafeHandle noteHandle = Proxy.git_note_read(repo.Handle, canonicalNamespace, id))
+                {
+                    return noteHandle == null
+                        ? null
+                        : Note.BuildFromPtr(noteHandle, UnCanonicalizeName(canonicalNamespace), id);
+                }
             }
         }
 
@@ -179,7 +191,7 @@ namespace LibGit2Sharp
 
             Proxy.git_note_create(repo.Handle, author, committer, canonicalNamespace, targetId, message, true);
 
-            return RetrieveNote(targetId, canonicalNamespace);
+            return this[canonicalNamespace, targetId];
         }
 
         /// <summary>


### PR DESCRIPTION
Might help scenarios like http://stackoverflow.com/questions/22468146/, where we know both the namespace we want to query, and the object for which we want the note.
