### PR TITLE
Test cloning from a new repo in a temporary path.

### DIFF
--- a/LibGit2Sharp.Tests/CloneFixture.cs
+++ b/LibGit2Sharp.Tests/CloneFixture.cs
@@ -69,6 +69,15 @@ namespace LibGit2Sharp.Tests
             AssertLocalClone(BareTestRepoPath);
         }
 
+        [Fact]
+        public void CanCloneALocalRepositoryFromANewlyCreatedTemporaryPath()
+        {
+            var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString().Substring(0, 8));
+            SelfCleaningDirectory scd = BuildSelfCleaningDirectory(path);
+            Repository.Init(scd.DirectoryPath);
+            AssertLocalClone(scd.DirectoryPath);
+        }
+
         [Theory]
         [InlineData("http://github.com/libgit2/TestGitRepository")]
         [InlineData("https://github.com/libgit2/TestGitRepository")]


### PR DESCRIPTION
It fails in `git_clone` with error -3, but I couldn't reproduce it in `libgit2` itself.
