### PR TITLE
Commit: Introduce commentChar and prettifyMessage in CommitOptions

### DIFF
--- a/LibGit2Sharp.Tests/CommitAncestorFixture.cs
+++ b/LibGit2Sharp.Tests/CommitAncestorFixture.cs
@@ -120,9 +120,9 @@ namespace LibGit2Sharp.Tests
                 random.Author,
                 random.Committer,
                 "This is a test commit created by 'CommitFixture.CannotFindCommonAncestorForCommmitsWithoutCommonAncestor'",
-                false,
                 random.Tree,
-                Enumerable.Empty<Commit>());
+                Enumerable.Empty<Commit>(),
+                false);
 
             return orphanedCommit;
         }

--- a/LibGit2Sharp.Tests/FilterBranchFixture.cs
+++ b/LibGit2Sharp.Tests/FilterBranchFixture.cs
@@ -171,8 +171,8 @@ namespace LibGit2Sharp.Tests
         public void CanRewriteAuthorOfCommitsOnlyBeingPointedAtByTags()
         {
             var commit = repo.ObjectDatabase.CreateCommit(
-                Constants.Signature, Constants.Signature, "I'm a lonesome commit", false,
-                repo.Head.Tip.Tree, Enumerable.Empty<Commit>());
+                Constants.Signature, Constants.Signature, "I'm a lonesome commit",
+                repo.Head.Tip.Tree, Enumerable.Empty<Commit>(), false);
 
             repo.Tags.Add("so-lonely", commit);
 

--- a/LibGit2Sharp.Tests/ObjectDatabaseFixture.cs
+++ b/LibGit2Sharp.Tests/ObjectDatabaseFixture.cs
@@ -336,8 +336,8 @@ namespace LibGit2Sharp.Tests
                 Assert.IsType<GitLink>(te.Target);
                 Assert.Equal(objectId, te.Target.Id);
 
-                var commitWithSubmodule = repo.ObjectDatabase.CreateCommit(Constants.Signature, Constants.Signature, "Submodule!", false,
-                                                                           tree, new[] { repo.Head.Tip });
+                var commitWithSubmodule = repo.ObjectDatabase.CreateCommit(Constants.Signature, Constants.Signature, "Submodule!",
+                                                                           tree, new[] { repo.Head.Tip }, false);
                 repo.Reset(ResetMode.Soft, commitWithSubmodule);
 
                 var submodule = repo.Submodules[submodulePath];
@@ -373,7 +373,7 @@ namespace LibGit2Sharp.Tests
 
                 Tree tree = repo.ObjectDatabase.CreateTree(td);
 
-                Commit commit = repo.ObjectDatabase.CreateCommit(Constants.Signature, Constants.Signature, "Ü message", true, tree, new[] { repo.Head.Tip });
+                Commit commit = repo.ObjectDatabase.CreateCommit(Constants.Signature, Constants.Signature, "Ü message", tree, new[] { repo.Head.Tip }, true);
 
                 Branch newHead = repo.Head;
 
@@ -454,7 +454,7 @@ namespace LibGit2Sharp.Tests
             using (var repo = new Repository(BareTestRepoPath))
             {
                 Assert.Throws<ArgumentException>(() => repo.ObjectDatabase.CreateCommit(
-                    Constants.Signature, Constants.Signature, message, false, repo.Head.Tip.Tree, Enumerable.Empty<Commit>()));
+                    Constants.Signature, Constants.Signature, message, repo.Head.Tip.Tree, Enumerable.Empty<Commit>(), false));
             }
         }
 

--- a/LibGit2Sharp.Tests/ReflogFixture.cs
+++ b/LibGit2Sharp.Tests/ReflogFixture.cs
@@ -158,8 +158,8 @@ namespace LibGit2Sharp.Tests
 
                 var blob = repo.ObjectDatabase.CreateBlob(Stream.Null);
                 var tree = repo.ObjectDatabase.CreateTree(new TreeDefinition().Add("yoink", blob, Mode.NonExecutableFile));
-                var commit = repo.ObjectDatabase.CreateCommit(Constants.Signature, Constants.Signature, "yoink", false,
-                                                 tree, Enumerable.Empty<Commit>());
+                var commit = repo.ObjectDatabase.CreateCommit(Constants.Signature, Constants.Signature, "yoink",
+                                                 tree, Enumerable.Empty<Commit>(), false);
 
                 var branch = repo.CreateBranch("yoink", commit);
                 var log = repo.Refs.Log(branch.CanonicalName);
