### PR TITLE
Extending repo.Network.Pull() #671

### DIFF
--- a/LibGit2Sharp/Network.cs
+++ b/LibGit2Sharp/Network.cs
@@ -347,6 +347,34 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
+        /// Pull changes from the configured upstream remote and branch into the branch pointed at by HEAD.
+        /// </summary>
+        /// <param name="branch"></param>
+        /// <param name="remote">The <see cref="Remote"/> to pull from.</param>
+        /// <param name="merger">If the merge is a non-fast forward merge that generates a merge commit, the <see cref="Signature"/> of who made the merge.</param>
+        /// <param name="options">Specifies optional parameters controlling merge behavior of pull; if null, the defaults are used.</param>
+        public virtual MergeResult Pull(Branch branch, Remote remote, Signature merger, PullOptions options)
+        {
+            Ensure.ArgumentNotNull(branch, "branch");
+            Ensure.ArgumentNotNull(remote, "remote");
+            Ensure.ArgumentNotNull(merger, "merger");
+            Ensure.ArgumentNotNull(options, "options");
+
+            if (!branch.IsTracking)
+            {
+                throw new LibGit2SharpException("There is no tracking information for the current branch.");
+            }
+
+            if (remote == null)
+            {
+                throw new LibGit2SharpException("No upstream remote for the current branch.");
+            }
+
+            Fetch(remote, options.FetchOptions);
+            return repository.MergeFetchHeads(merger, options.MergeOptions);
+        }
+
+        /// <summary>
         /// The heads that have been updated during the last fetch.
         /// </summary>
         [Obsolete("This property is meant for internal use only and will not be public in the next release.")]


### PR DESCRIPTION
Trying to help out with an up-for-grabs PR for issue #671 :smile:

I've added both Branch and Remote as an overload to Pull, but the Branch isn't really used for anything except checking if its Tracking. So not entirely sure if it makes sense to have or if it should be limited to Remote ?

Anyway, happy to change based on feedback.

Thanks!