### PR TITLE
Use a callback for credentials

### DIFF
--- a/LibGit2Sharp.Tests/CloneFixture.cs
+++ b/LibGit2Sharp.Tests/CloneFixture.cs
@@ -151,7 +151,7 @@ namespace LibGit2Sharp.Tests
             string clonedRepoPath = Repository.Clone(Constants.PrivateRepoUrl, scd.DirectoryPath,
                 new CloneOptions()
                 {
-                    Credentials = Constants.PrivateRepoCredentials
+                    CredentialsProvider = (_url, _user, _cred) => Constants.PrivateRepoCredentials
                 });
 
 

--- a/LibGit2Sharp.Tests/FetchFixture.cs
+++ b/LibGit2Sharp.Tests/FetchFixture.cs
@@ -60,7 +60,7 @@ namespace LibGit2Sharp.Tests
                 // Perform the actual fetch
                 repo.Network.Fetch(remote, new FetchOptions
                 {
-                    Credentials = Constants.PrivateRepoCredentials
+                    CredentialsProvider = (_url, _user, _credtype) => Constants.PrivateRepoCredentials
                 });
             }
         }

--- a/LibGit2Sharp.Tests/NetworkFixture.cs
+++ b/LibGit2Sharp.Tests/NetworkFixture.cs
@@ -121,7 +121,7 @@ namespace LibGit2Sharp.Tests
             {
                 Remote remote = repo.Network.Remotes.Add(remoteName, Constants.PrivateRepoUrl);
 
-                var references = repo.Network.ListReferences(remote, Constants.PrivateRepoCredentials);
+                var references = repo.Network.ListReferences(remote, (_url, _user, _credtype) => Constants.PrivateRepoCredentials);
 
                 foreach (var directReference in references)
                 {

--- a/LibGit2Sharp/CloneOptions.cs
+++ b/LibGit2Sharp/CloneOptions.cs
@@ -1,4 +1,5 @@
-﻿using LibGit2Sharp.Core;
+﻿using System;
+using LibGit2Sharp.Core;
 using LibGit2Sharp.Handlers;
 
 namespace LibGit2Sharp
@@ -40,7 +41,7 @@ namespace LibGit2Sharp
         /// <summary>
         /// Credentials to use for user/pass authentication
         /// </summary>
-        public Credentials Credentials { get; set; }
+        public CredentialsHandler CredentialsProvider { get; set; }
 
         #region IConvertableToGitCheckoutOpts
 

--- a/LibGit2Sharp/FetchOptions.cs
+++ b/LibGit2Sharp/FetchOptions.cs
@@ -1,4 +1,5 @@
-﻿using LibGit2Sharp.Handlers;
+﻿using System;
+using LibGit2Sharp.Handlers;
 
 namespace LibGit2Sharp
 {
@@ -41,6 +42,6 @@ namespace LibGit2Sharp
         /// <summary>
         /// Credentials to use for username/password authentication.
         /// </summary>
-        public Credentials Credentials { get; set; }
+        public CredentialsHandler CredentialsProvider { get; set; }
     }
 }

--- a/LibGit2Sharp/Handlers.cs
+++ b/LibGit2Sharp/Handlers.cs
@@ -23,6 +23,14 @@
     public delegate bool UpdateTipsHandler(string referenceName, ObjectId oldId, ObjectId newId);
 
     /// <summary>
+    /// Delegate definition for the credentials retrieval callback
+    /// </summary>
+    /// <param name="usernameFromUrl">Username which was extracted form the url, if any</param>
+    /// <param name="url">The url</param>
+    /// <param name="types">Credential types which the server accepts</param>
+    public delegate Credentials CredentialsHandler(string url, string usernameFromUrl, SupportedCredentialTypes types);
+
+    /// <summary>
     /// Delegate definition for transfer progress callback.
     /// </summary>
     /// <param name="progress">The <see cref="TransferProgress"/> object containing progress information.</param>

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -317,6 +317,7 @@
     <Compile Include="VoidReference.cs" />
     <Compile Include="Core\RawContentStream.cs" />
     <Compile Include="Core\Handles\OdbStreamSafeHandle.cs" />
+    <Compile Include="SupportedCredentialTypes.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="CustomDictionary.xml" />

--- a/LibGit2Sharp/Network.cs
+++ b/LibGit2Sharp/Network.cs
@@ -46,17 +46,17 @@ namespace LibGit2Sharp
         /// </para>
         /// </summary>
         /// <param name="remote">The <see cref="Remote"/> to list from.</param>
-        /// <param name="credentials">The optional <see cref="Credentials"/> used to connect to remote repository.</param>
+        /// <param name="credentials">The optional <see cref="Func<Credentials>"/> used to connect to remote repository.</param>
         /// <returns>The references in the <see cref="Remote"/> repository.</returns>
-        public virtual IEnumerable<DirectReference> ListReferences(Remote remote, Credentials credentials = null)
+        public virtual IEnumerable<DirectReference> ListReferences(Remote remote, CredentialsHandler credentialsProvider = null)
         {
             Ensure.ArgumentNotNull(remote, "remote");
 
             using (RemoteSafeHandle remoteHandle = Proxy.git_remote_load(repository.Handle, remote.Name, true))
             {
-                if (credentials != null)
+                if (credentialsProvider != null)
                 {
-                    var callbacks = new RemoteCallbacks(null, null, null, credentials);
+                    var callbacks = new RemoteCallbacks(null, null, null, credentialsProvider);
                     GitRemoteCallbacks gitCallbacks = callbacks.GenerateCallbacks();
                     Proxy.git_remote_set_callbacks(remoteHandle, ref gitCallbacks);
                 }
@@ -272,7 +272,7 @@ namespace LibGit2Sharp
             // Load the remote.
             using (RemoteSafeHandle remoteHandle = Proxy.git_remote_load(repository.Handle, remote.Name, true))
             {
-                var callbacks = new RemoteCallbacks(null, null, null, pushOptions.Credentials);
+                var callbacks = new RemoteCallbacks(null, null, null, pushOptions.CredentialsProvider);
                 GitRemoteCallbacks gitCallbacks = callbacks.GenerateCallbacks();
                 Proxy.git_remote_set_callbacks(remoteHandle, ref gitCallbacks);
 

--- a/LibGit2Sharp/PushOptions.cs
+++ b/LibGit2Sharp/PushOptions.cs
@@ -1,4 +1,5 @@
-﻿using LibGit2Sharp.Handlers;
+﻿using System;
+using LibGit2Sharp.Handlers;
 
 namespace LibGit2Sharp
 {
@@ -10,7 +11,7 @@ namespace LibGit2Sharp
         /// <summary>
         /// The <see cref="Credentials"/> to authenticate with during the push.
         /// </summary>
-        public Credentials Credentials { get; set; }
+        public CredentialsHandler CredentialsProvider { get; set; }
 
         /// <summary>
         /// If the transport being used to push to the remote requires the creation

--- a/LibGit2Sharp/Repository.cs
+++ b/LibGit2Sharp/Repository.cs
@@ -545,7 +545,7 @@ namespace LibGit2Sharp
             {
                 var gitCheckoutOptions = checkoutOptionsWrapper.Options;
 
-                var remoteCallbacks = new RemoteCallbacks(null, options.OnTransferProgress, null, options.Credentials);
+                var remoteCallbacks = new RemoteCallbacks(null, options.OnTransferProgress, null, options.CredentialsProvider);
                 var gitRemoteCallbacks = remoteCallbacks.GenerateCallbacks();
 
                 var cloneOpts = new GitCloneOptions

--- a/LibGit2Sharp/SupportedCredentialTypes.cs
+++ b/LibGit2Sharp/SupportedCredentialTypes.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace LibGit2Sharp
+{
+    /// <summary>
+    /// Credential types supported by the server. If the server supports a particular type of
+    /// authentication, it will be set to true.
+    /// </summary>
+    [Flags]
+    public enum SupportedCredentialTypes
+    {
+        /// <summary>
+        /// Plain username and password combination
+        /// </summary>
+        UsernamePassword = (1 << 0),
+
+        /// <summary>
+        /// Ask Windows to provide its default credentials for the current user (e.g. NTLM)
+        /// </summary>
+        Default = (1 << 1),
+    }
+}


### PR DESCRIPTION
Instead of making the user choose beforehand, use a callback to let the
user ask a database or human about the credentials.

If desired, a hard-coded value can still be provided via a lambda, e.g.

```
(_url, _user, _types) => new UsernamePasswordCredentials() { ... }
```

/cc @nulltoken @Therzok