@@ -178,8 +178,8 @@ namespace LibGit2Sharp.Tests
 
                 var blob = repo.ObjectDatabase.CreateBlob(Stream.Null);
                 var tree = repo.ObjectDatabase.CreateTree(new TreeDefinition().Add("yoink", blob, Mode.NonExecutableFile));
-                var commit = repo.ObjectDatabase.CreateCommit(Constants.Signature, Constants.Signature, "yoink", false,
-                                                 tree, Enumerable.Empty<Commit>());
+                var commit = repo.ObjectDatabase.CreateCommit(Constants.Signature, Constants.Signature, "yoink",
+                                                 tree, Enumerable.Empty<Commit>(), false);
 
                 var direct = repo.Refs.Add("refs/heads/direct", commit.Id);
                 AssertRefLogEntry(repo, direct.CanonicalName, direct.ResolveToDirectReference().Target.Id, null);

--- a/LibGit2Sharp/CommitOptions.cs
+++ b/LibGit2Sharp/CommitOptions.cs
@@ -14,6 +14,19 @@ namespace LibGit2Sharp
     public sealed class CommitOptions
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="CommitOptions"/> class.
+        /// <para>
+        ///   Default behavior:
+        ///     The message is prettified.
+        ///     No automatic removal of comments is performed.
+        /// </para>
+        /// </summary>
+        public CommitOptions()
+        {
+            PrettifyMessage = true;
+        }
+
+        /// <summary>
         /// True to amend the current <see cref="Commit"/> pointed at by <see cref="Repository.Head"/>, false otherwise.
         /// </summary>
         public bool AmendPreviousCommit { get; set; }
@@ -22,5 +35,16 @@ namespace LibGit2Sharp
         /// True to allow creation of an empty <see cref="Commit"/>, false otherwise.
         /// </summary>
         public bool AllowEmptyCommit { get; set; }
+
+        /// <summary>
+        /// True to prettify the message by stripping leading and trailing empty lines, trailing whitespace, and collapsing consecutive empty lines, false otherwise.
+        /// </summary>
+        public bool PrettifyMessage { get; set; }
+
+        /// <summary>
+        /// The starting line char used to identify commentaries in the Commit message during the prettifying of the Commit message. If set (usually to '#'), all lines starting with this char will be removed from the message before the Commit is done.
+        /// This property will only be considered when PrettifyMessage is set to true.
+        /// </summary>
+        public char? CommentaryChar { get; set; }
     }
 }

--- a/LibGit2Sharp/Core/HistoryRewriter.cs
+++ b/LibGit2Sharp/Core/HistoryRewriter.cs
@@ -234,9 +234,9 @@ namespace LibGit2Sharp.Core
             var newCommit = repo.ObjectDatabase.CreateCommit(newHeader.Author,
                                                              newHeader.Committer,
                                                              newHeader.Message,
-                                                             true,
                                                              newTree,
-                                                             mappedNewParents);
+                                                             mappedNewParents,
+                                                             true);
 
             // Record the rewrite
             objectMap[commit] = newCommit;

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -1070,17 +1070,23 @@ namespace LibGit2Sharp.Core
 
         #region git_message_
 
