### PR TITLE
Introduce internal ICommittish

### DIFF
--- a/LibGit2Sharp.Tests/MetaFixture.cs
+++ b/LibGit2Sharp.Tests/MetaFixture.cs
@@ -114,7 +114,7 @@ namespace LibGit2Sharp.Tests
             var methodsMissingFromInterfaces =
                 from t in Assembly.GetAssembly(typeof(IRepository)).GetExportedTypes()
                 where !t.IsInterface
-                where t.GetInterfaces().Any(i => i.Namespace == typeof(IRepository).Namespace)
+                where t.GetInterfaces().Any(i => i.IsPublic && i.Namespace == typeof(IRepository).Namespace)
                 let interfaceTargetMethods = from i in t.GetInterfaces()
                                              from im in t.GetInterfaceMap(i).TargetMethods
                                              select im

--- a/LibGit2Sharp/ObjectId.cs
+++ b/LibGit2Sharp/ObjectId.cs
@@ -8,7 +8,7 @@ namespace LibGit2Sharp
     /// <summary>
     /// Uniquely identifies a <see cref="GitObject"/>.
     /// </summary>
-    public sealed class ObjectId : IEquatable<ObjectId>
+    public sealed class ObjectId : IEquatable<ObjectId>, ICommittish
     {
         private readonly GitOid oid;
         private const int rawSize = 20;
@@ -320,5 +320,7 @@ namespace LibGit2Sharp
 
             return Sha.StartsWith(shortSha, StringComparison.OrdinalIgnoreCase);
         }
+
+        string ICommittish.Identifier { get { return Sha; } }
     }
 }

--- a/LibGit2Sharp/Reference.cs
+++ b/LibGit2Sharp/Reference.cs
@@ -10,7 +10,7 @@ namespace LibGit2Sharp
     /// A Reference to another git object
     /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
-    public abstract class Reference : IEquatable<Reference>
+    public abstract class Reference : IEquatable<Reference>, ICommittish
     {
         private static readonly LambdaEqualityHelper<Reference> equalityHelper =
             new LambdaEqualityHelper<Reference>(x => x.CanonicalName, x => x.TargetIdentifier);
@@ -179,5 +179,7 @@ namespace LibGit2Sharp
                     "{0} => \"{1}\"", CanonicalName, TargetIdentifier);
             }
         }
+
+        string ICommittish.Identifier { get { return CanonicalName; } }
     }
 }

--- a/LibGit2Sharp/RepositoryExtensions.cs
+++ b/LibGit2Sharp/RepositoryExtensions.cs
@@ -5,7 +5,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using LibGit2Sharp.Core;
-using LibGit2Sharp.Handlers;
 
 namespace LibGit2Sharp
 {
@@ -377,24 +376,14 @@ namespace LibGit2Sharp
                 return DereferenceToCommit(repo, (string)identifier);
             }
 
-            if (identifier is ObjectId)
-            {
-                return DereferenceToCommit(repo, ((ObjectId)identifier).Sha);
-            }
-
             if (identifier is Commit)
             {
                 return ((Commit)identifier).Id;
             }
 
-            if (identifier is TagAnnotation)
+            if (identifier is ICommittish)
             {
-                return DereferenceToCommit(repo, ((TagAnnotation)identifier).Target.Id.Sha);
-            }
-
-            if (identifier is Tag)
-            {
-                return DereferenceToCommit(repo, ((Tag)identifier).Target.Id.Sha);
+                return DereferenceToCommit(repo, ((ICommittish)identifier).Identifier);
             }
 
             var branch = identifier as Branch;
@@ -405,11 +394,6 @@ namespace LibGit2Sharp
                     Ensure.GitObjectIsNotNull(branch.Tip, branch.CanonicalName);
                     return branch.Tip.Id;
                 }
-            }
-
-            if (identifier is Reference)
-            {
-                return DereferenceToCommit(repo, ((Reference)identifier).CanonicalName);
             }
 
             return null;
@@ -462,5 +446,10 @@ namespace LibGit2Sharp
         {
             return repo.Committishes(identifier, true).First();
         }
+    }
+
+    internal interface ICommittish
+    {
+        string Identifier { get; }
     }
 }

--- a/LibGit2Sharp/Tag.cs
+++ b/LibGit2Sharp/Tag.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// A Tag
     /// </summary>
-    public class Tag : ReferenceWrapper<GitObject>
+    public class Tag : ReferenceWrapper<GitObject>, ICommittish
     {
         /// <summary>
         /// Needed for mocking purposes.
@@ -57,5 +57,7 @@
         {
             return CanonicalName.Substring(Reference.TagPrefix.Length);
         }
+
+        string ICommittish.Identifier { get { return Target.Id.Sha; } }
     }
 }

--- a/LibGit2Sharp/TagAnnotation.cs
+++ b/LibGit2Sharp/TagAnnotation.cs
@@ -5,7 +5,7 @@ namespace LibGit2Sharp
     /// <summary>
     /// A TagAnnotation
     /// </summary>
-    public class TagAnnotation : GitObject
+    public class TagAnnotation : GitObject, ICommittish
     {
         private readonly GitObjectLazyGroup group;
         private readonly ILazy<GitObject> lazyTarget;
@@ -50,5 +50,7 @@ namespace LibGit2Sharp
         /// Gets the tagger.
         /// </summary>
         public virtual Signature Tagger { get { return lazyTagger.Value; } }
+
+        string ICommittish.Identifier { get { return Target.Id.Sha; } }
     }
 }


### PR DESCRIPTION
As originally proposed in #667, this introduces an `internal` interface to let stuff that can identify a commit own how to do so (rather than having that logic live in `RepositoryExtensions`).

@nulltoken doesn't like the name `ICommittish`, and I agree. His [last comment](https://github.com/libgit2/libgit2sharp/pull/667#discussion_r11434347):

> Considering this and the fact that a `Tag` may also point to something else than a `Commit`, about about renaming it to `ITargetObjectIdAccessor` and making it return an `ObjectId` (or null when dealing with an unborn branch for instance)?
