### PR TITLE
Failure to create branch

### DIFF
--- a/LibGit2Sharp.Tests/BranchFixture.cs
+++ b/LibGit2Sharp.Tests/BranchFixture.cs
@@ -919,6 +919,24 @@ namespace LibGit2Sharp.Tests
             }
         }
 
+        [Fact]
+        public void CanCreateBranchInDeletedNestedBranchNamespace()
+        {
+            const string namespaceName = "level_one";
+            string branchWithNamespaceName = string.Join("/", namespaceName, "level_two");
+
+            string path = SandboxStandardTestRepo();
+            using (var repo = new Repository(path))
+            {
+                Commit commit = repo.Head.Tip;
+
+                Branch branchWithNamespace = repo.Branches.Add(branchWithNamespaceName, commit);
+                repo.Branches.Remove(branchWithNamespace);
+
+                repo.Branches.Add(namespaceName, commit);
+            }
+        }
+
         [Theory]
         [InlineData("I-donot-exist", false)]
         [InlineData("me/neither", true)]


### PR DESCRIPTION
When creating a branch with a name that matches the namespace of a previously deleted branch, branch creation will fail with:

`Could not open .../.git/logs/refs/heads/level_one for writing: Access is denied`

    at LibGit2Sharp.Core.Ensure.HandleError(Int32 result) in LibGit2Sharp\Core\Ensure.cs:line 126
    at LibGit2Sharp.Core.Ensure.ZeroResult(Int32 result) in LibGit2Sharp\Core\Ensure.cs:line 144
    at LibGit2Sharp.Core.Proxy.git_branch_create(RepositorySafeHandle repo, String branch_name, ObjectId targetId, Boolean force, Signature signature, String logMessage) in LibGit2Sharp\Core\Proxy.cs:line 155
    at LibGit2Sharp.BranchCollection.Add(String name, Commit commit, Signature signature, String logMessage, Boolean allowOverwrite) in LibGit2Sharp\BranchCollection.cs:line 128
    at LibGit2Sharp.BranchCollection.Add(String name, Commit commit, Boolean allowOverwrite) in LibGit2Sharp\BranchCollection.cs:line 143
    at LibGit2Sharp.Tests.BranchFixture.CanCreateBranchInDeletedNestedBranchNamespace() in LibGit2Sharp.Tests\BranchFixture.cs:line 877

The scenario is:

    git branch level_one/level_two
    git branch -D level_one/level_two
    git branch level_one



While a bit of a corner case - people sometimes do this and git.git handles this without issue. My thought is that this should probably be handled better in `git_branch_create`, but I will start with an issue and failing test case here.

/cc @ethomson @carlosmn