### PR TITLE
Demonstrates interesting problem with Remote

### DIFF
--- a/LibGit2Sharp/CloneOptions.cs
+++ b/LibGit2Sharp/CloneOptions.cs
@@ -15,6 +15,7 @@ namespace LibGit2Sharp
         public CloneOptions()
         {
             Checkout = true;
+            OnRemoteCreation = DefaultRemoteCreationHandler;
         }
 
         /// <summary>
@@ -48,6 +49,34 @@ namespace LibGit2Sharp
         /// Handler to generate <see cref="LibGit2Sharp.Credentials"/> for authentication.
         /// </summary>
         public CredentialsHandler CredentialsProvider { get; set; }
+
+        /// <summary>
+        /// Handler to use to create the remote.
+        /// </summary>
+        public RemoteCreationHandler OnRemoteCreation { get; set; }
+
+        /// <summary>
+        /// Default remote creation handler for the CloneOptions.
+        /// </summary>
+        /// <param name="repo">The repository where the remote should be created</param>
+        /// <param name="name">The suggested name of the remote</param>
+        /// <param name="url">The suggested URL of the remote</param>
+        /// <returns>The created remote</returns>
+        public Remote DefaultRemoteCreationHandler(Repository repo, string name, string url)
+        {
+            // Use the suggested remote name (generally "origin") and URI.
+            Remote remote = repo.Network.Remotes.Add(name, url);
+
+            // TODO: The caller ought to be able to invoke any or all of the following here:
+            //   git_remote_set_transport
+            //   git_remote_check_cert
+            //   git_remote_set_callbacks
+            //
+            // These all represent volatile properties of a git_remote instance, and are not
+            // serialized back to the "store" of remotes.
+
+            return remote;
+        }
 
         #region IConvertableToGitCheckoutOpts
 

--- a/LibGit2Sharp/Core/GitCloneOptions.cs
+++ b/LibGit2Sharp/Core/GitCloneOptions.cs
@@ -28,7 +28,7 @@ namespace LibGit2Sharp.Core
         public IntPtr RepositoryCb;
         public IntPtr RepositoryCbPayload;
 
-        public IntPtr RemoteCb;
+        public NativeMethods.git_remote_create_cb RemoteCb;
         public IntPtr RemoteCbPayload;
     }
 }

--- a/LibGit2Sharp/Core/Handles/RepositorySafeHandle.cs
+++ b/LibGit2Sharp/Core/Handles/RepositorySafeHandle.cs
@@ -1,7 +1,20 @@
-﻿namespace LibGit2Sharp.Core.Handles
+﻿using System;
+
+namespace LibGit2Sharp.Core.Handles
 {
     internal class RepositorySafeHandle : SafeHandleBase
     {
+        public RepositorySafeHandle()
+            : base()
+        {
+        }
+
+        public RepositorySafeHandle(IntPtr value)
+            : base(ownsHandle: false)
+        {
+            SetHandle(value);
+        }
+
         protected override bool ReleaseHandleImpl()
         {
             Proxy.git_repository_free(handle);

--- a/LibGit2Sharp/Core/Handles/SafeHandleBase.cs
+++ b/LibGit2Sharp/Core/Handles/SafeHandleBase.cs
@@ -21,7 +21,12 @@ namespace LibGit2Sharp.Core.Handles
         private int registered;
 
         protected SafeHandleBase()
-            : base(IntPtr.Zero, true)
+            : this(ownsHandle: true)
+        {
+        }
+
+        protected SafeHandleBase(bool ownsHandle)
+            : base(IntPtr.Zero, ownsHandle)
         {
             NativeMethods.AddHandle();
             registered = 1;

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -256,6 +256,13 @@ namespace LibGit2Sharp.Core
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath workdir_path,
             ref GitCloneOptions opts);
 
+        internal delegate int git_remote_create_cb(
+            out IntPtr remote,
+            IntPtr repo,
+            IntPtr name,
+            IntPtr url,
+            IntPtr payload);
+
         [DllImport(libgit2)]
         internal static extern IntPtr git_commit_author(GitObjectSafeHandle commit);
 

--- a/LibGit2Sharp/Handlers.cs
+++ b/LibGit2Sharp/Handlers.cs
@@ -97,6 +97,21 @@
     public delegate void RemoteRenameFailureHandler(string problematicRefspec);
 
     /// <summary>
+    /// Delegate definition for remote creation callback during a clone operation.
+    /// <para>
+    ///   This callback is called to allow the caller of Repository.Clone to override
+    ///   the creation of the remote prior to its use in the clone process. The caller
+    ///   can use this callback to customize properties such as the remote name, SSL
+    ///   certificate validation, and the transport to be used to perform the clone.
+    /// </para>
+    /// </summary>
+    /// <param name="repo">The repository where the remote should be created</param>
+    /// <param name="name">The suggested name of the remote</param>
+    /// <param name="url">The suggested URL of the remote</param>
+    /// <returns>The created remote</returns>
+    public delegate Remote RemoteCreationHandler(Repository repo, string name, string url);
+
+    /// <summary>
     /// The stages of pack building.
     /// </summary>
     public enum PackBuilderStage


### PR DESCRIPTION
This shows a scenario where we would want to have an object in LibGit2Sharp which represents a `git_remote` at runtime -- an object backed by a handle to a `git_remote` whose lifetime matches a `git_remote`.

I suppose we could just add one! Maybe we could call it `RuntimeRemote` or something :)
