### PR TITLE
Introduced Reference.IsValidName(string)

### DIFF
--- a/LibGit2Sharp.Tests/ReferenceFixture.cs
+++ b/LibGit2Sharp.Tests/ReferenceFixture.cs
@@ -752,7 +752,7 @@ namespace LibGit2Sharp.Tests
         {
             using (var repo = new Repository(BareTestRepoPath))
             {
-                Assert.Equal(expectedResult, repo.Refs.IsValidName(refname));
+                Assert.Equal(expectedResult, Reference.IsValidName(refname));
             }
         }
 

--- a/LibGit2Sharp/Reference.cs
+++ b/LibGit2Sharp/Reference.cs
@@ -65,6 +65,24 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
+        /// Determines if the proposed reference name is well-formed.
+        /// </summary>
+        /// <para>
+        /// - Top-level names must contain only capital letters and underscores,
+        /// and must begin and end with a letter. (e.g. "HEAD", "ORIG_HEAD").
+        ///
+        /// - Names prefixed with "refs/" can be almost anything.  You must avoid
+        /// the characters '~', '^', ':', '\\', '?', '[', and '*', and the
+        /// sequences ".." and "@{" which have special meaning to revparse.
+        /// </para>
+        /// <param name="canonicalName">The name to be checked.</param>
+        /// <returns>true is the name is valid; false otherwise.</returns>
+        public static bool IsValidName(string canonicalName)
+        {
+            return Proxy.git_reference_is_valid_name(canonicalName);
+        }
+
+        /// <summary>
         /// Gets the full name of this reference.
         /// </summary>
         public virtual string CanonicalName

--- a/LibGit2Sharp/ReferenceCollection.cs
+++ b/LibGit2Sharp/ReferenceCollection.cs
@@ -340,9 +340,10 @@ namespace LibGit2Sharp
         /// </para>
         /// <param name="canonicalName">The name to be checked.</param>
         /// <returns>true is the name is valid; false otherwise.</returns>
+        [Obsolete("This method will be removed in the next release. Please use Reference.IsValidName(string) instead.")]
         public virtual bool IsValidName(string canonicalName)
         {
-            return Proxy.git_reference_is_valid_name(canonicalName);
+            return Reference.IsValidName(canonicalName);
         }
 
         /// <summary>


### PR DESCRIPTION
Deprecated ReferenceCollection.IsValidName(string) .

Updated CanTellIfAReferenceIsValid Test .

Fixes #680
