### PR TITLE
Improve marshaling of git oid

### DIFF
--- a/LibGit2Sharp/Core/GitOid.cs
+++ b/LibGit2Sharp/Core/GitOid.cs
@@ -8,9 +8,14 @@ namespace LibGit2Sharp.Core
     internal struct GitOid
     {
         /// <summary>
+        /// Number of bytes in the Id.
+        /// </summary>
+        public const int Size = 20;
+
+        /// <summary>
         /// The raw binary 20 byte Id.
         /// </summary>
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 20)]
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = Size)]
         public byte[] Id;
 
         public static implicit operator ObjectId(GitOid oid)

--- a/LibGit2Sharp/Core/Handles/OidSafeHandle.cs
+++ b/LibGit2Sharp/Core/Handles/OidSafeHandle.cs
@@ -6,7 +6,14 @@ namespace LibGit2Sharp.Core.Handles
     {
         private GitOid? MarshalAsGitOid()
         {
-            return IsInvalid ? null : (GitOid?)handle.MarshalAs<GitOid>();
+            return IsInvalid ? null : (GitOid?)MarshalAsGitOid(handle);
+        }
+
+        private static GitOid MarshalAsGitOid(System.IntPtr data)
+        {
+            var gitOid = new GitOid { Id = new byte[GitOid.Size] };
+            Marshal.Copy(data, gitOid.Id, 0, GitOid.Size);
+            return gitOid;
         }
 
         public ObjectId MarshalAsObjectId()


### PR DESCRIPTION
Doing a simple copy of the byte array is a lot faster than using
Marshal.PtrToStructure.