-        public static string git_message_prettify(string message)
+        public static string git_message_prettify(string message, char? commentChar)
         {
             if (string.IsNullOrEmpty(message))
             {
                 return string.Empty;
             }
 
+            int comment = commentChar.GetValueOrDefault();
+            if (comment > sbyte.MaxValue)
+            {
+                throw new InvalidOperationException("Only single byte characters are allowed as commentary characters in a message (eg. '#').");
+            }
+
             using (ThreadAffinity())
             using (var buf = new GitBuf())
             {
-                int res= NativeMethods.git_message_prettify(buf, message, false, (sbyte)'#');
+                int res = NativeMethods.git_message_prettify(buf, message, false, (sbyte)comment);
                 Ensure.Int32Result(res);
 
                 return LaxUtf8Marshaler.FromNative(buf.ptr) ?? string.Empty;

--- a/LibGit2Sharp/ObjectDatabase.cs
+++ b/LibGit2Sharp/ObjectDatabase.cs
@@ -259,7 +259,32 @@ namespace LibGit2Sharp
         /// <param name="tree">The <see cref="Tree"/> of the <see cref="Commit"/> to be created.</param>
         /// <param name="parents">The parents of the <see cref="Commit"/> to be created.</param>
         /// <returns>The created <see cref="Commit"/>.</returns>
+        [Obsolete("This will be removed in future relases. Use the overload CreateCommit(Signature, Signature, string, Tree, IEnumerable<Commit>, bool, char).")]
         public virtual Commit CreateCommit(Signature author, Signature committer, string message, bool prettifyMessage, Tree tree, IEnumerable<Commit> parents)
+        {
+            return CreateCommit(author, committer, message, tree, parents, prettifyMessage);
+        }
+
+        /// <summary>
+        /// Inserts a <see cref="Commit"/> into the object database, referencing an existing <see cref="Tree"/>.
+        /// <para>
+        /// Prettifing the message includes:
+        /// * Removing empty lines from the beginning and end.
+        /// * Removing trailing spaces from every line.
+        /// * Turning multiple consecutive empty lines between paragraphs into just one empty line.
+        /// * Ensuring the commit message ends with a newline.
+        /// * Removing every line starting with "#".
+        /// </para>
+        /// </summary>
+        /// <param name="author">The <see cref="Signature"/> of who made the change.</param>
+        /// <param name="committer">The <see cref="Signature"/> of who added the change to the repository.</param>
+        /// <param name="message">The description of why a change was made to the repository.</param>
+        /// <param name="tree">The <see cref="Tree"/> of the <see cref="Commit"/> to be created.</param>
+        /// <param name="parents">The parents of the <see cref="Commit"/> to be created.</param>
+        /// <param name="prettifyMessage">True to prettify the message, or false to leave it as is.</param>
+        /// <param name="commentChar">Character that lines start with to be stripped if prettifyMessage is true.</param>
+        /// <returns>The created <see cref="Commit"/>.</returns>
+        public virtual Commit CreateCommit(Signature author, Signature committer, string message, Tree tree, IEnumerable<Commit> parents, bool prettifyMessage, char? commentChar = null)
         {
             Ensure.ArgumentNotNull(message, "message");
             Ensure.ArgumentDoesNotContainZeroByte(message, "message");
@@ -270,7 +295,7 @@ namespace LibGit2Sharp
 
             if (prettifyMessage)
             {
-                message = Proxy.git_message_prettify(message);
+                message = Proxy.git_message_prettify(message, commentChar);
             }
             GitOid[] parentIds = parents.Select(p => p.Id.Oid).ToArray();
 
@@ -296,7 +321,7 @@ namespace LibGit2Sharp
             Ensure.ArgumentDoesNotContainZeroByte(name, "name");
             Ensure.ArgumentDoesNotContainZeroByte(message, "message");
 
-            string prettifiedMessage = Proxy.git_message_prettify(message);
+            string prettifiedMessage = Proxy.git_message_prettify(message, null);
 
             ObjectId tagId = Proxy.git_tag_annotation_create(repo.Handle, name, target, tagger, prettifiedMessage);
 

--- a/LibGit2Sharp/Repository.cs
+++ b/LibGit2Sharp/Repository.cs
@@ -935,7 +935,7 @@ namespace LibGit2Sharp
                 }
             }
 
-            Commit result = ObjectDatabase.CreateCommit(author, committer, message, true, tree, parents);
+            Commit result = ObjectDatabase.CreateCommit(author, committer, message, tree, parents, options.PrettifyMessage, options.CommentaryChar);
 
             Proxy.git_repository_state_cleanup(handle);
 

--- a/LibGit2Sharp/StashCollection.cs
+++ b/LibGit2Sharp/StashCollection.cs
@@ -87,7 +87,7 @@ namespace LibGit2Sharp
         {
             Ensure.ArgumentNotNull(stasher, "stasher");
 
-            string prettifiedMessage = Proxy.git_message_prettify(string.IsNullOrEmpty(message) ? string.Empty : message);
+            string prettifiedMessage = Proxy.git_message_prettify(string.IsNullOrEmpty(message) ? string.Empty : message, null);
 
             ObjectId oid = Proxy.git_stash_save(repo.Handle, stasher, prettifiedMessage, options);
 

--- a/LibGit2Sharp/TagCollection.cs
+++ b/LibGit2Sharp/TagCollection.cs
@@ -85,7 +85,7 @@ namespace LibGit2Sharp
             Ensure.ArgumentNotNull(tagger, "tagger");
             Ensure.ArgumentNotNull(message, "message");
 
-            string prettifiedMessage = Proxy.git_message_prettify(message);
+            string prettifiedMessage = Proxy.git_message_prettify(message, null);
 
             Proxy.git_tag_create(repo.Handle, name, target, tagger, prettifiedMessage, allowOverwrite);
 


### PR DESCRIPTION
I'm still on a Mono which can't build so I'll be using travis to run the unit tests. :D
