### PR TITLE
Error updates

### DIFF
--- a/LibGit2Sharp.Tests/BlameFixture.cs
+++ b/LibGit2Sharp.Tests/BlameFixture.cs
@@ -34,7 +34,7 @@ namespace LibGit2Sharp.Tests
             using (var repo = new Repository(MergedTestRepoWorkingDirPath))
             {
                 // File doesn't exist at HEAD
-                Assert.Throws<LibGit2SharpException>(() => repo.Blame("ancestor-only.txt"));
+                Assert.Throws<NotFoundException>(() => repo.Blame("ancestor-only.txt"));
 
                 var blame = repo.Blame("ancestor-only.txt", new BlameOptions { StartingAt = "9107b30" });
                 Assert.Equal(1, blame.Count());

--- a/LibGit2Sharp.Tests/BranchFixture.cs
+++ b/LibGit2Sharp.Tests/BranchFixture.cs
@@ -241,9 +241,9 @@ namespace LibGit2Sharp.Tests
             using (var repo = new Repository(BareTestRepoPath))
             {
                 const string name = "sorry-dude-i-do-not-do-blobs-nor-trees";
-                Assert.Throws<LibGit2SharpException>(() => repo.CreateBranch(name, "refs/tags/point_to_blob"));
-                Assert.Throws<LibGit2SharpException>(() => repo.CreateBranch(name, "53fc32d"));
-                Assert.Throws<LibGit2SharpException>(() => repo.CreateBranch(name, "0266163"));
+                Assert.Throws<CannotDereferenceException>(() => repo.CreateBranch(name, "refs/tags/point_to_blob"));
+                Assert.Throws<CannotDereferenceException>(() => repo.CreateBranch(name, "53fc32d"));
+                Assert.Throws<CannotDereferenceException>(() => repo.CreateBranch(name, "0266163"));
             }
         }
 
@@ -252,7 +252,7 @@ namespace LibGit2Sharp.Tests
         {
             using (var repo = new Repository(BareTestRepoPath))
             {
-                Assert.Throws<LibGit2SharpException>(() => repo.Branches.Add("my_new_branch", "my_old_branch"));
+                Assert.Throws<NotFoundException>(() => repo.Branches.Add("my_new_branch", "my_old_branch"));
             }
         }
 
@@ -261,8 +261,8 @@ namespace LibGit2Sharp.Tests
         {
             using (var repo = new Repository(BareTestRepoPath))
             {
-                Assert.Throws<LibGit2SharpException>(() => repo.Branches.Add("my_new_branch", Constants.UnknownSha));
-                Assert.Throws<LibGit2SharpException>(() => repo.Branches.Add("my_new_branch", Constants.UnknownSha.Substring(0, 7)));
+                Assert.Throws<NotFoundException>(() => repo.Branches.Add("my_new_branch", Constants.UnknownSha));
+                Assert.Throws<NotFoundException>(() => repo.Branches.Add("my_new_branch", Constants.UnknownSha.Substring(0, 7)));
             }
         }
 
@@ -707,7 +707,7 @@ namespace LibGit2Sharp.Tests
 
                 Branch trackedBranch = repo.Branches[trackedBranchName];
 
-                Assert.Throws<LibGit2SharpException>(() => repo.Branches.Update(branch,
+                Assert.Throws<NotFoundException>(() => repo.Branches.Update(branch,
                                                                                 b => b.TrackedBranch = trackedBranch.CanonicalName));
             }
         }

--- a/LibGit2Sharp.Tests/CheckoutFixture.cs
+++ b/LibGit2Sharp.Tests/CheckoutFixture.cs
@@ -381,7 +381,7 @@ namespace LibGit2Sharp.Tests
         {
             using (var repo = new Repository(StandardTestRepoWorkingDirPath))
             {
-                Assert.Throws<LibGit2SharpException>(() => repo.Checkout("i-do-not-exist"));
+                Assert.Throws<NotFoundException>(() => repo.Checkout("i-do-not-exist"));
             }
         }
 
@@ -891,7 +891,7 @@ namespace LibGit2Sharp.Tests
         {
             using (var repo = new Repository(StandardTestRepoWorkingDirPath))
             {
-                Assert.Throws<LibGit2SharpException>(() => repo.Checkout("head"));
+                Assert.Throws<NotFoundException>(() => repo.Checkout("head"));
             }
         }
 

