### PR TITLE
Throw NotFound and CannotDereference Exceptions - Reborn

### DIFF
--- a/LibGit2Sharp.Tests/BlameFixture.cs
+++ b/LibGit2Sharp.Tests/BlameFixture.cs
@@ -36,7 +36,7 @@ namespace LibGit2Sharp.Tests
             using (var repo = new Repository(path))
             {
                 // File doesn't exist at HEAD
-                Assert.Throws<LibGit2SharpException>(() => repo.Blame("ancestor-only.txt"));
+                Assert.Throws<NotFoundException>(() => repo.Blame("ancestor-only.txt"));
 
                 var blame = repo.Blame("ancestor-only.txt", new BlameOptions { StartingAt = "9107b30" });
                 Assert.Equal(1, blame.Count());

--- a/LibGit2Sharp.Tests/BranchFixture.cs
+++ b/LibGit2Sharp.Tests/BranchFixture.cs
@@ -254,7 +254,7 @@ namespace LibGit2Sharp.Tests
             string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
-                Assert.Throws<LibGit2SharpException>(() => repo.Branches.Add("my_new_branch", "my_old_branch"));
+                Assert.Throws<NotFoundException>(() => repo.Branches.Add("my_new_branch", "my_old_branch"));
             }
         }
 
@@ -264,8 +264,8 @@ namespace LibGit2Sharp.Tests
             string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
-                Assert.Throws<LibGit2SharpException>(() => repo.Branches.Add("my_new_branch", Constants.UnknownSha));
-                Assert.Throws<LibGit2SharpException>(() => repo.Branches.Add("my_new_branch", Constants.UnknownSha.Substring(0, 7)));
+                Assert.Throws<NotFoundException>(() => repo.Branches.Add("my_new_branch", Constants.UnknownSha));
+                Assert.Throws<NotFoundException>(() => repo.Branches.Add("my_new_branch", Constants.UnknownSha.Substring(0, 7)));
             }
         }
 
@@ -729,7 +729,7 @@ namespace LibGit2Sharp.Tests
 
                 Branch trackedBranch = repo.Branches[trackedBranchName];
 
-                Assert.Throws<LibGit2SharpException>(() => repo.Branches.Update(branch,
+                Assert.Throws<NotFoundException>(() => repo.Branches.Update(branch,
                                                                                 b => b.TrackedBranch = trackedBranch.CanonicalName));
             }
         }

--- a/LibGit2Sharp.Tests/CheckoutFixture.cs
+++ b/LibGit2Sharp.Tests/CheckoutFixture.cs
@@ -383,7 +383,7 @@ namespace LibGit2Sharp.Tests
             string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
-                Assert.Throws<LibGit2SharpException>(() => repo.Checkout("i-do-not-exist"));
+                Assert.Throws<NotFoundException>(() => repo.Checkout("i-do-not-exist"));
             }
         }
 
@@ -895,7 +895,7 @@ namespace LibGit2Sharp.Tests
             string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
-                Assert.Throws<LibGit2SharpException>(() => repo.Checkout("head"));
+                Assert.Throws<NotFoundException>(() => repo.Checkout("head"));
             }
         }
 

--- a/LibGit2Sharp.Tests/CommitFixture.cs
+++ b/LibGit2Sharp.Tests/CommitFixture.cs
@@ -107,8 +107,8 @@ namespace LibGit2Sharp.Tests
             string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
-                Assert.Throws<LibGit2SharpException>(() => repo.Commits.QueryBy(new CommitFilter { Since = Constants.UnknownSha }).Count());
-                Assert.Throws<LibGit2SharpException>(() => repo.Commits.QueryBy(new CommitFilter { Since = "refs/heads/deadbeef" }).Count());
+                Assert.Throws<NotFoundException>(() => repo.Commits.QueryBy(new CommitFilter { Since = Constants.UnknownSha }).Count());
+                Assert.Throws<NotFoundException>(() => repo.Commits.QueryBy(new CommitFilter { Since = "refs/heads/deadbeef" }).Count());
                 Assert.Throws<ArgumentNullException>(() => repo.Commits.QueryBy(new CommitFilter { Since = null }).Count());
             }
         }
@@ -121,8 +121,8 @@ namespace LibGit2Sharp.Tests
             {
                 CreateCorruptedDeadBeefHead(repo.Info.Path);
 
-                Assert.Throws<LibGit2SharpException>(() => repo.Commits.QueryBy(new CommitFilter { Since = repo.Branches["deadbeef"] }).Count());
-                Assert.Throws<LibGit2SharpException>(() => repo.Commits.QueryBy(new CommitFilter { Since = repo.Refs["refs/heads/deadbeef"] }).Count());
+                Assert.Throws<NotFoundException>(() => repo.Commits.QueryBy(new CommitFilter { Since = repo.Branches["deadbeef"] }).Count());
+                Assert.Throws<NotFoundException>(() => repo.Commits.QueryBy(new CommitFilter { Since = repo.Refs["refs/heads/deadbeef"] }).Count());
             }
         }
 

