### PR TITLE
Test for tracking deleted branch

### DIFF
--- a/LibGit2Sharp.Tests/BranchFixture.cs
+++ b/LibGit2Sharp.Tests/BranchFixture.cs
@@ -503,6 +503,28 @@ namespace LibGit2Sharp.Tests
         }
 
         [Fact]
+        public void TrackingInformationIsEmptyForBranchTrackingPrunedRemoteBranch()
+        {
+            var path = CloneStandardTestRepo();
+            using (var repo = new Repository(path))
+            {
+                const string remoteRef = "refs/remotes/origin/master";
+                repo.Refs.Remove(remoteRef);
+
+                Branch master = repo.Branches["master"];
+                Assert.True(master.IsTracking);
+                Assert.NotNull(master.TrackedBranch);
+                Assert.Equal(remoteRef, master.TrackedBranch.CanonicalName);
+                Assert.Null(master.TrackedBranch.Tip);
+
+                Assert.NotNull(master.TrackingDetails);
+                Assert.Null(master.TrackingDetails.AheadBy);
+                Assert.Null(master.TrackingDetails.BehindBy);
+                Assert.Null(master.TrackingDetails.CommonAncestor);
+            }
+        }
+
+        [Fact]
         public void TrackingInformationIsEmptyForNonTrackingBranch()
         {
             using (var repo = new Repository(BareTestRepoPath))


### PR DESCRIPTION
Got a question over email:

> we just cleaned up our origin and stripped it of a bunch of branches that are no longer used.  If the user’s local repo is set to one of those cleaned branches, I fail out when I try to get the ahead/behind status of the branch.  I would like to be able to automatically prune local of these deprecated branches, but I can’t find a way to use LibGit2Sharp to accomplish that.

The attached test simply proves (I think) that we're doing The Right Thing™ for branches tracking pruned remote refs.
