### PR TITLE
Update .nuspec to require a min NuGet version

### DIFF
--- a/nuget.package/LibGit2Sharp.nuspec
+++ b/nuget.package/LibGit2Sharp.nuspec
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
-  <metadata>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd">
+  <metadata minClientVersion="2.7">
     <id>$id$</id>
     <version>$version$</version>
     <authors>$author$</authors>


### PR DESCRIPTION
#821 improved the way the binaries are deployed on Windows through NuGet.

However, this requires a minimum NuGet version for this to work.

Maybe something like this (from #425) should do the trick

``` diff
diff --git a/nuget.package/LibGit2Sharp.nuspec b/nuget.package/LibGit2Sharp.nuspec
index 3bacd54..77d637d 100644
--- a/nuget.package/LibGit2Sharp.nuspec
+++ b/nuget.package/LibGit2Sharp.nuspec
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
-  <metadata>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd">
+  <metadata minClientVersion="2.7">
     <id>$id$</id>
     <version>$version$</version>
```
