### PR TITLE
Can't commit on a bare repository

### DIFF
--- a/LibGit2Sharp.Tests/RepositoryOptionsFixture.cs
+++ b/LibGit2Sharp.Tests/RepositoryOptionsFixture.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using System.Text;
 using LibGit2Sharp.Tests.TestHelpers;
 using Xunit;
@@ -173,6 +174,32 @@ namespace LibGit2Sharp.Tests
             }
 
             AssertValueInConfigFile(systemLocation, "xpaulbettsx");
+        }
+
+        [Fact]
+        public void CanCommitOnBareRepository()
+        {
+            string repoPath = InitNewRepository(true);
+            SelfCleaningDirectory scd = BuildSelfCleaningDirectory();
+            string workPath = Path.Combine(scd.RootedDirectoryPath, "work");
+            Directory.CreateDirectory(workPath);
+
+            var repositoryOptions = new RepositoryOptions
+            {
+                WorkingDirectoryPath = workPath,
+                IndexPath = Path.Combine(scd.RootedDirectoryPath, "index")
+            };
+
+            using (var repo = new Repository(repoPath, repositoryOptions))
+            {
+                const string relativeFilepath = "test.txt";
+                Touch(repo.Info.WorkingDirectory, relativeFilepath, "test\n");
+                repo.Index.Stage(relativeFilepath);
+
+                Assert.NotNull(repo.Commit("Initial commit", Constants.Signature, Constants.Signature));
+                Assert.Equal(1, repo.Head.Commits.Count());
+                Assert.Equal(1, repo.Commits.Count());
+            }
         }
     }
 }

--- a/LibGit2Sharp/Repository.cs
+++ b/LibGit2Sharp/Repository.cs
@@ -894,14 +894,8 @@ namespace LibGit2Sharp
 
             Proxy.git_repository_state_cleanup(handle);
 
-            var logAllRefUpdates = Config.GetValueOrDefault<bool>("core.logAllRefUpdates", false);
-            if (!logAllRefUpdates)
-            {
-                return result;
-            }
-
             var logMessage = BuildCommitLogMessage(result, options.AmendPreviousCommit, isHeadOrphaned, parents.Count > 1);
-            LogCommit(result, logMessage);
+            UpdateHeadAndTerminalReference(result, logMessage);
 
             return result;
         }
@@ -925,7 +919,7 @@ namespace LibGit2Sharp
             return string.Format(CultureInfo.InvariantCulture, "commit{0}: {1}", kind, commit.MessageShort);
         }
 
-        private void LogCommit(Commit commit, string reflogMessage)
+        private void UpdateHeadAndTerminalReference(Commit commit, string reflogMessage)
         {
             Reference reference = Refs.Head;
 


### PR DESCRIPTION
Could somebody review whether the following test case correct?

``` c#
[Fact]
public void CanCommitOnBareRepository()
{
    string repoPath = InitNewRepository(true);
    SelfCleaningDirectory scd = BuildSelfCleaningDirectory();
    string workPath = Path.Combine(scd.RootedDirectoryPath, "work");
    Directory.CreateDirectory(workPath);

    RepositoryOptions repositoryOptions = new RepositoryOptions()
    {
        WorkingDirectoryPath = workPath,
        IndexPath = Path.Combine(scd.RootedDirectoryPath, "index")
    }

    using (var repo = new Repository(repoPath, repositoryOptions))
    {
        const string relativeFilepath = "test.txt";
        Touch(repo.Info.WorkingDirectory, relativeFilepath, "test\n");
        repo.Index.Stage(relativeFilepath);

        Assert.NotNull(repo.Commit("Initial commit", Constants.Signature, Constants.Signature));
        Assert.Equal(1, repo.Head.Commits.Count());
        Assert.Equal(1, repo.Commits.Count());
    }
}
```
