### PR TITLE
Fix truncation of Blob.Size

### DIFF
--- a/LibGit2Sharp/Blob.cs
+++ b/LibGit2Sharp/Blob.cs
@@ -32,7 +32,7 @@ namespace LibGit2Sharp
         /// can be used.
         /// </para>
         /// </summary>
-        public virtual int Size { get { return (int)lazySize.Value; } }
+        public virtual long Size { get { return lazySize.Value; } }
 
         /// <summary>
         ///  Determine if the blob content is most certainly binary or not.


### PR DESCRIPTION
Aligns Blob.Size return type with GitObjectMetadata.Size.
