### PR TITLE
Expose git_index_write_tree and git_index_read_tree with a nice API

### DIFF
--- a/LibGit2Sharp.Tests/ObjectDatabaseFixture.cs
+++ b/LibGit2Sharp.Tests/ObjectDatabaseFixture.cs
@@ -361,6 +361,40 @@ namespace LibGit2Sharp.Tests
         }
 
         [Fact]
+        public void CreatingATreeFromIndexWithUnmergedEntriesThrows()
+        {
+            using (var repo = new Repository(MergedTestRepoWorkingDirPath))
+            {
+                Assert.False(repo.Index.IsFullyMerged);
+
+                Assert.Throws<UnmergedIndexEntriesException>(
+                    () => repo.ObjectDatabase.CreateTree(repo.Index));
+            }
+        }
+
+        [Fact]
+        public void CanCreateATreeFromIndex()
+        {
+            string path = CloneStandardTestRepo();
+
+            using (var repo = new Repository(path))
+            {
+                const string expectedIndexTreeSha = "0fe0fd1943a1b63ecca36fa6bbe9bbe045f791a4";
+
+                // The tree representing the index is not in the db.
+                Assert.Null(repo.Lookup(expectedIndexTreeSha));
+
+                var tree = repo.ObjectDatabase.CreateTree(repo.Index);
+                Assert.NotNull(tree);
+                Assert.Equal(expectedIndexTreeSha, tree.Id.Sha);
+
+                // The tree representing the index is now in the db.
+                tree = repo.Lookup<Tree>(expectedIndexTreeSha);
+                Assert.NotNull(tree);
+            }
+        }
+
+        [Fact]
         public void CanCreateACommit()
         {
             string path = CloneBareTestRepo();

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -610,6 +610,9 @@ namespace LibGit2Sharp.Core
         internal static extern int git_index_write_tree(out GitOid treeOid, IndexSafeHandle index);
 
         [DllImport(libgit2)]
+        internal static extern int git_index_read_tree(IndexSafeHandle index, GitObjectSafeHandle tree);
+
+        [DllImport(libgit2)]
         internal static extern int git_merge_base_many(
             out GitOid mergeBase,
             RepositorySafeHandle repo,

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -984,6 +984,15 @@ namespace LibGit2Sharp.Core
             }
         }
 
+        public static void git_index_read_fromtree(Index index, GitObjectSafeHandle tree)
+        {
+            using (ThreadAffinity())
+            {
+                int res = NativeMethods.git_index_read_tree(index.Handle, tree);
+                Ensure.ZeroResult(res);
+            }
+        }
+
         #endregion
 
         #region git_merge_

--- a/LibGit2Sharp/Index.cs
+++ b/LibGit2Sharp/Index.cs
@@ -458,6 +458,23 @@ namespace LibGit2Sharp
             }
         }
 
+        /// <summary>
+        /// Replaces entries in the staging area with entries from the specified tree.
+        /// <para>
+        ///   This overwrites all existing state in the staging area.
+        /// </para>
+        /// </summary>
+        /// <param name="source">The <see cref="Tree"/> to read the entries from.</param>
+        public virtual void Reset(Tree source)
+        {
+            using (var obj = new ObjectSafeWrapper(source.Id, repo.Handle))
+            {
+                Proxy.git_index_read_fromtree(this, obj.ObjectPtr);
+            }
+
+            UpdatePhysicalIndex();
+        }
+
         private IDictionary<Tuple<string, FileStatus>, Tuple<string, FileStatus>> PrepareBatch(IEnumerable<string> leftPaths, IEnumerable<string> rightPaths)
         {
             IDictionary<Tuple<string, FileStatus>, Tuple<string, FileStatus>> dic = new Dictionary<Tuple<string, FileStatus>, Tuple<string, FileStatus>>();

--- a/LibGit2Sharp/ObjectDatabase.cs
+++ b/LibGit2Sharp/ObjectDatabase.cs
@@ -246,6 +246,25 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
+        /// Inserts a <see cref="Tree"/> into the object database, created from the <see cref="Index"/>.
+        /// <para>
+        ///   It recursively creates tree objects for each of the subtrees stored in the index, but only returns the root tree.
+        /// </para>
+        /// <para>
+        ///   The index must be fully merged.
+        /// </para>
+        /// </summary>
+        /// <param name="index">The <see cref="Index"/>.</param>
+        /// <returns>The created <see cref="Tree"/>. This can be used e.g. to create a <see cref="Commit"/>.</returns>
+        public virtual Tree CreateTree(Index index)
+        {
+            Ensure.ArgumentNotNull(index, "index");
+
+            var treeId = Proxy.git_tree_create_fromindex(index);
+            return this.repo.Lookup<Tree>(treeId);
+        }
+
+        /// <summary>
         /// Inserts a <see cref="Commit"/> into the object database, referencing an existing <see cref="Tree"/>.
         /// <para>
         /// Prettifing the message includes:


### PR DESCRIPTION
Hi,

In my project I need to be able to read/write the index from/to a tree (libgit2 git_index_write_tree and git_index_read_tree). I understand these are plumbing operations and probably not useful for everybody, but, hey, I need them, and perhaps if they're exposed in a nice way you're gonna be OK with them :)

I tried to stay away from libgit2 names, as they were confusing for me at first, so I thought to expose git_index_write_tree as Index.CreateTree and git_index_read_tree as Index.ReplaceWithTree. I am not feeling strong about the names, so please feel free to make better suggestions :).

I've added tests for the following:
- Index.CreateTree throws when the index has conflicts
- Index.CreateTree works & inserts tree in objects db
- Index.ReplaceWithTree works & is persisted to disk (I only check that a previously added file becomes untracked, I don't think it is necessary to check all the previously staged files) 

Cheers,
Alex
