### PR TITLE
Fix for computing blob size without loading entire blob content in memory - Fix #873

### DIFF
--- a/LibGit2Sharp.Tests/ObjectDatabaseFixture.cs
+++ b/LibGit2Sharp.Tests/ObjectDatabaseFixture.cs
@@ -49,6 +49,25 @@ namespace LibGit2Sharp.Tests
         }
 
         [Fact]
+        public void RetrieveObjectMetadataReturnsCorrectSizeAndTypeForBlob()
+        {
+            string path = InitNewRepository();
+
+            using (var repo = new Repository(path))
+            {
+                Blob blob = CreateBlob(repo, "I'm a new file\n");
+                Assert.NotNull(blob);
+
+                GitObjectMetadata blobMetadata = repo.ObjectDatabase.RetrieveObjectMetadata(blob.Id);
+                Assert.Equal(blobMetadata.Size, blob.Size);
+                Assert.Equal(blobMetadata.Type, ObjectType.Blob);
+
+                Blob fetchedBlob = repo.Lookup<Blob>(blob.Id);
+                Assert.Equal(blobMetadata.Size, fetchedBlob.Size);
+            }
+        }
+
+        [Fact]
         public void CanCreateABlobIntoTheDatabaseOfABareRepository()
         {
             string path = InitNewRepository();

--- a/LibGit2Sharp/Blob.cs
+++ b/LibGit2Sharp/Blob.cs
@@ -27,6 +27,10 @@ namespace LibGit2Sharp
 
         /// <summary>
         /// Gets the size in bytes of the raw content of a blob.
+        /// <para> Please note that this would load entire blob content in the memory to compute the Size.
+        /// In order to read blob size from header, Repository.ObjectMetadata.RetrieveObjectMetadata(Blob.Id).Size
+        /// can be used.
+        /// </para>
         /// </summary>
         public virtual int Size { get { return (int)lazySize.Value; } }
 

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -755,6 +755,9 @@ namespace LibGit2Sharp.Core
         internal static extern void git_odb_free(IntPtr odb);
 
         [DllImport(libgit2)]
+        internal static extern int git_odb_read_header(out UIntPtr len_out, out GitObjectType type, ObjectDatabaseSafeHandle odb, ref GitOid id);
+
+        [DllImport(libgit2)]
         internal static extern void git_object_free(IntPtr obj);
 
         [DllImport(libgit2)]

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -1378,6 +1378,21 @@ namespace LibGit2Sharp.Core
             }
         }
 
+        public static GitObjectMetadata git_odb_read_header(ObjectDatabaseSafeHandle odb, ObjectId id)
+        {
+            using (ThreadAffinity())
+            {
+                GitOid oid = id.Oid;
+                UIntPtr length;
+                GitObjectType objectType;
+
+                int res = NativeMethods.git_odb_read_header(out length, out objectType, odb, ref oid);
+                Ensure.ZeroResult(res);
+
+                return new GitObjectMetadata((long)length, objectType);
+            }
+        }
+
         public static ICollection<TResult> git_odb_foreach<TResult>(
             ObjectDatabaseSafeHandle odb,
             Func<IntPtr, TResult> resultSelector)

--- a/LibGit2Sharp/GitObjectMetadata.cs
+++ b/LibGit2Sharp/GitObjectMetadata.cs
@@ -1,0 +1,35 @@
+﻿using LibGit2Sharp.Core;
+using System;
+
+namespace LibGit2Sharp
+{
+    /// <summary>
+    /// Exposes low level Git object metadata
+    /// </summary>
+    public sealed class GitObjectMetadata
+    {
+        private readonly GitObjectType type;
+
+        /// <summary>
+        /// Size of the Object 
+        /// </summary>
+        public long Size { get; private set; }
+
+        /// <summary>
+        /// Object Type
+        /// </summary>
+        public ObjectType Type
+        {
+            get
+            {
+                return type.ToObjectType();
+            }
+        }
+
+        internal GitObjectMetadata(long size, GitObjectType type)
+        {
+            this.Size = size;
+            this.type = type;
+        }
+    }
+}

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -95,6 +95,7 @@
     <Compile Include="MergeOptions.cs" />
     <Compile Include="MergeResult.cs" />
     <Compile Include="NotFoundException.cs" />
+    <Compile Include="GitObjectMetadata.cs" />
     <Compile Include="PatchEntryChanges.cs" />
     <Compile Include="PatchStats.cs" />
     <Compile Include="PullOptions.cs" />

--- a/LibGit2Sharp/ObjectDatabase.cs
+++ b/LibGit2Sharp/ObjectDatabase.cs
@@ -73,6 +73,20 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
+        /// Retrieves the header of a GitObject from the object database. The header contains the Size
+        /// and Type of the object. Note that most backends do not support reading only the header
+        /// of an object, so the whole object will be read and then size would be returned.  
+        /// </summary>
+        /// <param name="objectId">Object Id of the queried object</param>
+        /// <returns>GitObjectMetadata object instance containg object header information</returns>
+        public virtual GitObjectMetadata RetrieveObjectMetadata(ObjectId objectId)
+        {
+            Ensure.ArgumentNotNull(objectId, "objectId");
+
+            return Proxy.git_odb_read_header(handle, objectId);
+        }
+
+        /// <summary>
         /// Inserts a <see cref="Blob"/> into the object database, created from the content of a file.
         /// </summary>
         /// <param name="path">Path to the file to create the blob from.  A relative path is allowed to


### PR DESCRIPTION
Fix for computing blob size without loading entire blob content in memory - Fix #873.

Summary of the fix - 
Added a new public method GetObjectSize in ObjectDatabase class which takes ObjectId as input and returns object size. Underneath this calls git_odb_read_header native method to read the header of the object. The header contains Object Type and size. The size is returned as an int value here.

Detailed summary - 

1- Added a new public method GetObjectSize in ObjectDatabase class which returns the Object size for a given Object Id.

2- Added a new class ObjectHeader, which stores the size and type of an object. This is in agreement with the return values of underlying libgit function git_odb_read_header, which is called underneath to fetch this information from ODB.

3- Added a wrapper around git_odb_read_header method to return an ObjectHeader C# object containing size and type info of the queried git object.

4- Added a unit test GetObjectSizeReturnsCorrectSizeForBlob which creates an empty repo, adds a new blob to it, and then verifies that the value returned by repo.ObjectDatabase.GetObjectSize(blob.Id) is same as blob.Size.

Verified this on my local setup with a repository which has about 50K files on the tip. Seems to work fine.

Thanks @ethomson for suggesting the solution and @jamill  for helping me out on the implementation and testing.
