### PR TITLE
Introduce Network.ListReferences(Remote, Credentials)

### DIFF
--- a/LibGit2Sharp.Tests/NetworkFixture.cs
+++ b/LibGit2Sharp.Tests/NetworkFixture.cs
@@ -107,6 +107,29 @@ namespace LibGit2Sharp.Tests
             }
         }
 
+        [SkippableFact]
+        public void CanListRemoteReferencesWithCredentials()
+        {
+            InconclusiveIf(() => string.IsNullOrEmpty(Constants.PrivateRepoUrl),
+                "Populate Constants.PrivateRepo* to run this test");
+
+            string remoteName = "origin";
+
+            string repoPath = InitNewRepository();
+
+            using (var repo = new Repository(repoPath))
+            {
+                Remote remote = repo.Network.Remotes.Add(remoteName, Constants.PrivateRepoUrl);
+
+                var references = repo.Network.ListReferences(remote, Constants.PrivateRepoCredentials);
+
+                foreach (var directReference in references)
+                {
+                    Assert.NotNull(directReference);
+                }
+            }
+        }
+
         [Theory]
         [InlineData(FastForwardStrategy.Default)]
         [InlineData(FastForwardStrategy.NoFastFoward)]

--- a/LibGit2Sharp/Network.cs
+++ b/LibGit2Sharp/Network.cs
@@ -46,13 +46,21 @@ namespace LibGit2Sharp
         /// </para>
         /// </summary>
         /// <param name="remote">The <see cref="Remote"/> to list from.</param>
+        /// <param name="credentials">The optional <see cref="Credentials"/> used to connect to remote repository.</param>
         /// <returns>The references in the <see cref="Remote"/> repository.</returns>
-        public virtual IEnumerable<DirectReference> ListReferences(Remote remote)
+        public virtual IEnumerable<DirectReference> ListReferences(Remote remote, Credentials credentials = null)
         {
             Ensure.ArgumentNotNull(remote, "remote");
 
             using (RemoteSafeHandle remoteHandle = Proxy.git_remote_load(repository.Handle, remote.Name, true))
             {
+                if (credentials != null)
+                {
+                    var callbacks = new RemoteCallbacks(null, null, null, credentials);
+                    GitRemoteCallbacks gitCallbacks = callbacks.GenerateCallbacks();
+                    Proxy.git_remote_set_callbacks(remoteHandle, ref gitCallbacks);
+                }
+
                 Proxy.git_remote_connect(remoteHandle, GitDirection.Fetch);
                 return Proxy.git_remote_ls(repository, remoteHandle);
             }


### PR DESCRIPTION
Network.ListReferences(Remote) was marked Obsolete and it's users have been updated to use the new Network.ListReferences(Remote, Credentials).

Fixes #647
