### PR TITLE
Kill GetCredentialsHandler with :fire:

### DIFF
--- a/LibGit2Sharp/CloneOptions.cs
+++ b/LibGit2Sharp/CloneOptions.cs
@@ -7,7 +7,7 @@ namespace LibGit2Sharp
     /// <summary>
     /// Options to define clone behaviour
     /// </summary>
-    public sealed class CloneOptions : IConvertableToGitCheckoutOpts, ICredentialsProvider
+    public sealed class CloneOptions : IConvertableToGitCheckoutOpts
     {
         /// <summary>
         /// Creates default <see cref="CloneOptions"/> for a non-bare clone

--- a/LibGit2Sharp/Credentials.cs
+++ b/LibGit2Sharp/Credentials.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using LibGit2Sharp.Core;
-using LibGit2Sharp.Handlers;
 
 namespace LibGit2Sharp
 {
@@ -19,31 +18,5 @@ namespace LibGit2Sharp
         /// <param name="payload">The payload provided when specifying this callback.</param>
         /// <returns>0 for success, &lt; 0 to indicate an error, &gt; 0 to indicate no credential was acquired.</returns>
         protected internal abstract int GitCredentialHandler(out IntPtr cred, IntPtr url, IntPtr usernameFromUrl, GitCredentialType types, IntPtr payload);
-    }
-
-    internal interface ICredentialsProvider
-    {
-        /// <summary>
-        /// Handler to generate <see cref="LibGit2Sharp.Credentials"/> for authentication.
-        /// </summary>
-        CredentialsHandler CredentialsProvider { get; }
-    }
-
-    internal static class CredentialsProviderExtensions
-    {
-        public static CredentialsHandler GetCredentialsHandler(this ICredentialsProvider provider)
-        {
-            if (provider == null)
-            {
-                return null;
-            }
-
-            if (provider.CredentialsProvider == null)
-            {
-                return null;
-            }
-
-            return provider.CredentialsProvider;
-        }
     }
 }

--- a/LibGit2Sharp/FetchOptions.cs
+++ b/LibGit2Sharp/FetchOptions.cs
@@ -6,7 +6,7 @@ namespace LibGit2Sharp
     /// <summary>
     /// Collection of parameters controlling Fetch behavior.
     /// </summary>
-    public sealed class FetchOptions : ICredentialsProvider
+    public sealed class FetchOptions
     {
         /// <summary>
         /// Specifies the tag-following behavior of the fetch operation.

--- a/LibGit2Sharp/Network.cs
+++ b/LibGit2Sharp/Network.cs
@@ -100,7 +100,8 @@ namespace LibGit2Sharp
                 Proxy.git_remote_set_autotag(remoteHandle, options.TagFetchMode.Value);
             }
 
-            var callbacks = new RemoteCallbacks(options);
+            var callbacks = new RemoteCallbacks(
+                options.OnProgress, options.OnTransferProgress, options.OnUpdateTips, options.CredentialsProvider);
             GitRemoteCallbacks gitCallbacks = callbacks.GenerateCallbacks();
 
             // It is OK to pass the reference to the GitCallbacks directly here because libgit2 makes a copy of
@@ -272,7 +273,8 @@ namespace LibGit2Sharp
             // Load the remote.
             using (RemoteSafeHandle remoteHandle = Proxy.git_remote_load(repository.Handle, remote.Name, true))
             {
-                var callbacks = new RemoteCallbacks(null, null, null, pushOptions);
+                var callbacks = new RemoteCallbacks(
+                    null, null, null, pushOptions.CredentialsProvider);
                 GitRemoteCallbacks gitCallbacks = callbacks.GenerateCallbacks();
                 Proxy.git_remote_set_callbacks(remoteHandle, ref gitCallbacks);
 

--- a/LibGit2Sharp/PushOptions.cs
+++ b/LibGit2Sharp/PushOptions.cs
@@ -5,7 +5,7 @@ namespace LibGit2Sharp
     /// <summary>
     /// Collection of parameters controlling Push behavior.
     /// </summary>
-    public sealed class PushOptions : ICredentialsProvider
+    public sealed class PushOptions
     {
         /// <summary>
         /// Handler to generate <see cref="LibGit2Sharp.Credentials"/> for authentication.

--- a/LibGit2Sharp/RemoteCallbacks.cs
+++ b/LibGit2Sharp/RemoteCallbacks.cs
@@ -16,33 +16,12 @@ namespace LibGit2Sharp
             ProgressHandler onProgress = null,
             TransferProgressHandler onDownloadProgress = null,
             UpdateTipsHandler onUpdateTips = null,
-            ICredentialsProvider credentialsProvider = null)
-        {
-            Progress = onProgress;
-            DownloadTransferProgress = onDownloadProgress;
-            UpdateTips = onUpdateTips;
-            CredentialsProvider = credentialsProvider.GetCredentialsHandler();
-        }
-
-        internal RemoteCallbacks(
-            ProgressHandler onProgress = null,
-            TransferProgressHandler onDownloadProgress = null,
-            UpdateTipsHandler onUpdateTips = null,
             CredentialsHandler credentialsProvider = null)
         {
             Progress = onProgress;
             DownloadTransferProgress = onDownloadProgress;
             UpdateTips = onUpdateTips;
             CredentialsProvider = credentialsProvider;
-        }
-
-        internal RemoteCallbacks(FetchOptions fetchOptions)
-        {
-            Ensure.ArgumentNotNull(fetchOptions, "fetchOptions");
-            Progress = fetchOptions.OnProgress;
-            DownloadTransferProgress = fetchOptions.OnTransferProgress;
-            UpdateTips = fetchOptions.OnUpdateTips;
-            CredentialsProvider = fetchOptions.GetCredentialsHandler();
         }
 
         #region Delegates


### PR DESCRIPTION
Following this https://github.com/libgit2/libgit2sharp/issues/834#issuecomment-58065056
- Drop class `CredentialsProviderExtensions`
- Replace every call to `xxx.GetCredentialsHandler()` with `xxx.CredentialsProvider`
