### PR TITLE
Remove unneeded clone for Remote validity test.

### DIFF
--- a/LibGit2Sharp.Tests/RemoteFixture.cs
+++ b/LibGit2Sharp.Tests/RemoteFixture.cs
@@ -151,10 +151,7 @@ namespace LibGit2Sharp.Tests
         [InlineData("/", false)]
         public void CanTellIfARemoteNameIsValid(string refname, bool expectedResult)
         {
-            using (var repo = new Repository(BareTestRepoPath))
-            {
-                Assert.Equal(expectedResult, Remote.IsValidName(refname));
-            }
+            Assert.Equal(expectedResult, Remote.IsValidName(refname));
         }
 
         [Fact]


### PR DESCRIPTION
d4a7489045a90b0d65ea513a15203469e6c38b5f didn't change the test to match current usage.