--- a/LibGit2Sharp.Tests/CommitFixture.cs
+++ b/LibGit2Sharp.Tests/CommitFixture.cs
@@ -101,8 +101,8 @@ namespace LibGit2Sharp.Tests
         {
             using (var repo = new Repository(BareTestRepoPath))
             {
-                Assert.Throws<LibGit2SharpException>(() => repo.Commits.QueryBy(new CommitFilter { Since = Constants.UnknownSha }).Count());
-                Assert.Throws<LibGit2SharpException>(() => repo.Commits.QueryBy(new CommitFilter { Since = "refs/heads/deadbeef" }).Count());
+                Assert.Throws<NotFoundException>(() => repo.Commits.QueryBy(new CommitFilter { Since = Constants.UnknownSha }).Count());
+                Assert.Throws<NotFoundException>(() => repo.Commits.QueryBy(new CommitFilter { Since = "refs/heads/deadbeef" }).Count());
                 Assert.Throws<ArgumentNullException>(() => repo.Commits.QueryBy(new CommitFilter { Since = null }).Count());
             }
         }
@@ -115,8 +115,8 @@ namespace LibGit2Sharp.Tests
             {
                 CreateCorruptedDeadBeefHead(repo.Info.Path);
 
-                Assert.Throws<LibGit2SharpException>(() => repo.Commits.QueryBy(new CommitFilter { Since = repo.Branches["deadbeef"] }).Count());
-                Assert.Throws<LibGit2SharpException>(() => repo.Commits.QueryBy(new CommitFilter { Since = repo.Refs["refs/heads/deadbeef"] }).Count());
+                Assert.Throws<NotFoundException>(() => repo.Commits.QueryBy(new CommitFilter { Since = repo.Branches["deadbeef"] }).Count());
+                Assert.Throws<NotFoundException>(() => repo.Commits.QueryBy(new CommitFilter { Since = repo.Refs["refs/heads/deadbeef"] }).Count());
             }
         }
 

--- a/LibGit2Sharp.Tests/ReferenceFixture.cs
+++ b/LibGit2Sharp.Tests/ReferenceFixture.cs
@@ -73,7 +73,7 @@ namespace LibGit2Sharp.Tests
             string path = CloneBareTestRepo();
             using (var repo = new Repository(path))
             {
-                Assert.Throws<LibGit2SharpException>(() => repo.Refs.Add(name, "master^42"));
+                Assert.Throws<NotFoundException>(() => repo.Refs.Add(name, "master^42"));
             }
         }
 
@@ -596,7 +596,7 @@ namespace LibGit2Sharp.Tests
         {
             using (var repo = new Repository(BareTestRepoPath))
             {
-                Assert.Throws<LibGit2SharpException>(() => repo.Refs.UpdateTarget(repo.Refs["refs/heads/master"], "refs/heads/nope"));
+                Assert.Throws<NotFoundException>(() => repo.Refs.UpdateTarget(repo.Refs["refs/heads/master"], "refs/heads/nope"));
             }
         }
 

--- a/LibGit2Sharp.Tests/ResetHeadFixture.cs
+++ b/LibGit2Sharp.Tests/ResetHeadFixture.cs
@@ -70,8 +70,8 @@ namespace LibGit2Sharp.Tests
                 Assert.Throws<ArgumentNullException>(() => repo.Reset(ResetMode.Soft, (string)null));
                 Assert.Throws<ArgumentNullException>(() => repo.Reset(ResetMode.Soft, (Commit)null));
                 Assert.Throws<ArgumentException>(() => repo.Reset(ResetMode.Soft, ""));
-                Assert.Throws<LibGit2SharpException>(() => repo.Reset(ResetMode.Soft, Constants.UnknownSha));
-                Assert.Throws<LibGit2SharpException>(() => repo.Reset(ResetMode.Soft, repo.Head.Tip.Tree.Sha));
+                Assert.Throws<NotFoundException>(() => repo.Reset(ResetMode.Soft, Constants.UnknownSha));
+                Assert.Throws<CannotDereferenceException>(() => repo.Reset(ResetMode.Soft, repo.Head.Tip.Tree.Sha));
             }
         }
 

--- a/LibGit2Sharp.Tests/TagFixture.cs
+++ b/LibGit2Sharp.Tests/TagFixture.cs
@@ -257,7 +257,7 @@ namespace LibGit2Sharp.Tests
         {
             using (var repo = new Repository(BareTestRepoPath))
             {
-                Assert.Throws<LibGit2SharpException>(() => repo.ApplyTag("mytagnorev", "aaaaaaaaaaa"));
+                Assert.Throws<NotFoundException>(() => repo.ApplyTag("mytagnorev", "aaaaaaaaaaa"));
             }
         }
 
@@ -267,7 +267,7 @@ namespace LibGit2Sharp.Tests
         {
             using (var repo = new Repository(BareTestRepoPath))
             {
-                Assert.Throws<LibGit2SharpException>(() => repo.ApplyTag("mytagnorev", Constants.UnknownSha));
+                Assert.Throws<NotFoundException>(() => repo.ApplyTag("mytagnorev", Constants.UnknownSha));
             }
         }
 