--- a/LibGit2Sharp.Tests/ReferenceFixture.cs
+++ b/LibGit2Sharp.Tests/ReferenceFixture.cs
@@ -73,7 +73,7 @@ namespace LibGit2Sharp.Tests
             string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
-                Assert.Throws<LibGit2SharpException>(() => repo.Refs.Add(name, "master^42"));
+                Assert.Throws<NotFoundException>(() => repo.Refs.Add(name, "master^42"));
             }
         }
 
@@ -610,7 +610,7 @@ namespace LibGit2Sharp.Tests
             string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
-                Assert.Throws<LibGit2SharpException>(() => repo.Refs.UpdateTarget(repo.Refs["refs/heads/master"], "refs/heads/nope"));
+                Assert.Throws<NotFoundException>(() => repo.Refs.UpdateTarget(repo.Refs["refs/heads/master"], "refs/heads/nope"));
             }
         }
 

--- a/LibGit2Sharp.Tests/RepositoryFixture.cs
+++ b/LibGit2Sharp.Tests/RepositoryFixture.cs
@@ -504,6 +504,7 @@ namespace LibGit2Sharp.Tests
                 Assert.Throws<InvalidSpecificationException>(() => repo.Lookup<Commit>("tags/point_to_blob^{commit}"));
                 Assert.Throws<InvalidSpecificationException>(() => repo.Lookup("master^{tree}^{blob}"));
                 Assert.Throws<InvalidSpecificationException>(() => repo.Lookup<Blob>("master^{blob}"));
+                Assert.Throws<PeelException>(() => repo.Lookup<Blob>("tags/e90810b^{blob}"));
             }
         }
 

--- a/LibGit2Sharp.Tests/RepositoryFixture.cs
+++ b/LibGit2Sharp.Tests/RepositoryFixture.cs
@@ -494,6 +494,20 @@ namespace LibGit2Sharp.Tests
         }
 
         [Fact]
+        public void LookingUpByAWrongRevParseExpressionThrows()
+        {
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
+            {
+                Assert.Throws<InvalidSpecificationException>(() => repo.Lookup("tags/point_to_blob^{tree}"));
+                Assert.Throws<InvalidSpecificationException>(() => repo.Lookup("tags/point_to_blob^{commit}"));
+                Assert.Throws<InvalidSpecificationException>(() => repo.Lookup<Commit>("tags/point_to_blob^{commit}"));
+                Assert.Throws<InvalidSpecificationException>(() => repo.Lookup("master^{tree}^{blob}"));
+                Assert.Throws<InvalidSpecificationException>(() => repo.Lookup<Blob>("master^{blob}"));
+            }
+        }
+
+        [Fact]
         public void LookingUpAGitLinkThrows()
         {
             string path = SandboxBareTestRepo();

--- a/LibGit2Sharp.Tests/ResetHeadFixture.cs
+++ b/LibGit2Sharp.Tests/ResetHeadFixture.cs
@@ -71,7 +71,7 @@ namespace LibGit2Sharp.Tests
                 Assert.Throws<ArgumentNullException>(() => repo.Reset(ResetMode.Soft, (string)null));
                 Assert.Throws<ArgumentNullException>(() => repo.Reset(ResetMode.Soft, (Commit)null));
                 Assert.Throws<ArgumentException>(() => repo.Reset(ResetMode.Soft, ""));
-                Assert.Throws<LibGit2SharpException>(() => repo.Reset(ResetMode.Soft, Constants.UnknownSha));
+                Assert.Throws<NotFoundException>(() => repo.Reset(ResetMode.Soft, Constants.UnknownSha));
                 Assert.Throws<InvalidSpecificationException>(() => repo.Reset(ResetMode.Soft, repo.Head.Tip.Tree.Sha));
             }
         }

--- a/LibGit2Sharp.Tests/TagFixture.cs
+++ b/LibGit2Sharp.Tests/TagFixture.cs
@@ -258,7 +258,7 @@ namespace LibGit2Sharp.Tests
             string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
-                Assert.Throws<LibGit2SharpException>(() => repo.ApplyTag("mytagnorev", "aaaaaaaaaaa"));
+                Assert.Throws<NotFoundException>(() => repo.ApplyTag("mytagnorev", "aaaaaaaaaaa"));
             }
         }
 
@@ -269,7 +269,7 @@ namespace LibGit2Sharp.Tests
             string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
-                Assert.Throws<LibGit2SharpException>(() => repo.ApplyTag("mytagnorev", Constants.UnknownSha));
+                Assert.Throws<NotFoundException>(() => repo.ApplyTag("mytagnorev", Constants.UnknownSha));
             }
         }
 
