### PR TITLE
Check for workdirPath null in Repository.Clone

### DIFF
--- a/LibGit2Sharp.Tests/CloneFixture.cs
+++ b/LibGit2Sharp.Tests/CloneFixture.cs
@@ -234,5 +234,13 @@ namespace LibGit2Sharp.Tests
         {
             Assert.Throws<ArgumentNullException>(() => Repository.Clone(url, null));
         }
+
+        [Fact]
+        public void CloningWithoutUrlThrows()
+        {
+            var scd = BuildSelfCleaningDirectory();
+
+            Assert.Throws<ArgumentNullException>(() => Repository.Clone(null, scd.DirectoryPath));
+        }
     }
 }

--- a/LibGit2Sharp/Repository.cs
+++ b/LibGit2Sharp/Repository.cs
@@ -538,6 +538,7 @@ namespace LibGit2Sharp
         public static string Clone(string sourceUrl, string workdirPath,
             CloneOptions options = null)
         {
+            Ensure.ArgumentNotNull(sourceUrl, "sourceUrl");
             Ensure.ArgumentNotNull(workdirPath, "workdirPath");
 
             options = options ?? new CloneOptions();


### PR DESCRIPTION
If you try to call `Repository.Clone` with `null` for `workdirPath`, it throws an `AccessViolationException` somewhere down the line. It took me a while to figure out why my code wasn't working until I discovered a typo of my own, which caused me to pass `null` instead of an actual valid path.

It's really silly and really simple, but I figured throwing an `ArgumentNullException` instead of an `AccessViolationException` wouldn't hurt, right?

_Disclaimer: I have no experience when it comes to contributing to anything that isn't my own, so I hope this is okay._
