### PR TITLE
FastForward merge should block if there are checkout conflicts.

### DIFF
--- a/LibGit2Sharp.Tests/MergeFixture.cs
+++ b/LibGit2Sharp.Tests/MergeFixture.cs
@@ -573,6 +573,32 @@ namespace LibGit2Sharp.Tests
         }
 
         [Theory]
+        [InlineData(true, FastForwardStrategy.FastForwardOnly)]
+        [InlineData(false, FastForwardStrategy.FastForwardOnly)]
+        [InlineData(true, FastForwardStrategy.NoFastFoward)]
+        [InlineData(false, FastForwardStrategy.NoFastFoward)]
+        public void MergeWithWorkDirConflictsThrows(bool shouldStage, FastForwardStrategy strategy)
+        {
+            // Merging the fast_forward branch results in a change to file
+            // b.txt. In this test we modify the file in the working directory
+            // and then attempt to perform a merge. We expect the merge to fail
+            // due to merge conflicts.
+            string committishToMerge = "fast_forward";
+
+            using (var repo = new Repository(CloneMergeTestRepo()))
+            {
+                Touch(repo.Info.WorkingDirectory, "b.txt", "this is an alternate change");
+
+                if (shouldStage)
+                {
+                    repo.Index.Stage("b.txt");
+                }
+
+                Assert.Throws<MergeConflictException>(() => repo.Merge(committishToMerge, Constants.Signature, new MergeOptions() { FastForwardStrategy = strategy }));
+            }
+        }
+
+        [Theory]
         [InlineData(CheckoutFileConflictStrategy.Ours)]
         [InlineData(CheckoutFileConflictStrategy.Theirs)]
         public void CanSpecifyConflictFileStrategy(CheckoutFileConflictStrategy conflictStrategy)

--- a/LibGit2Sharp/CherryPickOptions.cs
+++ b/LibGit2Sharp/CherryPickOptions.cs
@@ -104,7 +104,6 @@ namespace LibGit2Sharp
             get
             {
                 return CheckoutStrategy.GIT_CHECKOUT_SAFE |
-                       CheckoutStrategy.GIT_CHECKOUT_ALLOW_CONFLICTS |
                        GitCheckoutOptsWrapper.CheckoutStrategyFromFileConflictStrategy(FileConflictStrategy);
             }
         }

--- a/LibGit2Sharp/Core/GitCheckoutOpts.cs
+++ b/LibGit2Sharp/Core/GitCheckoutOpts.cs
@@ -160,4 +160,50 @@ namespace LibGit2Sharp.Core
 
         CheckoutNotifyFlags CheckoutNotifyFlags { get; }
     }
+
+    /// <summary>
+    /// This wraps an IConvertableToGitCheckoutOpts object and can tweak the
+    /// properties so that they are appropriate for a checkout performed as
+    /// part of a FastForward merge. Most properties are passthrough to the
+    /// wrapped object.
+    /// </summary>
+    internal class FastForwardCheckoutOptionsAdapter : IConvertableToGitCheckoutOpts
+    {
+        private IConvertableToGitCheckoutOpts internalOptions;
+
+        internal FastForwardCheckoutOptionsAdapter(IConvertableToGitCheckoutOpts internalOptions)
+        {
+            this.internalOptions = internalOptions;
+        }
+
+        /// <summary>
+        /// Passthrough to the wrapped object.
+        /// </summary>
+        /// <returns></returns>
+        public CheckoutCallbacks GenerateCallbacks()
+        {
+            return internalOptions.GenerateCallbacks();
+        }
+
+        /// <summary>
+        /// There should be no resolvable conflicts in a FastForward merge.
+        /// Just perform checkout with the safe checkout strategy.
+        /// </summary>
+        public CheckoutStrategy CheckoutStrategy
+        {
+            get
+            {
+                return CheckoutStrategy.GIT_CHECKOUT_SAFE;
+            }
+        }
+
+        /// <summary>
+        /// Passthrough to the wrapped object.
+        /// </summary>
+        /// <returns></returns>
+        public CheckoutNotifyFlags CheckoutNotifyFlags
+        {
+            get { return internalOptions.CheckoutNotifyFlags; }
+        }
+    }
 }

--- a/LibGit2Sharp/MergeOptions.cs
+++ b/LibGit2Sharp/MergeOptions.cs
@@ -95,8 +95,7 @@ namespace LibGit2Sharp
         {
             get
             {
-                return CheckoutStrategy.GIT_CHECKOUT_SAFE|
-                       CheckoutStrategy.GIT_CHECKOUT_ALLOW_CONFLICTS |
+                return CheckoutStrategy.GIT_CHECKOUT_SAFE |
                        GitCheckoutOptsWrapper.CheckoutStrategyFromFileConflictStrategy(FileConflictStrategy);
             }
         }

--- a/LibGit2Sharp/Repository.cs
+++ b/LibGit2Sharp/Repository.cs
@@ -1351,7 +1351,7 @@ namespace LibGit2Sharp
             Commit fastForwardCommit = (Commit) Lookup(id, ObjectType.Commit);
             Ensure.GitObjectIsNotNull(fastForwardCommit, id.Sha);
 
-            CheckoutTree(fastForwardCommit.Tree, null, options);
+            CheckoutTree(fastForwardCommit.Tree, null, new FastForwardCheckoutOptionsAdapter(options));
 
             var reference = Refs.Head.ResolveToDirectReference();
 

--- a/LibGit2Sharp/RevertOptions.cs
+++ b/LibGit2Sharp/RevertOptions.cs
@@ -104,7 +104,6 @@ namespace LibGit2Sharp
             get
             {
                 return CheckoutStrategy.GIT_CHECKOUT_SAFE |
-                       CheckoutStrategy.GIT_CHECKOUT_ALLOW_CONFLICTS |
                        GitCheckoutOptsWrapper.CheckoutStrategyFromFileConflictStrategy(FileConflictStrategy);
             }
         }


### PR DESCRIPTION
Currently, if there are changes in your working directory and
a fastforward merge would update those files, the checkout
that is performed as part of the fast forward will skip over
these files. This change fixes and adds regression tests around
this behavior.

Originally, we needed to pass in the `GIT_CHECKOUT_ALLOW_CONFLICTS` flag for the merge calls, but this flag should not be passed in during the fast-forward update. There have been updates for libgit2 since this was originally implemented where this flag should not even be passed to the merge calls.

/cc @ethomson 
