### PR TITLE
[Blob] Fix truncation of Size when passing to native.

### DIFF
--- a/LibGit2Sharp/Blob.cs
+++ b/LibGit2Sharp/Blob.cs
@@ -28,7 +28,7 @@ namespace LibGit2Sharp
         /// <summary>
         /// Gets the size in bytes of the raw content of a blob.
         /// </summary>
-        public virtual int Size { get { return (int)lazySize.Value; } }
+        public virtual long Size { get { return lazySize.Value; } }
 
         /// <summary>
         ///  Determine if the blob content is most certainly binary or not.


### PR DESCRIPTION
In Blob.cs, Size was an Int32, whereas the size type for RawContentStream is a long.

I realise this is an edge case in functionality, but we should be sure we have no such issues.
