### PR TITLE
Introduce merge.ff configuration handling

### DIFF
--- a/LibGit2Sharp.Tests/MergeFixture.cs
+++ b/LibGit2Sharp.Tests/MergeFixture.cs
@@ -472,6 +472,19 @@ namespace LibGit2Sharp.Tests
         }
 
         [Fact]
+        public void CanForceFastForwardMergeThroughConfig()
+        {
+            string path = CloneMergeTestRepo();
+            using (var repo = new Repository(path))
+            {
+                repo.Config.Set("merge.ff", "only");
+
+                Commit commitToMerge = repo.Branches["normal_merge"].Tip;
+                Assert.Throws<NonFastForwardException>(() => repo.Merge(commitToMerge, Constants.Signature, new MergeOptions()));
+            }
+        }
+
+        [Fact]
         public void CanMergeAndNotCommit()
         {
             string path = CloneMergeTestRepo();
@@ -501,6 +514,24 @@ namespace LibGit2Sharp.Tests
                 Commit commitToMerge = repo.Branches["fast_forward"].Tip;
 
                 MergeResult result = repo.Merge(commitToMerge, Constants.Signature, new MergeOptions() { FastForwardStrategy = FastForwardStrategy.NoFastFoward });
+
+                Assert.Equal(MergeStatus.NonFastForward, result.Status);
+                Assert.Equal("f58f780d5a0ae392efd4a924450b1bbdc0577d32", result.Commit.Id.Sha);
+                Assert.False(repo.Index.RetrieveStatus().Any());
+            }
+        }
+
+        [Fact]
+        public void CanForceNonFastForwardMergeThroughConfig()
+        {
+            string path = CloneMergeTestRepo();
+            using (var repo = new Repository(path))
+            {
+                repo.Config.Set("merge.ff", "false");
+
+                Commit commitToMerge = repo.Branches["fast_forward"].Tip;
+
+                MergeResult result = repo.Merge(commitToMerge, Constants.Signature, new MergeOptions());
 
                 Assert.Equal(MergeStatus.NonFastForward, result.Status);
                 Assert.Equal("f58f780d5a0ae392efd4a924450b1bbdc0577d32", result.Commit.Id.Sha);

--- a/LibGit2Sharp/MergeOptions.cs
+++ b/LibGit2Sharp/MergeOptions.cs
@@ -12,7 +12,7 @@ namespace LibGit2Sharp
         /// Initializes a new instance of the <see cref="MergeOptions"/> class.
         /// <para>
         ///   Default behavior:
-        ///     A fast-forward merge will be performed if possible.
+        ///     A fast-forward merge will be performed if possible, unless the merge.ff configuration option is set.
         ///     A merge commit will be committed, if one was created.
         ///     Merge will attempt to find renames.
         /// </para>
@@ -110,9 +110,9 @@ namespace LibGit2Sharp
     public enum FastForwardStrategy
     {
         /// <summary>
-        /// Default fast-forward strategy. This will perform a fast-forward merge
-        /// if possible, otherwise will perform a non-fast-forward merge that
-        /// results in a merge commit.
+        /// Default fast-forward strategy.  If the merge.ff configuration option is set,
+        /// it will be used.  If it is not set, this will perform a fast-forward merge if
+        /// possible, otherwise a non-fast-forward merge that results in a merge commit.
         /// </summary>
         Default = 0,
 

--- a/LibGit2Sharp/Repository.cs
+++ b/LibGit2Sharp/Repository.cs
@@ -1196,6 +1196,21 @@ namespace LibGit2Sharp
             return result;
         }
 
+        private FastForwardStrategy FastForwardStrategyFromMergePreference(GitMergePreference preference)
+        {
+            switch (preference)
+            {
+                case GitMergePreference.GIT_MERGE_PREFERENCE_NONE:
+                    return FastForwardStrategy.Default;
+                case GitMergePreference.GIT_MERGE_PREFERENCE_FASTFORWARD_ONLY:
+                    return FastForwardStrategy.FastForwardOnly;
+                case GitMergePreference.GIT_MERGE_PREFERENCE_NO_FASTFORWARD:
+                    return FastForwardStrategy.NoFastFoward;
+                default:
+                    throw new InvalidOperationException(String.Format("Unknown merge preference: {0}", preference));
+            }
+        }
+
         /// <summary>
         /// Internal implementation of merge.
         /// </summary>
@@ -1217,7 +1232,10 @@ namespace LibGit2Sharp
                 return new MergeResult(MergeStatus.UpToDate);
             }
 
-            switch(options.FastForwardStrategy)
+            FastForwardStrategy fastForwardStrategy = (options.FastForwardStrategy != FastForwardStrategy.Default) ?
+                options.FastForwardStrategy : FastForwardStrategyFromMergePreference(mergePreference);
+
+            switch(fastForwardStrategy)
             {
                 case FastForwardStrategy.Default:
                     if (mergeAnalysis.HasFlag(GitMergeAnalysis.GIT_MERGE_ANALYSIS_FASTFORWARD))


### PR DESCRIPTION
When the provided `FastForwardStrategy` is `FastForwardStrategy.Default`, honor the `merge.ff` configuration setting.  When `merge.ff=only`, enable fast-forward only mode; when `merge.ff=false`, enable no-ff mode.
