### PR TITLE
Exposing clearing the index

### DIFF
--- a/LibGit2Sharp.Tests/IndexFixture.cs
+++ b/LibGit2Sharp.Tests/IndexFixture.cs
@@ -340,5 +340,31 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(FileStatus.Modified, repo.Index.RetrieveStatus(testFile));
             }
         }
+
+        [Fact]
+        public void CanClearTheIndex()
+        {
+            string path = CloneStandardTestRepo();
+            const string testFile = "1.txt";
+
+            // It is sufficient to check just one of the stage area changes, such as the modified file,
+            // to verify that the index has indeed been read from the tree.
+            using (var repo = new Repository(path))
+            {
+                Assert.Equal(FileStatus.Unaltered, repo.Index.RetrieveStatus(testFile));
+                Assert.NotEqual(0, repo.Index.Count);
+
+                repo.Index.Clear();
+                Assert.Equal(0, repo.Index.Count);
+
+                Assert.Equal(FileStatus.Removed | FileStatus.Untracked, repo.Index.RetrieveStatus(testFile));
+            }
+
+            // Check that the index was persisted to disk.
+            using (var repo = new Repository(path))
+            {
+                Assert.Equal(FileStatus.Removed | FileStatus.Untracked, repo.Index.RetrieveStatus(testFile));
+            }
+        }
     }
 }

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -613,6 +613,9 @@ namespace LibGit2Sharp.Core
         internal static extern int git_index_read_tree(IndexSafeHandle index, GitObjectSafeHandle tree);
 
         [DllImport(libgit2)]
+        internal static extern int git_index_clear(IndexSafeHandle index);
+
+        [DllImport(libgit2)]
         internal static extern int git_merge_base_many(
             out GitOid mergeBase,
             RepositorySafeHandle repo,

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -993,6 +993,15 @@ namespace LibGit2Sharp.Core
             }
         }
 
+        public static void git_index_clear(Index index)
+        {
+            using (ThreadAffinity())
+            {
+                int res = NativeMethods.git_index_clear(index.Handle);
+                Ensure.ZeroResult(res);
+            }
+        }
+
         #endregion
 
         #region git_merge_

--- a/LibGit2Sharp/Index.cs
+++ b/LibGit2Sharp/Index.cs
@@ -475,6 +475,19 @@ namespace LibGit2Sharp
             UpdatePhysicalIndex();
         }
 
+        /// <summary>
+        /// Clears all entries the index. This is semantically equivalent to
+        /// creating an empty tree object and resetting the index to that tree.
+        /// <para>
+        ///   This overwrites all existing state in the staging area.
+        /// </para>
+        /// </summary>
+        public virtual void Clear()
+        {
+            Proxy.git_index_clear(this);
+            UpdatePhysicalIndex();
+        }
+
         private IDictionary<Tuple<string, FileStatus>, Tuple<string, FileStatus>> PrepareBatch(IEnumerable<string> leftPaths, IEnumerable<string> rightPaths)
         {
             IDictionary<Tuple<string, FileStatus>, Tuple<string, FileStatus>> dic = new Dictionary<Tuple<string, FileStatus>, Tuple<string, FileStatus>>();


### PR DESCRIPTION
GitHub for Windows needs a way to blow away the entire index (undoing the initial commit). Up until now we've done this through shelling out but I'm moving that over to libgit2sharp now.

Clearing the index can be done right now in l2gs by explicitly creating an empty tree object and resetting to that but that involves a few more moving parts of actually creating the object in the odb and I was thinking there should be a way to explicitly clear as well.

Initially I though about adding an `Index.Clear` that calls `git_index_clear` but I'm concerned that people will confuse `Index.Clear` with something that just unstages everything, not clearing the index completely so I opted for allowing passing in null to `Index.Reset` and clearly documenting it.

There has been some discussion of libgit2 supporting the empty tree sha (https://github.com/libgit2/libgit2/issues/1713#issuecomment-20585528). If libgit2 ends up supporting that a Tree.Empty static property might be a nice touch.
