### PR TITLE
Remove conflicts in Index.Remove

### DIFF
--- a/LibGit2Sharp.Tests/ConflictFixture.cs
+++ b/LibGit2Sharp.Tests/ConflictFixture.cs
@@ -51,6 +51,8 @@ namespace LibGit2Sharp.Tests
         [InlineData(false, "ancestor-and-ours.txt", true, true, FileStatus.Removed |FileStatus.Untracked, 2)]
         [InlineData(true, "ancestor-and-theirs.txt", true, false, FileStatus.Nonexistent, 2)]
         [InlineData(false, "ancestor-and-theirs.txt", true, true, FileStatus.Untracked, 2)]
+        [InlineData(true, "ancestor-only.txt", false, false, FileStatus.Nonexistent, 1)]
+        [InlineData(false, "ancestor-only.txt", false, false, FileStatus.Nonexistent, 1)]
         [InlineData(true, "conflicts-one.txt", true, false, FileStatus.Removed, 3)]
         [InlineData(false, "conflicts-one.txt", true, true, FileStatus.Removed | FileStatus.Untracked, 3)]
         [InlineData(true, "conflicts-two.txt", true, false, FileStatus.Removed, 3)]
@@ -61,13 +63,6 @@ namespace LibGit2Sharp.Tests
         [InlineData(false, "ours-only.txt", true, true, FileStatus.Removed | FileStatus.Untracked, 1)]
         [InlineData(true, "theirs-only.txt", true, false, FileStatus.Nonexistent, 1)]
         [InlineData(false, "theirs-only.txt", true, true, FileStatus.Untracked, 1)]
-        /* Conflicts clearing through Index.Remove() only works when a version of the entry exists in the workdir.
-         * This is because libgit2's git_iterator_for_index() seem to only care about stage level 0.
-         * Corrolary: other cases only work out of sheer luck (however, the behaviour is stable, so I guess we
-         *   can rely on it for the moment.
-         * [InlineData(true, "ancestor-only.txt", false, false, FileStatus.Nonexistent, 0)]
-         * [InlineData(false, "ancestor-only.txt", false, false, FileStatus.Nonexistent, 0)]
-         */
         public void CanResolveConflictsByRemovingFromTheIndex(
             bool removeFromWorkdir, string filename, bool existsBeforeRemove, bool existsAfterRemove, FileStatus lastStatus, int removedIndexEntries)
         {

--- a/LibGit2Sharp.Tests/RemoveFixture.cs
+++ b/LibGit2Sharp.Tests/RemoveFixture.cs
@@ -180,7 +180,7 @@ namespace LibGit2Sharp.Tests
                 Assert.Throws<ArgumentException>(() => repo.Index.Remove(string.Empty));
                 Assert.Throws<ArgumentNullException>(() => repo.Index.Remove((string)null));
                 Assert.Throws<ArgumentException>(() => repo.Index.Remove(new string[] { }));
-                Assert.Throws<ArgumentException>(() => repo.Index.Remove(new string[] { null }));
+                Assert.Throws<ArgumentNullException>(() => repo.Index.Remove(new string[] { null }));
             }
         }
     }

--- a/LibGit2Sharp/Core/Ensure.cs
+++ b/LibGit2Sharp/Core/Ensure.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Linq;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -21,6 +23,21 @@ namespace LibGit2Sharp.Core
             if (argumentValue == null)
             {
                 throw new ArgumentNullException(argumentName);
+            }
+        }
+
+        /// <summary>
+        /// Checks an array argument to ensure it isn't null or empty.
+        /// </summary>
+        /// <param name="argumentValue">The argument value to check.</param>
+        /// <param name="argumentName">The name of the argument.</param>
+        public static void ArgumentNotNullOrEmptyEnumerable<T>(IEnumerable<T> argumentValue, string argumentName)
+        {
+            ArgumentNotNull(argumentValue, argumentName);
+
+            if (argumentValue.Count() == 0)
+            {
+                throw new ArgumentException("Enumerable cannot be empty", argumentName);
             }
         }
 


### PR DESCRIPTION
We never got around to dealing with conflicts properly in #398.  We should do that.
