### PR TITLE
Automate code analysis through Coverity scan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,12 @@
 
 language: c
 
+env:
+  global:
+   # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
+   #   via the "travis encrypt" command using the project repo's public key
+   - secure: "D9NGp5DLAgV7ijJMGmI0XppO4/NR0pYVxHQatcPoFAMcWOBR+NoKSLVROfNldMauCedo6YXCJlh9xb1e3vurTFuUbl+gF+5p1Ji2cpNaTPdoC6vq2I3cJfHlTqbMA5lDQxw6TQ0h23CRQyeSr+0fFdHmpnEdvNk3uXugur8rZ40="
+
 os:
  - osx
  - linux
@@ -10,7 +16,6 @@ os:
 before_install:
  - date -u
  - uname -a
- - env | sort
 
 # Make sure CMake and Mono are installed
 install:
@@ -19,14 +24,24 @@ install:
 
 # Build libgit2, LibGit2Sharp and run the tests
 script:
- - ./build.libgit2sharp.sh
+ - if [ "${COVERITY_SCAN_BRANCH}" != "1" ]; then ./build.libgit2sharp.sh ; fi
 
 # Only watch the development branch
 branches:
  only:
    - vNext
+   - coverity
 
 # Notify of build changes
 notifications:
  email:
   - emeric.fermas@gmail.com
+
+addons:
+  coverity_scan:
+    project:
+      name: "libgit2/libgit2sharp"
+    notification_email: emeric.fermas@gmail.com
+    build_command_prepend: ./CI/travis.build.libgit2.sh
+    build_command: ./CI/travis.build.libgit2sharp.sh
+    branch_pattern: coverity

--- a/CI/travis.build.libgit2.sh
+++ b/CI/travis.build.libgit2.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+CURLOC=$(dirname "$0")
+
+LIBGIT2SHA=$(cat "${CURLOC}"/../LibGit2Sharp/libgit2_hash.txt)
+SHORTSHA="${LIBGIT2SHA:0:7}"
+
+echo "SHORTSHA=${SHORTSHA}"
+
+rm -rf "${CURLOC}"/../libgit2/build
+mkdir "${CURLOC}"/../libgit2/build
+pushd "${CURLOC}"/../libgit2/build
+
+cmake -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo \
+      -DTHREADSAFE:BOOL=ON \
+      -DBUILD_CLAR:BOOL=OFF \
+      -DUSE_SSH=OFF \
+      -DLIBGIT2_FILENAME=git2-"$SHORTSHA" \
+      -DCMAKE_OSX_ARCHITECTURES="i386;x86_64" \
+      ..
+cmake --build .
+
+popd

--- a/CI/travis.build.libgit2sharp.sh
+++ b/CI/travis.build.libgit2sharp.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+CURLOC=$(dirname "$0")
+
+# The Mono interop probing mechanism relies on absolute paths.
+# Below, a tad complicated way (but a cross-platform one) of
+# retrieving an absolute path to the libgit2 binaries.
+_BINPATH=$(cd "${CURLOC}"/../libgit2/build ; pwd)
+
+export LD_LIBRARY_PATH="$_BINPATH":$LD_LIBRARY_PATH
+export DYLD_LIBRARY_PATH="$_BINPATH":$DYLD_LIBRARY_PATH
+
+echo "DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}"
+echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}"
+
+export MONO_OPTIONS=--debug
+
+xbuild "${CURLOC}"/build.msbuild /t:Deploy
+
+exit $?

--- a/CI/travis.linux.install.deps.sh
+++ b/CI/travis.linux.install.deps.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-set -ev
+set -e
 
 sudo apt-get install cmake mono-devel mono-gmcs

--- a/CI/travis.osx.install.deps.sh
+++ b/CI/travis.osx.install.deps.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ev
+set -e
 
 MONO_VER=2.10.10
 

--- a/build.libgit2sharp.sh
+++ b/build.libgit2sharp.sh
@@ -1,31 +1,9 @@
 #!/bin/bash
+set -e
 
-LIBGIT2SHA=`cat ./LibGit2Sharp/libgit2_hash.txt`
-SHORTSHA=${LIBGIT2SHA:0:7}
+CURLOC=$(dirname "$0")
 
-rm -rf libgit2/build
-mkdir libgit2/build
-pushd libgit2/build
-export _BINPATH=`pwd`
-
-cmake -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo \
-      -DTHREADSAFE:BOOL=ON \
-      -DBUILD_CLAR:BOOL=OFF \
-      -DUSE_SSH=OFF \
-      -DLIBGIT2_FILENAME=git2-$SHORTSHA \
-      -DCMAKE_OSX_ARCHITECTURES="i386;x86_64" \
-      ..
-cmake --build .
-
-export LD_LIBRARY_PATH=$_BINPATH:$LD_LIBRARY_PATH
-export DYLD_LIBRARY_PATH=$_BINPATH:$DYLD_LIBRARY_PATH
-
-popd
-
-export MONO_OPTIONS=--debug
-
-echo $DYLD_LIBRARY_PATH
-echo $LD_LIBRARY_PATH
-xbuild CI/build.msbuild /t:Deploy
+"${CURLOC}"/CI/travis.build.libgit2.sh
+"${CURLOC}"/CI/travis.build.libgit2sharp.sh
 
 exit $?


### PR DESCRIPTION
Coverity Scan now supports C# in Beta. Might be interesting to leverage this analysis as part of our CI build.

The project has been registered but isn't fully configured yet.

Some potential references:
 - Travis CI addon: https://scan.coverity.com/travis_ci
 - Manual setup for libgit2: **[coverity.sh](https://github.com/libgit2/libgit2/blob/development/script/coverity.sh)**
 - Interesting **[comment](https://github.com/travis-ci/travis-ci/issues/1975#issuecomment-39793883)** regarding the way to override standard coverity build script