### PR TITLE
.gitignore not in root folder is ignored

### DIFF
--- a/LibGit2Sharp.Tests/IgnoreFixture.cs
+++ b/LibGit2Sharp.Tests/IgnoreFixture.cs
@@ -83,5 +83,39 @@ namespace LibGit2Sharp.Tests
                 Assert.True(repo.Ignore.IsPathIgnored(string.Format(@"NewFolder{0}NewFolder{0}File.txt", Path.DirectorySeparatorChar)));
             }
         }
+
+        [Fact]
+        public void HonorDeeplyNestedGitIgnoreFile()
+        {
+            string path = InitNewRepository();
+            using (var repo = new Repository(path))
+            {
+                char pd = Path.DirectorySeparatorChar;
+
+                var gitIgnoreFile = string.Format("deeply{0}nested{0}.gitignore", pd);
+                Touch(repo.Info.WorkingDirectory, gitIgnoreFile, "SmtCounters.h");
+
+                repo.Stage(gitIgnoreFile);
+                repo.Commit("Add .gitignore", Constants.Signature, Constants.Signature);
+
+                Assert.False(repo.RetrieveStatus().IsDirty);
+
+                var ignoredFile = string.Format("deeply{0}nested{0}SmtCounters.h", pd);
+                Touch(repo.Info.WorkingDirectory, ignoredFile, "Content");
+                Assert.False(repo.RetrieveStatus().IsDirty);
+
+                var file = string.Format("deeply{0}nested{0}file.txt", pd);
+                Touch(repo.Info.WorkingDirectory, file, "Yeah!");
+
+                var repositoryStatus = repo.RetrieveStatus();
+                Assert.True(repositoryStatus.IsDirty);
+
+                Assert.Equal(FileStatus.Ignored, repositoryStatus[ignoredFile].State);
+                Assert.Equal(FileStatus.NewInWorkdir, repositoryStatus[file].State);
+
+                Assert.True(repo.Ignore.IsPathIgnored(ignoredFile));
+                Assert.False(repo.Ignore.IsPathIgnored(file));
+            }
+        }
     }
 }


### PR DESCRIPTION
If you create a folder and place .gitignore file there:

D:\repo\Reports\Acl_report 
» type .gitignore
\fixes
Fixes.zip
DeviceStatistic.csv
PolicyStatistic.csv

The files mentioned in that .gitignore file would be ignored by git, but LibGti2Sharp would list them as untracked. That makes automation that uses LibGit2Sharp buggy - before push it tests if index is dirty. LibGit2 says it is, git says it is not.

PS Possible it is a limitation of lib2git - I don't know. If that is the case - please repost this bug or advice where do lib2git tracks bugs.