### PR TITLE
repo.Index.Stage() won't notice a change if it occurs within the same second

### DIFF
--- a/LibGit2Sharp.Tests/StageFixture.cs
+++ b/LibGit2Sharp.Tests/StageFixture.cs
@@ -372,5 +372,25 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(expected, repo.RetrieveStatus(filename));
             }
         }
+
+        [Fact]
+        public void CanSuccessfullyStageTheContentOfAModifiedFileOfTheSameSizeWithinTheSameSecond()
+        {
+            string repoPath = InitNewRepository();
+
+            using (var repo = new Repository(repoPath))
+            {
+                for (int i = 0; i < 10; i++)
+                {
+                    Touch(repo.Info.WorkingDirectory, "test.txt",
+                               Guid.NewGuid().ToString());
+
+                    repo.Stage("test.txt");
+
+                    Assert.DoesNotThrow(() => repo.Commit(
+                                "Commit", Constants.Signature, Constants.Signature));
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
The test below actually fails

```csharp
[Fact]
public void CanSuccessfullyStageAModifiedFileOfTheSameSizeWithinTheSameSecond()
{
    string repoPath = InitNewRepository();

    using (var repo = new Repository(repoPath))
    {
        for (int i = 0; i < 10; i++)
        {
            Touch(repo.Info.WorkingDirectory, "test.txt",
                       Guid.NewGuid().ToString());

            repo.Index.Stage("test.txt");

            Assert.DoesNotThrow(() => repo.Commit(
                        "Commit", Constants.Signature, Constants.Signature));
        } 
    }
}
```

See this **[SO question](http://stackoverflow.com/questions/23242825/wait-until-commit-operation-is-finished/23246222#23246222)** for some background information.