### PR TITLE
Replace deprecated MSBuild CreateItem with ItemGroup

### DIFF
--- a/CI/build.msbuild
+++ b/CI/build.msbuild
@@ -41,15 +41,17 @@
   </Target>
 
   <Target Name="Deploy" DependsOnTargets="Test">
-    <CreateItem Include="$(TestBuildDir)\LibGit2*.*">
-        <Output TaskParameter="Include" ItemName="OutputFiles" />
-    </CreateItem>
+    <ItemGroup>
+      <OutputFiles Include="$(TestBuildDir)\LibGit2*.*" />
+    </ItemGroup>
+
     <Copy SourceFiles="@(OutputFiles)"
         DestinationFiles="@(OutputFiles->'$(DeployFolder)\%(RecursiveDir)%(Filename)%(Extension)')" />
 
-    <CreateItem Include="$(TestBuildDir)\NativeBinaries\**\*.*">
-        <Output TaskParameter="Include" ItemName="NativeBinaries" />
-    </CreateItem>
+    <ItemGroup>
+      <NativeBinaries Include="$(TestBuildDir)\NativeBinaries\**\*.*" />
+    </ItemGroup>
+
     <Copy SourceFiles="@(NativeBinaries)"
       DestinationFiles="@(NativeBinaries->'$(DeployFolder)\NativeBinaries\%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true" />
   </Target>

--- a/LibGit2Sharp/CopyWindowsNativeDependencies.targets
+++ b/LibGit2Sharp/CopyWindowsNativeDependencies.targets
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Target Name="AfterBuild" Condition="'$(OS)' == 'Windows_NT'">
-    <CreateItem Include="$(NativeBinariesDirectory)\**\*.*">
-      <Output TaskParameter="Include" ItemName="NativeBinaries" />
-    </CreateItem>
+    <ItemGroup>
+      <NativeBinaries Include="$(NativeBinariesDirectory)\**\*.*" />
+    </ItemGroup>
 
     <Copy
       SourceFiles="@(NativeBinaries)"


### PR DESCRIPTION
Partial follow up to #733.

- This doesn't solve the "let's be nice with libgit2 binaries on non Windows platforms" issue.

- This only focus on trying to get a little bit more compatible when it comes to `.targets` files and the different flavors of Mono.

- This actually doesn't work. yet. (or at least I hope that it will *eventually* work)

Related:
 - https://bugzilla.xamarin.com/show_bug.cgi?id=3055
 - https://connect.microsoft.com/VisualStudio/feedback/details/615290/itemgroup-tag-works-different-to-deprecated-createitem-task