@@ -497,7 +497,7 @@ namespace LibGit2Sharp.Tests
         {
             using (var repo = new Repository(BareTestRepoPath))
             {
-                Assert.Throws<LibGit2SharpException>(() => repo.Tags.Add("test_tag", Constants.UnknownSha, signatureTim, "message"));
+                Assert.Throws<NotFoundException>(() => repo.Tags.Add("test_tag", Constants.UnknownSha, signatureTim, "message"));
             }
         }
 
@@ -608,7 +608,7 @@ namespace LibGit2Sharp.Tests
         {
             using (var repo = new Repository(BareTestRepoPath))
             {
-                Assert.Throws<LibGit2SharpException>(() => repo.Tags.Remove("unknown-tag"));
+                Assert.Throws<NotFoundException>(() => repo.Tags.Remove("unknown-tag"));
             }
         }
 

--- a/LibGit2Sharp/AmbiguousSpecificationException.cs
+++ b/LibGit2Sharp/AmbiguousSpecificationException.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.Serialization;
+using LibGit2Sharp.Core;
 
 namespace LibGit2Sharp
 {
@@ -42,6 +43,11 @@ namespace LibGit2Sharp
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
         protected AmbiguousSpecificationException(SerializationInfo info, StreamingContext context)
             : base(info, context)
+        {
+        }
+
+        internal AmbiguousSpecificationException(string message, GitErrorCode code, GitErrorCategory category)
+            : base(message, code, category)
         {
         }
     }

--- a/LibGit2Sharp/Blob.cs
+++ b/LibGit2Sharp/Blob.cs
@@ -26,6 +26,21 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
+        /// A blob cannot be dereferenced to a commit - throws or returns null.
+        /// </summary>
+        /// <param name="throwsIfCanNotBeDereferencedToACommit"></param>
+        /// <returns></returns>
+        internal override Commit DereferenceToCommit(bool throwsIfCanNotBeDereferencedToACommit)
+        {
+            if (throwsIfCanNotBeDereferencedToACommit)
+            {
+                throw new CannotDereferenceException("Cannot dereference a blob object to a commit.");
+            }
+
+            return null;
+        }
+
+        /// <summary>
         /// Gets the size in bytes of the raw content of a blob.
         /// </summary>
         public virtual int Size { get { return (int)lazySize.Value; } }

--- a/LibGit2Sharp/CannotDereferenceException.cs
+++ b/LibGit2Sharp/CannotDereferenceException.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace LibGit2Sharp
+{
+    /// <summary>
+    /// The exception that is thrown when a GitObject cannot be dereferenced to the desired type.
+    /// </summary>
+    [Serializable]
+    public class CannotDereferenceException : LibGit2SharpException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CannotDereferenceException"/> class.
+        /// </summary>
+        public CannotDereferenceException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CannotDereferenceException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="message">A message that describes the error.</param>
+        public CannotDereferenceException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CannotDereferenceException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception. If the <paramref name="innerException"/> parameter is not a null reference, the current exception is raised in a catch block that handles the inner exception.</param>
+        public CannotDereferenceException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CannotDereferenceException"/> class with a serialized data.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        protected CannotDereferenceException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/LibGit2Sharp/Commit.cs
+++ b/LibGit2Sharp/Commit.cs
@@ -52,6 +52,16 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
+        /// This object is already a commit - no need to further dereference.
+        /// </summary>
+        /// <param name="throwsIfCanNotBeDereferencedToACommit"></param>
+        /// <returns></returns>
+        internal override Commit DereferenceToCommit(bool throwsIfCanNotBeDereferencedToACommit)
+        {
+            return this;
+        }
+
+        /// <summary>
         /// Gets the <see cref="TreeEntry"/> pointed at by the <paramref name="relativePath"/> in the <see cref="Tree"/>.
         /// </summary>
         /// <param name="relativePath">The relative path to the <see cref="TreeEntry"/> from the <see cref="Commit"/> working directory.</param>

--- a/LibGit2Sharp/Core/Ensure.cs
+++ b/LibGit2Sharp/Core/Ensure.cs
@@ -100,6 +100,8 @@ namespace LibGit2Sharp.Core
                     { GitErrorCode.NonFastForward, (m, r, c) => new NonFastForwardException(m, r, c) },
                     { GitErrorCode.MergeConflict, (m, r, c) => new MergeConflictException(m, r, c) },
                     { GitErrorCode.LockedFile, (m, r, c) => new LockedFileException(m, r, c) },
+                    { GitErrorCode.NotFound, (m, r, c) => new NotFoundException(m, r, c) },
+                    { GitErrorCode.Ambiguous, (m, r, c) => new AmbiguousSpecificationException(m, r, c) },
                 };
 
         private static void HandleError(int result)
