### PR TITLE
Make Travis build target osx platform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,25 @@
 
 language: c
 
+env:
+ - TRAVIS_OS_UNAME=$(uname -s)
+
+os:
+ - osx
+ - linux
+
+before_install:
+ - date -u
+ - uname -a
+ - env | sort
+
 # Make sure CMake and Mono are installed
 install:
- - sudo apt-get install cmake mono-devel mono-gmcs
+ - if [[ $TRAVIS_OS_UNAME = 'Linux' ]]; then ./CI/travis.linux.install.deps.sh; fi
+ - if [[ $TRAVIS_OS_UNAME = 'Darwin' ]]; then ./CI/travis.osx.install.deps.sh; fi
 
 # Build libgit2, LibGit2Sharp and run the tests
 script:
- - git submodule update --init
  - ./build.libgit2sharp.sh
 
 # Only watch the development branch
@@ -17,10 +29,7 @@ branches:
  only:
    - vNext
 
-# Notify development list when needed
+# Notify of build changes
 notifications:
- recipients:
-   - emeric.fermas@gmail.com
  email:
-   on_success: change
-   on_failure: always
+  - emeric.fermas@gmail.com

--- a/CI/build.msbuild
+++ b/CI/build.msbuild
@@ -1,12 +1,12 @@
 <Project DefaultTargets="Deploy" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
-    <RootDir>$(MSBuildProjectDirectory)</RootDir>
+    <RootDir>$(MSBuildProjectDirectory)\..</RootDir>
     <TestBuildDir>$(RootDir)\LibGit2Sharp.Tests\bin\$(Configuration)</TestBuildDir>
     <DeployFolder>$(RootDir)\Build</DeployFolder>
   </PropertyGroup>
 
-  <UsingTask AssemblyFile="$(MSBuildProjectDirectory)/Lib/xUnit/xunit.runner.msbuild.dll"
+  <UsingTask AssemblyFile="$(RootDir)\Lib\xUnit\xunit.runner.msbuild.dll"
                TaskName="Xunit.Runner.MSBuild.xunit" />
   <Target Name="Clean">
 	<Message Text="Commit SHA = $(CommitSha)" />
@@ -30,7 +30,7 @@
 
   <Target Name="Build" DependsOnTargets="Init">
     <MSBuild
-      Projects="LibGit2Sharp.sln"
+      Projects="$(RootDir)\LibGit2Sharp.sln"
       Targets="Build"
       Properties="Configuration=$(Configuration);TrackFileAccess=false" />
   </Target>

--- a/CI/travis.linux.install.deps.sh
+++ b/CI/travis.linux.install.deps.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -ev
+
+sudo apt-get install cmake mono-devel mono-gmcs

--- a/CI/travis.osx.install.deps.sh
+++ b/CI/travis.osx.install.deps.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -ev
+
+MONO_VER=2.10.10
+
+brew update
+brew install cmake
+
+wget "http://download.mono-project.com/archive/${MONO_VER}/macos-10-x86/MonoFramework-MDK-${MONO_VER}.macos10.xamarin.x86.dmg"
+hdid "MonoFramework-MDK-${MONO_VER}.macos10.xamarin.x86.dmg"
+sudo installer -pkg "/Volumes/Mono Framework MDK ${MONO_VER}/MonoFramework-MDK-${MONO_VER}.macos10.xamarin.x86.pkg" -target /

--- a/build.libgit2sharp.cmd
+++ b/build.libgit2sharp.cmd
@@ -5,7 +5,7 @@ SET FrameworkVersion=v4.0.30319
 SET FrameworkDir=%SystemRoot%\Microsoft.NET\Framework
 SET CommitSha=%~1
 
-"%FrameworkDir%\%FrameworkVersion%\msbuild.exe" "%BASEDIR%CI-build.msbuild" /property:CommitSha=%CommitSha%
+"%FrameworkDir%\%FrameworkVersion%\msbuild.exe" "%BASEDIR%CI\build.msbuild" /property:CommitSha=%CommitSha%
 
 ENDLOCAL
 

--- a/build.libgit2sharp.sh
+++ b/build.libgit2sharp.sh
@@ -26,6 +26,6 @@ export MONO_OPTIONS=--debug
 
 echo $DYLD_LIBRARY_PATH
 echo $LD_LIBRARY_PATH
-xbuild CI-build.msbuild /t:Deploy
+xbuild CI/build.msbuild /t:Deploy
 
 exit $?

--- a/build.libgit2sharp.x64.cmd
+++ b/build.libgit2sharp.x64.cmd
@@ -5,7 +5,7 @@ SET FrameworkVersion=v4.0.30319
 SET FrameworkDir=%SystemRoot%\Microsoft.NET\Framework64
 SET CommitSha=%~1
 
-"%FrameworkDir%\%FrameworkVersion%\msbuild.exe" "%BASEDIR%CI-build.msbuild" /property:CommitSha=%CommitSha%
+"%FrameworkDir%\%FrameworkVersion%\msbuild.exe" "%BASEDIR%CI\build.msbuild" /property:CommitSha=%CommitSha%
 
 ENDLOCAL
 


### PR DESCRIPTION
- [x] Build on OS X and Linux
- [x] Move `CI-build.msbuild` and `travis.*` build scripts under a folder (while keeping the `build.*` ones under the root)