@@ -507,7 +507,7 @@ namespace LibGit2Sharp.Tests
             string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
-                Assert.Throws<LibGit2SharpException>(() => repo.Tags.Add("test_tag", Constants.UnknownSha, signatureTim, "message"));
+                Assert.Throws<NotFoundException>(() => repo.Tags.Add("test_tag", Constants.UnknownSha, signatureTim, "message"));
             }
         }
 
@@ -623,7 +623,7 @@ namespace LibGit2Sharp.Tests
             string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
-                Assert.Throws<LibGit2SharpException>(() => repo.Tags.Remove("unknown-tag"));
+                Assert.Throws<NotFoundException>(() => repo.Tags.Remove("unknown-tag"));
             }
         }
 

--- a/LibGit2Sharp/Core/Ensure.cs
+++ b/LibGit2Sharp/Core/Ensure.cs
@@ -100,6 +100,7 @@ namespace LibGit2Sharp.Core
                     { GitErrorCode.NonFastForward, (m, r, c) => new NonFastForwardException(m, r, c) },
                     { GitErrorCode.MergeConflict, (m, r, c) => new MergeConflictException(m, r, c) },
                     { GitErrorCode.LockedFile, (m, r, c) => new LockedFileException(m, r, c) },
+                    { GitErrorCode.NotFound, (m, r, c) => new NotFoundException(m, r, c) },
                 };
 
         private static void HandleError(int result)
@@ -215,7 +216,7 @@ namespace LibGit2Sharp.Core
             }
             else
             {
-                exceptionBuilder = m => new LibGit2SharpException(m);
+                exceptionBuilder = m => new NotFoundException(m);
             }
 
             GitObjectIsNotNull(gitObject, identifier, exceptionBuilder);

--- a/LibGit2Sharp/Core/Ensure.cs
+++ b/LibGit2Sharp/Core/Ensure.cs
@@ -101,6 +101,7 @@ namespace LibGit2Sharp.Core
                     { GitErrorCode.MergeConflict, (m, r, c) => new MergeConflictException(m, r, c) },
                     { GitErrorCode.LockedFile, (m, r, c) => new LockedFileException(m, r, c) },
                     { GitErrorCode.NotFound, (m, r, c) => new NotFoundException(m, r, c) },
+                    { GitErrorCode.Peel, (m, r, c) => new PeelException(m, r, c)  },
                 };
 
         private static void HandleError(int result)

--- a/LibGit2Sharp/InvalidSpecificationException.cs
+++ b/LibGit2Sharp/InvalidSpecificationException.cs
@@ -5,7 +5,10 @@ using LibGit2Sharp.Core;
 namespace LibGit2Sharp
 {
     /// <summary>
-    /// The exception that is thrown when the provided specification is syntactically incorrect.
+    /// The exception that is thrown when a provided specification is bad. This
+    /// can happen if the provided specification is syntactically incorrect, or
+    /// if the spec refers to an object of an incorrect type (e.g. asking to
+    /// create a branch from a blob, or peeling a blob to a commit).
     /// </summary>
     [Serializable]
     public class InvalidSpecificationException : LibGit2SharpException

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -98,6 +98,7 @@
     <Compile Include="GitObjectMetadata.cs" />
     <Compile Include="PatchEntryChanges.cs" />
     <Compile Include="PatchStats.cs" />
+    <Compile Include="PeelException.cs" />
     <Compile Include="PullOptions.cs" />
     <Compile Include="RefSpec.cs" />
     <Compile Include="RefSpecCollection.cs" />

--- a/LibGit2Sharp/PeelException.cs
+++ b/LibGit2Sharp/PeelException.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Runtime.Serialization;
+using LibGit2Sharp.Core;
+
+namespace LibGit2Sharp
+{
+    /// <summary>
+    /// The exception that is thrown when a tag cannot be peeled to the
+    /// target type due to the object model.
+    /// </summary>
+    [Serializable]
+    public class PeelException : LibGit2SharpException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PeelException"/> class.
+        /// </summary>
+        public PeelException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PeelException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="message">A message that describes the error.</param>
+        public PeelException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PeelException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception. If the <paramref name="innerException"/> parameter is not a null reference, the current exception is raised in a catch block that handles the inner exception.</param>
+        public PeelException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PeelException"/> class with a serialized data.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        protected PeelException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+
+        internal PeelException(string message, GitErrorCode code, GitErrorCategory category)
+            : base(message, code, category)
+        {
+        }
+    }
+}


### PR DESCRIPTION
This change is to throw more specific exceptions in several cases when
possible. If an object cannot be found, throw a more specific
NotFoundException. If an object exists but cannot be dereferenced to its
desired type, then throw a CannotDereferenceException.

This is the rebirth of #839 that has been too hastily merged (then reverted). :blush: 