@@ -218,7 +220,7 @@ namespace LibGit2Sharp.Core
             }
             else
             {
-                exceptionBuilder = m => new LibGit2SharpException(m);
+                exceptionBuilder = m => new NotFoundException(m);
             }
 
             GitObjectIsNotNull(gitObject, identifier, exceptionBuilder);

--- a/LibGit2Sharp/GitLink.cs
+++ b/LibGit2Sharp/GitLink.cs
@@ -14,6 +14,21 @@ namespace LibGit2Sharp
         protected GitLink()
         { }
 
+        /// <summary>
+        /// A GitLink cannot be dereferenced to a commit - throws or returns null.
+        /// </summary>
+        /// <param name="throwsIfCanNotBeDereferencedToACommit"></param>
+        /// <returns></returns>
+        internal override Commit DereferenceToCommit(bool throwsIfCanNotBeDereferencedToACommit)
+        {
+            if (throwsIfCanNotBeDereferencedToACommit)
+            {
+                throw new CannotDereferenceException("Cannot dereference a git-link object to a commit.");
+            }
+
+            return null;
+        }
+
         internal GitLink(Repository repo, ObjectId id)
             : base(repo, id)
         {

--- a/LibGit2Sharp/GitObject.cs
+++ b/LibGit2Sharp/GitObject.cs
@@ -77,7 +77,12 @@ namespace LibGit2Sharp
             }
         }
 
-        internal Commit DereferenceToCommit(bool throwsIfCanNotBeDereferencedToACommit)
+        /// <summary>
+        /// Dereference object to a commit.
+        /// </summary>
+        /// <param name="throwsIfCanNotBeDereferencedToACommit"></param>
+        /// <returns></returns>
+        internal virtual Commit DereferenceToCommit(bool throwsIfCanNotBeDereferencedToACommit)
         {
             using (GitObjectSafeHandle peeledHandle = Proxy.git_object_peel(repo.Handle, Id, GitObjectType.Commit, throwsIfCanNotBeDereferencedToACommit))
             {

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -68,6 +68,7 @@
     <Compile Include="BranchCollectionExtensions.cs" />
     <Compile Include="BranchTrackingDetails.cs" />
     <Compile Include="BranchUpdater.cs" />
+    <Compile Include="CannotDereferenceException.cs" />
     <Compile Include="CheckoutCallbacks.cs" />
     <Compile Include="CheckoutFileConflictStrategy.cs" />
     <Compile Include="CheckoutModifiers.cs" />

--- a/LibGit2Sharp/TagAnnotation.cs
+++ b/LibGit2Sharp/TagAnnotation.cs
@@ -1,4 +1,5 @@
 ﻿using LibGit2Sharp.Core;
+using LibGit2Sharp.Core.Handles;
 
 namespace LibGit2Sharp
 {
@@ -29,6 +30,24 @@ namespace LibGit2Sharp
             group = new GitObjectLazyGroup(repo, id);
             lazyTagger = group.AddLazy(Proxy.git_tag_tagger);
             lazyMessage = group.AddLazy(Proxy.git_tag_message);
+        }
+
+        /// <summary>
+        /// Dereference tag to a commit.
+        /// </summary>
+        /// <param name="throwsIfCanNotBeDereferencedToACommit"></param>
+        /// <returns></returns>
+        internal override Commit DereferenceToCommit(bool throwsIfCanNotBeDereferencedToACommit)
+        {
+            using (GitObjectSafeHandle peeledHandle = Proxy.git_object_peel(repo.Handle, Id, GitObjectType.Commit, throwsIfCanNotBeDereferencedToACommit))
+            {
+                if (peeledHandle == null)
+                {
+                    return null;
+                }
+
+                return (Commit)BuildFrom(repo, Proxy.git_object_id(peeledHandle), GitObjectType.Commit, null);
+            }
         }
 
         /// <summary>

--- a/LibGit2Sharp/Tree.cs
+++ b/LibGit2Sharp/Tree.cs
@@ -33,6 +33,21 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
+        /// A tree cannot be dereferenced to a commit - throws or returns null.
+        /// </summary>
+        /// <param name="throwsIfCanNotBeDereferencedToACommit"></param>
+        /// <returns></returns>
+        internal override Commit DereferenceToCommit(bool throwsIfCanNotBeDereferencedToACommit)
+        {
+            if (throwsIfCanNotBeDereferencedToACommit)
+            {
+                throw new CannotDereferenceException("Cannot dereference a tree object to a commit.");
+            }
+
+            return null;
+        }
+
+        /// <summary>
         /// Gets the number of <see cref="TreeEntry"/> immediately under this <see cref="Tree"/>.
         /// </summary>
         public virtual int Count { get { return lazyCount.Value; } }


### PR DESCRIPTION
This PR is to throw more specifically typed exceptions in several cases - most notably when objects cannot be found or cannot be dereferenced to a commit.

The second commit is to add an exception to indicated an exception case around the Pull operation.
