### PR TITLE
Introduce Remote.IsValidName(string)

### DIFF
--- a/LibGit2Sharp.Tests/RemoteFixture.cs
+++ b/LibGit2Sharp.Tests/RemoteFixture.cs
@@ -153,7 +153,7 @@ namespace LibGit2Sharp.Tests
         {
             using (var repo = new Repository(BareTestRepoPath))
             {
-                Assert.Equal(expectedResult, repo.Network.Remotes.IsValidName(refname));
+                Assert.Equal(expectedResult, Remote.IsValidName(refname));
             }
         }
 

--- a/LibGit2Sharp/Remote.cs
+++ b/LibGit2Sharp/Remote.cs
@@ -96,6 +96,16 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
+        /// Determines if the proposed remote name is well-formed.
+        /// </summary>
+        /// <param name="name">The name to be checked.</param>
+        /// <returns>true is the name is valid; false otherwise.</returns>
+        public static bool IsValidName(string name)
+        {
+            return Proxy.git_remote_is_valid_name(name);
+        }
+
+        /// <summary>
         /// Determines whether the specified <see cref="Object"/> is equal to the current <see cref="Remote"/>.
         /// </summary>
         /// <param name="obj">The <see cref="Object"/> to compare with the current <see cref="Remote"/>.</param>

--- a/LibGit2Sharp/RemoteCollection.cs
+++ b/LibGit2Sharp/RemoteCollection.cs
@@ -131,9 +131,10 @@ namespace LibGit2Sharp
         /// </summary>
         /// <param name="name">The name to be checked.</param>
         /// <returns>true is the name is valid; false otherwise.</returns>
+        [Obsolete("This method will be removed in the next release. Please use Remote.IsValidName(string) instead.")]
         public virtual bool IsValidName(string name)
         {
-            return Proxy.git_remote_is_valid_name(name);
+            return Remote.IsValidName(name);
         }
 
         private string DebuggerDisplay


### PR DESCRIPTION
Deprecate RemoteCollection.IsValidName(string).

Update test CanTellIfARemoteNameIsValid(string, bool).

Fixes #679
