### PR TITLE
Improve CanRetrieveValidVersionString()

### DIFF
--- a/LibGit2Sharp.Tests/RepositoryFixture.cs
+++ b/LibGit2Sharp.Tests/RepositoryFixture.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using LibGit2Sharp.Tests.TestHelpers;
 using Xunit;
+using System.Text.RegularExpressions;
 
 namespace LibGit2Sharp.Tests
 {
@@ -88,9 +89,35 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanRetrieveValidVersionString()
         {
+            // Version string format is:
+            //      Major.Minor.Patch-LibGit2Sharp_abbrev_hash-libgit2_abbrev_hash (x86|amd64 - features)
+            // Example output:
+            //      "0.17.0-unknown-06d772d (x86 - Threads, Https)"
+
             string versionInfo = Repository.Version;
 
+            // The Repository.Version returned string should contain :
+            //      version:'0.17.0' LibGit2Sharp version number.
+            //      git2SharpHash:'unknown' ( when compiled from source ) else LibGit2Sharp library hash.
+            //      git2hash: '06d772d' LibGit2 library hash.
+            //      arch: 'x86' or 'amd64' LibGit2 target.
+            //      git2Features: 'Threads, Ssh' LibGit2 features compiled with.
+            string regex = @"^(?<version>\d{1,}\.\d{1,2}\.\d{1,3})-(?<git2SharpHash>\w+)-(?<git2Hash>\w+) \((?<arch>\w+) - (?<git2Features>(?:\w*(?:, )*\w+)*)\)$";
+
             Assert.NotNull(versionInfo);
+
+            Match regexResult = Regex.Match(versionInfo, regex);
+
+            Assert.True(regexResult.Success, "The following version string format is enforced:" +
+                                             "Major.Minor.Patch-LibGit2Sharp_abbrev_hash-libgit2_abbrev_hash (x86|amd64 - features)");
+            
+            GroupCollection matchGroups = regexResult.Groups;
+
+            // Check that all groups are valid
+            foreach(Group group in matchGroups)
+            {
+                Assert.True(group.Success);
+            }
         }
 
         [Fact]

--- a/LibGit2Sharp/Repository.cs
+++ b/LibGit2Sharp/Repository.cs
@@ -1005,7 +1005,7 @@ namespace LibGit2Sharp
         /// Gets the current LibGit2Sharp version.
         /// <para>
         ///   The format of the version number is as follows:
-        ///   <para>Major.Minor.Patch-LibGit2Sharp_abbrev_hash-libgit2_abbrev_hash (x86|amd64 - capabilities)</para>
+        ///   <para>Major.Minor.Patch-LibGit2Sharp_abbrev_hash-libgit2_abbrev_hash (x86|amd64 - features)</para>
         /// </para>
         /// </summary>
         public static string Version


### PR DESCRIPTION
Enforces Major.Minor.Patch-LibGit2Sharp_abbrev_hash-libgit2_abbrev_hash (x86|amd64 - capabilities) format.
The regex is based on the output I'm getting from Repository.Version, "0.17.0-unknown-06d772d (x86 - Threads, Https)".
