### PR TITLE
Add SignatureEnumerator

### DIFF
--- a/LibGit2Sharp/Commit.cs
+++ b/LibGit2Sharp/Commit.cs
@@ -16,7 +16,8 @@ namespace LibGit2Sharp
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class Commit : GitObject
     {
-        private readonly GitObjectLazyGroup group;
+        private readonly GitObjectLazyGroup group1;
+        private readonly GitObjectLazyGroup group2;
         private readonly ILazy<Tree> lazyTree;
         private readonly ILazy<Signature> lazyAuthor;
         private readonly ILazy<Signature> lazyCommitter;
@@ -38,12 +39,13 @@ namespace LibGit2Sharp
         {
             lazyTree = GitObjectLazyGroup.Singleton(this.repo, id, obj => new Tree(this.repo, Proxy.git_commit_tree_id(obj), null));
 
-            group = new GitObjectLazyGroup(this.repo, id);
-            lazyAuthor = group.AddLazy(Proxy.git_commit_author);
-            lazyCommitter = group.AddLazy(Proxy.git_commit_committer);
-            lazyMessage = group.AddLazy(Proxy.git_commit_message);
-            lazyMessageShort = group.AddLazy(Proxy.git_commit_summary);
-            lazyEncoding = group.AddLazy(RetrieveEncodingOf);
+            group1 = new GitObjectLazyGroup(this.repo, id);
+            lazyAuthor = group1.AddLazy(Proxy.git_commit_author);
+            lazyCommitter = group1.AddLazy(Proxy.git_commit_committer);
+            group2 = new GitObjectLazyGroup(this.repo, id);
+            lazyMessage = group2.AddLazy(Proxy.git_commit_message);
+            lazyMessageShort = group2.AddLazy(Proxy.git_commit_summary);
+            lazyEncoding = group2.AddLazy(RetrieveEncodingOf);
 
             lazyNotes = new Lazy<IEnumerable<Note>>(() => RetrieveNotesOfCommit(id).ToList());
 


### PR DESCRIPTION
I want to count how many commits and authors. In case of a super big repository (the Linux kernel source tree), Libgit2sharp use too many memory(about x86 1GB \ x64 1.5GB) to raise a OutOfMemoryException.

``` cs
using (var repo = new Repository(@"path\to\Linux\kernel\source"))
{
    var commits = repo.Commits.ToArray();
    Console.WriteLine(commits.Length);
    Console.WriteLine((double)Process.GetCurrentProcess().PagedMemorySize64 / 1024 / 1024);
}
```

So that I want create the `SignatureEnumerator` that will save half memory. the usage of memory is about x86 500MB, x64 600MB.

But I don't think current PR was done. I want to hear your opinion.
