### PR TITLE
Tests can't run in parallel.

### DIFF
--- a/LibGit2Sharp.Tests/ArchiveFixture.cs
+++ b/LibGit2Sharp.Tests/ArchiveFixture.cs
@@ -11,7 +11,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanArchiveATree()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var tree = repo.Lookup<Tree>("581f9824ecaf824221bd36edf5430f2739a7c4f5");
 
@@ -36,7 +37,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanArchiveACommit()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var commit = repo.Lookup<Commit>("4c062a6361ae6959e06292c1fa5e2822d9c96345");
 
@@ -61,7 +63,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void ArchivingANullTreeOrCommitThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentNullException>(() => repo.ObjectDatabase.Archive((Commit)null, null));
                 Assert.Throws<ArgumentNullException>(() => repo.ObjectDatabase.Archive((Tree)null, null));

--- a/LibGit2Sharp.Tests/ArchiveTarFixture.cs
+++ b/LibGit2Sharp.Tests/ArchiveTarFixture.cs
@@ -26,7 +26,7 @@ namespace LibGit2Sharp.Tests
                 var commit = repo.Lookup<Commit>("4c062a6361ae6959e06292c1fa5e2822d9c96345");
 
                 var scd = BuildSelfCleaningDirectory();
-                var archivePath = Path.Combine(scd.RootedDirectoryPath, Guid.NewGuid() + ".tar");
+                var archivePath = Path.Combine(scd.RootedDirectoryPath, Path.GetRandomFileName() + ".tar");
                 Directory.CreateDirectory(scd.RootedDirectoryPath);
 
                 repo.ObjectDatabase.Archive(commit, archivePath);

--- a/LibGit2Sharp.Tests/ArchiveTarFixture.cs
+++ b/LibGit2Sharp.Tests/ArchiveTarFixture.cs
@@ -11,7 +11,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanArchiveACommitWithDirectoryAsTar()
         {
-            var path = CloneBareTestRepo();
+            var path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 // This tests generates an archive of the bare test repo, and compares it with

--- a/LibGit2Sharp.Tests/AttributesFixture.cs
+++ b/LibGit2Sharp.Tests/AttributesFixture.cs
@@ -9,7 +9,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void StagingHonorsTheAttributesFiles()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 CreateAttributesFile(repo);

--- a/LibGit2Sharp.Tests/BlameFixture.cs
+++ b/LibGit2Sharp.Tests/BlameFixture.cs
@@ -22,7 +22,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanBlameSimply()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 AssertCorrectHeadBlame(repo.Blame("README"));
             }
@@ -31,7 +32,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanBlameFromADifferentCommit()
         {
-            using (var repo = new Repository(MergedTestRepoWorkingDirPath))
+            string path = SandboxMergedTestRepo();
+            using (var repo = new Repository(path))
             {
                 // File doesn't exist at HEAD
                 Assert.Throws<LibGit2SharpException>(() => repo.Blame("ancestor-only.txt"));
@@ -44,7 +46,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void ValidatesLimits()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var blame = repo.Blame("README");
 
@@ -56,7 +59,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanBlameFromVariousTypes()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 AssertCorrectHeadBlame(repo.Blame("README", new BlameOptions {StartingAt = "HEAD" }));
                 AssertCorrectHeadBlame(repo.Blame("README", new BlameOptions {StartingAt = repo.Head }));
@@ -68,7 +72,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanStopBlame()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 // $ git blame .\new.txt
                 // 9fd738e8 (Scott Chacon 2010-05-24 10:19:19 -0700 1) my new file

--- a/LibGit2Sharp.Tests/BlobFixture.cs
+++ b/LibGit2Sharp.Tests/BlobFixture.cs
@@ -30,7 +30,7 @@ namespace LibGit2Sharp.Tests
         {
             SkipIfNotSupported(autocrlf);
 
-            var path = CloneBareTestRepo();
+            var path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 repo.Config.Set("core.autocrlf", autocrlf);
@@ -52,7 +52,7 @@ namespace LibGit2Sharp.Tests
         [InlineData("utf-32", 20, "FF FE 00 00 31 00 00 00 32 00 00 00 33 00 00 00 34 00 00 00")]
         public void CanGetBlobAsTextWithVariousEncodings(string encodingName, int expectedContentBytes, string expectedUtf7Chars)
         {
-            var path = CloneStandardTestRepo();
+            var path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 var bomFile = "bom.txt";
@@ -129,7 +129,7 @@ namespace LibGit2Sharp.Tests
         {
             SkipIfNotSupported(autocrlf);
 
-            var path = CloneBareTestRepo();
+            var path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 repo.Config.Set("core.autocrlf", autocrlf);
@@ -153,7 +153,7 @@ namespace LibGit2Sharp.Tests
         {
             var binaryContent = new byte[] { 0, 1, 2, 3, 4, 5 };
 
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 using (var stream = new MemoryStream(binaryContent))

--- a/LibGit2Sharp.Tests/BlobFixture.cs
+++ b/LibGit2Sharp.Tests/BlobFixture.cs
@@ -12,7 +12,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanGetBlobAsText()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var blob = repo.Lookup<Blob>("a8233120f6ad708f843d861ce2b7228ec4e3dec6");
 
@@ -86,7 +87,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanGetBlobSize()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var blob = repo.Lookup<Blob>("a8233120f6ad708f843d861ce2b7228ec4e3dec6");
                 Assert.Equal(10, blob.Size);
@@ -96,7 +98,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanLookUpBlob()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var blob = repo.Lookup<Blob>("a8233120f6ad708f843d861ce2b7228ec4e3dec6");
                 Assert.NotNull(blob);
@@ -106,7 +109,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanReadBlobStream()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var blob = repo.Lookup<Blob>("a8233120f6ad708f843d861ce2b7228ec4e3dec6");
 
@@ -208,7 +212,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanTellIfTheBlobContentLooksLikeBinary()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var blob = repo.Lookup<Blob>("a8233120f6ad708f843d861ce2b7228ec4e3dec6");
                 Assert.Equal(false, blob.IsBinary);

--- a/LibGit2Sharp.Tests/BranchFixture.cs
+++ b/LibGit2Sharp.Tests/BranchFixture.cs
@@ -238,7 +238,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CreatingABranchFromANonCommitObjectThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 const string name = "sorry-dude-i-do-not-do-blobs-nor-trees";
                 Assert.Throws<InvalidSpecificationException>(() => repo.CreateBranch(name, "refs/tags/point_to_blob"));
@@ -250,7 +251,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CreatingBranchWithUnknownNamedTargetThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<LibGit2SharpException>(() => repo.Branches.Add("my_new_branch", "my_old_branch"));
             }
@@ -259,7 +261,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CreatingBranchWithUnknownShaTargetThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<LibGit2SharpException>(() => repo.Branches.Add("my_new_branch", Constants.UnknownSha));
                 Assert.Throws<LibGit2SharpException>(() => repo.Branches.Add("my_new_branch", Constants.UnknownSha.Substring(0, 7)));
@@ -269,7 +272,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CreatingBranchWithBadParamsThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentNullException>(() => repo.Branches.Add(null, repo.Head.CanonicalName));
                 Assert.Throws<ArgumentException>(() => repo.Branches.Add(string.Empty, repo.Head.CanonicalName));
@@ -282,7 +286,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanListAllBranches()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Equal(expectedBranches, SortedBranches(repo.Branches, b => b.Name));
 
@@ -312,7 +317,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanListAllBranchesWhenGivenWorkingDir()
         {
-            using (var repo = new Repository(StandardTestRepoWorkingDirPath))
+            string path = SandboxStandardTestRepo();
+            using (var repo = new Repository(path))
             {
                 var expectedWdBranches = new[]
                                              {
@@ -328,7 +334,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanListAllBranchesIncludingRemoteRefs()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            string path = SandboxStandardTestRepo();
+            using (var repo = new Repository(path))
             {
                 var expectedBranchesIncludingRemoteRefs = new[]
                                                               {
@@ -352,7 +359,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanResolveRemote()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            string path = SandboxStandardTestRepo();
+            using (var repo = new Repository(path))
             {
                 Branch master = repo.Branches["master"];
                 Assert.Equal(repo.Network.Remotes["origin"], master.Remote);
@@ -362,7 +370,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void RemoteAndUpstreamBranchCanonicalNameForNonTrackingBranchIsNull()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            string path = SandboxStandardTestRepo();
+            using (var repo = new Repository(path))
             {
                 Branch test = repo.Branches["i-do-numbers"];
                 Assert.Null(test.Remote);
@@ -374,7 +383,8 @@ namespace LibGit2Sharp.Tests
         public void QueryRemoteForLocalTrackingBranch()
         {
             // There is not a Remote to resolve for a local tracking branch.
-            using (var repo = new Repository(StandardTestRepoPath))
+            string path = SandboxStandardTestRepo();
+            using (var repo = new Repository(path))
             {
                 Branch trackLocal = repo.Branches["track-local"];
                 Assert.Null(trackLocal.Remote);
@@ -384,7 +394,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void QueryUpstreamBranchCanonicalNameForLocalTrackingBranch()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            string path = SandboxStandardTestRepo();
+            using (var repo = new Repository(path))
             {
                 Branch trackLocal = repo.Branches["track-local"];
                 Assert.Equal("refs/heads/master", trackLocal.UpstreamBranchCanonicalName);
@@ -394,7 +405,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void QueryRemoteForRemoteBranch()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            string path = SandboxStandardTestRepo();
+            using (var repo = new Repository(path))
             {
                 var master = repo.Branches["origin/master"];
                 Assert.Equal(repo.Network.Remotes["origin"], master.Remote);
@@ -452,7 +464,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanLookupABranchByItsCanonicalName()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Branch branch = repo.Branches["refs/heads/br2"];
                 Assert.NotNull(branch);
@@ -470,7 +483,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanLookupLocalBranch()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Branch master = repo.Branches["master"];
                 Assert.NotNull(master);
@@ -501,7 +515,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void LookingOutABranchByNameWithBadParamsThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Branch branch;
                 Assert.Throws<ArgumentNullException>(() => branch = repo.Branches[null]);
@@ -587,7 +602,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void TrackingInformationIsEmptyForNonTrackingBranch()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Branch branch = repo.Branches["test"];
                 Assert.False(branch.IsTracking);
@@ -603,7 +619,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanGetTrackingInformationForTrackingBranch()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            string path = SandboxStandardTestRepo();
+            using (var repo = new Repository(path))
             {
                 Branch master = repo.Branches["master"];
                 Assert.True(master.IsTracking);
@@ -619,7 +636,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanGetTrackingInformationForLocalTrackingBranch()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            string path = SandboxStandardTestRepo();
+            using (var repo = new Repository(path))
             {
                 var branch = repo.Branches["track-local"];
                 Assert.True(branch.IsTracking);
@@ -635,7 +653,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void RenamingARemoteTrackingBranchThrows()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            string path = SandboxStandardTestRepo();
+            using (var repo = new Repository(path))
             {
                 Branch master = repo.Branches["refs/remotes/origin/master"];
                 Assert.True(master.IsRemote);
@@ -647,7 +666,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanWalkCommitsFromAnotherBranch()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Branch master = repo.Branches["test"];
                 Assert.Equal(2, master.Commits.Count());
@@ -813,7 +833,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanWalkCommitsFromBranch()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Branch master = repo.Branches["master"];
                 Assert.Equal(7, master.Commits.Count());
@@ -871,7 +892,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void RemovingABranchWhichIsTheCurrentHeadThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<LibGit2SharpException>(() => repo.Branches.Remove(repo.Head.Name));
             }
@@ -880,7 +902,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void RemovingABranchWithBadParamsThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentException>(() => repo.Branches.Remove(string.Empty));
                 Assert.Throws<ArgumentNullException>(() => repo.Branches.Remove(null));
@@ -890,7 +913,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void OnlyOneBranchIsTheHead()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Branch head = null;
 
@@ -957,7 +981,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void BlindlyRenamingABranchOverAnExistingOneThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<NameConflictException>(() => repo.Branches.Rename("br2", "test"));
             }
@@ -1068,7 +1093,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void RemoteBranchesDoNotTrackAnything()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            string path = SandboxStandardTestRepo();
+            using (var repo = new Repository(path))
             {
                 var branches = repo.Branches.Where(b => b.IsRemote);
 

--- a/LibGit2Sharp.Tests/BranchFixture.cs
+++ b/LibGit2Sharp.Tests/BranchFixture.cs
@@ -17,7 +17,7 @@ namespace LibGit2Sharp.Tests
         [InlineData("Ångström")]
         public void CanCreateBranch(string name)
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 EnableRefLog(repo);
@@ -50,7 +50,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCreateAnUnbornBranch()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 // No branch named orphan
@@ -85,7 +85,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCreateBranchUsingAbbreviatedSha()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 EnableRefLog(repo);
@@ -108,7 +108,7 @@ namespace LibGit2Sharp.Tests
         [InlineData("master")]
         public void CanCreateBranchFromImplicitHead(string headCommitOrBranchSpec)
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 EnableRefLog(repo);
@@ -136,7 +136,7 @@ namespace LibGit2Sharp.Tests
         [InlineData("master")]
         public void CanCreateBranchFromExplicitHead(string headCommitOrBranchSpec)
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 EnableRefLog(repo);
@@ -157,7 +157,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCreateBranchFromCommit()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 EnableRefLog(repo);
@@ -177,7 +177,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCreateBranchFromRevparseSpec()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 EnableRefLog(repo);
@@ -200,7 +200,7 @@ namespace LibGit2Sharp.Tests
         [InlineData("refs/tags/test")]
         public void CreatingABranchFromATagPeelsToTheCommit(string committish)
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 EnableRefLog(repo);
@@ -220,7 +220,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CreatingABranchTriggersTheCreationOfADirectReference()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 Branch newBranch = repo.CreateBranch("clone-of-master");
@@ -293,7 +293,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanListBranchesWithRemoteAndLocalBranchWithSameShortName()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 // Create a local branch with the same short name as a remote branch.
@@ -404,7 +404,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void QueryUnresolvableRemoteForRemoteBranch()
         {
-            var path = CloneStandardTestRepo();
+            var path = SandboxStandardTestRepo();
 
             var fetchRefSpecs = new string[] { "+refs/heads/notfound/*:refs/remotes/origin/notfound/*" };
 
@@ -429,7 +429,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void QueryAmbigousRemoteForRemoteBranch()
         {
-            var path = CloneStandardTestRepo();
+            var path = SandboxStandardTestRepo();
 
             var fetchRefSpec = "+refs/heads/*:refs/remotes/origin/*";
             var url = "http://github.com/libgit2/TestGitRepository";
@@ -485,7 +485,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanLookupABranchWhichNameIsMadeOfNon7BitsAsciiCharacters()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 const string name = "Ångström";
@@ -539,7 +539,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanGetTrackingInformationFromBranchSharingNoHistoryWithItsTrackedBranch()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 Branch master = repo.Branches["master"];
@@ -565,7 +565,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void TrackingInformationIsEmptyForBranchTrackingPrunedRemoteBranch()
         {
-            var path = CloneStandardTestRepo();
+            var path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 const string remoteRef = "refs/remotes/origin/master";
@@ -660,7 +660,7 @@ namespace LibGit2Sharp.Tests
             const string testBranchName = "branchToSetUpstreamInfoFor";
             const string trackedBranchName = "refs/remotes/origin/master";
 
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 Branch branch = repo.CreateBranch(testBranchName);
@@ -692,7 +692,7 @@ namespace LibGit2Sharp.Tests
             const string trackedBranchName = "refs/remotes/origin/master";
             var fetchRefSpecs = new string[] { "+refs/heads/notfound/*:refs/remotes/origin/notfound/*" };
 
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 // Modify the fetch spec so that the remote for the remote-tracking branch
@@ -720,7 +720,7 @@ namespace LibGit2Sharp.Tests
             const string trackedBranchName = "refs/remotes/origin/master";
             const string remoteName = "origin";
 
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 Branch branch = repo.CreateBranch(testBranchName);
@@ -750,7 +750,7 @@ namespace LibGit2Sharp.Tests
             const string testBranchName = "branchToSetUpstreamInfoFor";
             const string localTrackedBranchName = "refs/heads/master";
 
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 Branch branch = repo.CreateBranch(testBranchName);
@@ -788,7 +788,7 @@ namespace LibGit2Sharp.Tests
             const string testBranchName = "branchToSetUpstreamInfoFor";
             const string trackedBranchName = "refs/remotes/origin/master";
 
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 Branch branch = repo.CreateBranch(testBranchName);
@@ -822,7 +822,7 @@ namespace LibGit2Sharp.Tests
 
         private void AssertRemoval(string branchName, bool isRemote, bool shouldPreviouslyAssertExistence)
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 if (shouldPreviouslyAssertExistence)
@@ -849,7 +849,7 @@ namespace LibGit2Sharp.Tests
         [InlineData("origin/br2")]
         public void CanRemoveAnExistingBranch(string branchName)
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 Branch curBranch = repo.Branches[branchName];
@@ -919,7 +919,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void TwoBranchesPointingAtTheSameCommitAreNotBothCurrent()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 Branch master = repo.Branches["refs/heads/master"];
@@ -932,7 +932,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanRenameABranch()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 EnableRefLog(repo);
@@ -966,7 +966,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanRenameABranchWhileOverwritingAnExistingOne()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 EnableRefLog(repo);
@@ -998,7 +998,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void DetachedHeadIsNotATrackingBranch()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 repo.Reset(ResetMode.Hard);
@@ -1095,7 +1095,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CreatingABranchIncludesTheCorrectReflogEntries()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 EnableRefLog(repo);
@@ -1111,7 +1111,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void RenamingABranchIncludesTheCorrectReflogEntries()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 EnableRefLog(repo);

--- a/LibGit2Sharp.Tests/CheckoutFixture.cs
+++ b/LibGit2Sharp.Tests/CheckoutFixture.cs
@@ -19,7 +19,7 @@ namespace LibGit2Sharp.Tests
         [InlineData("diff-test-cases")]
         public void CanCheckoutAnExistingBranch(string branchName)
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 Branch master = repo.Branches["master"];
@@ -62,7 +62,7 @@ namespace LibGit2Sharp.Tests
         [InlineData("diff-test-cases")]
         public void CanCheckoutAnExistingBranchByName(string branchName)
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 Branch master = repo.Branches["master"];
@@ -104,7 +104,7 @@ namespace LibGit2Sharp.Tests
         [InlineData("HEAD~2", false, "4c062a6361ae6959e06292c1fa5e2822d9c96345")]
         public void CanCheckoutAnArbitraryCommit(string commitPointer, bool checkoutByCommitOrBranchSpec, string expectedReflogTarget)
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 Branch master = repo.Branches["master"];
@@ -237,7 +237,7 @@ namespace LibGit2Sharp.Tests
             // 4) Create conflicting change
             // 5) Forcefully checkout master
 
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 Branch master = repo.Branches["master"];
@@ -699,7 +699,7 @@ namespace LibGit2Sharp.Tests
         [InlineData("origin/master")]
         public void CheckingOutRemoteBranchResultsInDetachedHead(string remoteBranchSpec)
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 Branch master = repo.Branches["master"];
@@ -719,7 +719,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CheckingOutABranchDoesNotAlterBinaryFiles()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 // $ git hash-object square-logo.png
@@ -748,7 +748,7 @@ namespace LibGit2Sharp.Tests
         [InlineData("e90810^{}")]
         public void CheckoutFromDetachedHead(string commitPointer)
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 // Set the working directory to the current head
@@ -774,7 +774,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CheckoutBranchFromDetachedHead()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 // Set the working directory to the current head
@@ -799,7 +799,7 @@ namespace LibGit2Sharp.Tests
         [InlineData("heads/master", "refs/heads/master")]
         public void CheckoutBranchByShortNameAttachesTheHead(string shortBranchName, string referenceName)
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 // Set the working directory to the current head
@@ -820,7 +820,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CheckoutPreviousCheckedOutBranch()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 // Set the working directory to the current head
@@ -842,7 +842,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CheckoutCurrentReference()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 Branch master = repo.Branches["master"];
@@ -898,7 +898,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCheckoutAttachedHead()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 Assert.False(repo.Info.IsHeadDetached);
@@ -914,7 +914,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCheckoutDetachedHead()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 repo.Checkout(repo.Head.Tip.Sha);
@@ -936,7 +936,7 @@ namespace LibGit2Sharp.Tests
         [InlineData("i-do-numbers", "diff-test-cases", "numbers.txt", FileStatus.Staged)]
         public void CanCheckoutPath(string originalBranch, string checkoutFrom, string path, FileStatus expectedStatus)
         {
-            string repoPath = CloneStandardTestRepo();
+            string repoPath = SandboxStandardTestRepo();
             using (var repo = new Repository(repoPath))
             {
                 // Set the working directory to the current head
@@ -955,7 +955,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCheckoutPaths()
         {
-            string repoPath = CloneStandardTestRepo();
+            string repoPath = SandboxStandardTestRepo();
             var checkoutPaths = new[] { "numbers.txt", "super-file.txt" };
 
             using (var repo = new Repository(repoPath))
@@ -976,7 +976,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CannotCheckoutPathsWithEmptyOrNullPathArgument()
         {
-            string repoPath = CloneStandardTestRepo();
+            string repoPath = SandboxStandardTestRepo();
 
             using (var repo = new Repository(repoPath))
             {
@@ -999,7 +999,7 @@ namespace LibGit2Sharp.Tests
         [InlineData("1.txt")]
         public void CanCheckoutPathFromCurrentBranch(string fileName)
         {
-            string repoPath = CloneStandardTestRepo();
+            string repoPath = SandboxStandardTestRepo();
 
             using (var repo = new Repository(repoPath))
             {

--- a/LibGit2Sharp.Tests/CheckoutFixture.cs
+++ b/LibGit2Sharp.Tests/CheckoutFixture.cs
@@ -356,7 +356,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CheckingOutInABareRepoThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<BareRepositoryException>(() => repo.Checkout(repo.Branches["refs/heads/test"]));
                 Assert.Throws<BareRepositoryException>(() => repo.Checkout("refs/heads/test"));
@@ -379,7 +380,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CheckingOutANonExistingBranchThrows()
         {
-            using (var repo = new Repository(StandardTestRepoWorkingDirPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<LibGit2SharpException>(() => repo.Checkout("i-do-not-exist"));
             }
@@ -388,7 +390,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CheckingOutABranchWithBadParamsThrows()
         {
-            using (var repo = new Repository(StandardTestRepoWorkingDirPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentException>(() => repo.Checkout(string.Empty));
                 Assert.Throws<ArgumentNullException>(() => repo.Checkout(default(Branch)));
@@ -889,7 +892,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CheckoutLowerCasedHeadThrows()
         {
-            using (var repo = new Repository(StandardTestRepoWorkingDirPath))
+            string path = SandboxStandardTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<LibGit2SharpException>(() => repo.Checkout("head"));
             }

--- a/LibGit2Sharp.Tests/CherryPickFixture.cs
+++ b/LibGit2Sharp.Tests/CherryPickFixture.cs
@@ -14,7 +14,7 @@ namespace LibGit2Sharp.Tests
         [InlineData(false)]
         public void CanCherryPick(bool fromDetachedHead)
         {
-            string path = CloneMergeTestRepo();
+            string path = SandboxMergeTestRepo();
             using (var repo = new Repository(path))
             {
                 if (fromDetachedHead)
@@ -42,7 +42,7 @@ namespace LibGit2Sharp.Tests
             const string secondBranchFileName = "second branch file.txt";
             const string sharedBranchFileName = "first+second branch file.txt";
 
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 var firstBranch = repo.CreateBranch("FirstBranch");
@@ -83,7 +83,7 @@ namespace LibGit2Sharp.Tests
             const string conflictFile = "a.txt";
             const string conflictBranchName = "conflicts";
 
-            string path = CloneMergeTestRepo();
+            string path = SandboxMergeTestRepo();
             using (var repo = new Repository(path))
             {
                 Branch branch = repo.Branches[conflictBranchName];

--- a/LibGit2Sharp.Tests/CleanFixture.cs
+++ b/LibGit2Sharp.Tests/CleanFixture.cs
@@ -27,7 +27,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CannotCleanABareRepository()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<BareRepositoryException>(() => repo.RemoveUntrackedFiles());
             }

--- a/LibGit2Sharp.Tests/CleanFixture.cs
+++ b/LibGit2Sharp.Tests/CleanFixture.cs
@@ -9,7 +9,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCleanWorkingDirectory()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 // Verify that there are the expected number of entries and untracked files

--- a/LibGit2Sharp.Tests/CloneFixture.cs
+++ b/LibGit2Sharp.Tests/CloneFixture.cs
@@ -92,7 +92,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCloneALocalRepositoryFromANewlyCreatedTemporaryPath()
         {
-            var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString().Substring(0, 8));
+            var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             SelfCleaningDirectory scd = BuildSelfCleaningDirectory(path);
             Repository.Init(scd.DirectoryPath);
             AssertLocalClone(scd.DirectoryPath, isCloningAnEmptyRepository: true);

--- a/LibGit2Sharp.Tests/CloneFixture.cs
+++ b/LibGit2Sharp.Tests/CloneFixture.cs
@@ -79,7 +79,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCloneALocalRepositoryFromALocalUri()
         {
-            var uri = new Uri(BareTestRepoPath);
+            var uri = new Uri(Path.GetFullPath(BareTestRepoPath));
             AssertLocalClone(uri.AbsoluteUri, BareTestRepoPath);
         }
 

--- a/LibGit2Sharp.Tests/CommitAncestorFixture.cs
+++ b/LibGit2Sharp.Tests/CommitAncestorFixture.cs
@@ -35,7 +35,8 @@ namespace LibGit2Sharp.Tests
         [InlineData(null, "be3563a", "-")]
         public void FindCommonAncestorForTwoCommits(string result, string sha1, string sha2)
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var first = sha1 == "-" ? CreateOrphanedCommit(repo) : repo.Lookup<Commit>(sha1);
                 var second = sha2 == "-" ? CreateOrphanedCommit(repo) : repo.Lookup<Commit>(sha2);
@@ -65,7 +66,8 @@ namespace LibGit2Sharp.Tests
         [InlineData(null, new[] { "4c062a6", "-" }, MergeBaseFindingStrategy.Standard)]
         public void FindCommonAncestorForCommitsAsEnumerable(string result, string[] shas, MergeBaseFindingStrategy strategy)
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var commits = shas.Select(sha => sha == "-" ? CreateOrphanedCommit(repo) : repo.Lookup<Commit>(sha)).ToArray();
 
@@ -88,7 +90,8 @@ namespace LibGit2Sharp.Tests
         [InlineData("0000000", "4c062a6")]
         public void FindCommonAncestorForTwoCommitsThrows(string sha1, string sha2)
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var first = repo.Lookup<Commit>(sha1);
                 var second = repo.Lookup<Commit>(sha2);
@@ -104,7 +107,8 @@ namespace LibGit2Sharp.Tests
         [InlineData(new[] { "4c062a6", "be3563a", "000000" }, MergeBaseFindingStrategy.Standard)]
         public void FindCommonAncestorForCommitsAsEnumerableThrows(string[] shas, MergeBaseFindingStrategy strategy)
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var commits = shas.Select(sha => sha == "-" ? CreateOrphanedCommit(repo) : repo.Lookup<Commit>(sha)).ToArray();
 

--- a/LibGit2Sharp.Tests/CommitFixture.cs
+++ b/LibGit2Sharp.Tests/CommitFixture.cs
@@ -17,7 +17,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCountCommits()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Equal(7, repo.Commits.Count());
             }
@@ -47,7 +48,8 @@ namespace LibGit2Sharp.Tests
         public void CanEnumerateCommits()
         {
             int count = 0;
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 foreach (Commit commit in repo.Commits)
                 {
@@ -76,7 +78,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void DefaultOrderingWhenEnumeratingCommitsIsTimeBased()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Equal(CommitSortStrategies.Time, repo.Commits.SortedBy);
             }
@@ -86,7 +89,8 @@ namespace LibGit2Sharp.Tests
         public void CanEnumerateCommitsFromSha()
         {
             int count = 0;
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 foreach (Commit commit in repo.Commits.QueryBy(new CommitFilter { Since = "a4a7dce85cf63874e984719f4fdd239f5145052f" }))
                 {
@@ -100,7 +104,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void QueryingTheCommitHistoryWithUnknownShaOrInvalidEntryPointThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<LibGit2SharpException>(() => repo.Commits.QueryBy(new CommitFilter { Since = Constants.UnknownSha }).Count());
                 Assert.Throws<LibGit2SharpException>(() => repo.Commits.QueryBy(new CommitFilter { Since = "refs/heads/deadbeef" }).Count());
@@ -124,7 +129,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void QueryingTheCommitHistoryWithBadParamsThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentException>(() => repo.Commits.QueryBy(new CommitFilter { Since = string.Empty }));
                 Assert.Throws<ArgumentNullException>(() => repo.Commits.QueryBy(new CommitFilter { Since = null }));
@@ -139,7 +145,8 @@ namespace LibGit2Sharp.Tests
             reversedShas.Reverse();
 
             int count = 0;
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 foreach (Commit commit in repo.Commits.QueryBy(new CommitFilter
                                                                     {
@@ -158,7 +165,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanEnumerateCommitsWithReverseTopoSorting()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 List<Commit> commits = repo.Commits.QueryBy(new CommitFilter
                                                                 {
@@ -192,7 +200,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanGetParentsCount()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Equal(1, repo.Commits.First().Parents.Count());
             }
@@ -202,7 +211,8 @@ namespace LibGit2Sharp.Tests
         public void CanEnumerateCommitsWithTimeSorting()
         {
             int count = 0;
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 foreach (Commit commit in repo.Commits.QueryBy(new CommitFilter
                                                                     {
@@ -221,7 +231,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanEnumerateCommitsWithTopoSorting()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 List<Commit> commits = repo.Commits.QueryBy(new CommitFilter
                                                                 {
@@ -364,7 +375,7 @@ namespace LibGit2Sharp.Tests
             CanEnumerateCommitsFromATag(t => t.Annotation);
         }
 
-        private static void CanEnumerateCommitsFromATag(Func<Tag, object> transformer)
+        private void CanEnumerateCommitsFromATag(Func<Tag, object> transformer)
         {
             AssertEnumerationOfCommits(
                 repo => new CommitFilter { Since = transformer(repo.Tags["test"]) },
@@ -413,9 +424,10 @@ namespace LibGit2Sharp.Tests
             }
         }
 
-        private static void AssertEnumerationOfCommits(Func<IRepository, CommitFilter> filterBuilder, IEnumerable<string> abbrevIds)
+        private void AssertEnumerationOfCommits(Func<IRepository, CommitFilter> filterBuilder, IEnumerable<string> abbrevIds)
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 AssertEnumerationOfCommitsInRepo(repo, filterBuilder, abbrevIds);
             }
@@ -433,7 +445,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanLookupCommitGeneric()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var commit = repo.Lookup<Commit>(sha);
                 Assert.Equal("testing\n", commit.Message);
@@ -445,7 +458,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanReadCommitData()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 GitObject obj = repo.Lookup(sha);
                 Assert.NotNull(obj);
@@ -476,7 +490,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanReadCommitWithMultipleParents()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var commit = repo.Lookup<Commit>("a4a7dce85cf63874e984719f4fdd239f5145052f");
                 Assert.Equal(2, commit.Parents.Count());
@@ -486,7 +501,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanDirectlyAccessABlobOfTheCommit()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var commit = repo.Lookup<Commit>("4c062a6");
 
@@ -500,7 +516,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanDirectlyAccessATreeOfTheCommit()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var commit = repo.Lookup<Commit>("4c062a6");
 
@@ -512,7 +529,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void DirectlyAccessingAnUnknownTreeEntryOfTheCommitReturnsNull()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var commit = repo.Lookup<Commit>("4c062a6");
 

--- a/LibGit2Sharp.Tests/CommitFixture.cs
+++ b/LibGit2Sharp.Tests/CommitFixture.cs
@@ -831,7 +831,7 @@ namespace LibGit2Sharp.Tests
 
         private static void CreateAndStageANewFile(IRepository repo)
         {
-            string relativeFilepath = string.Format("new-file-{0}.txt", Guid.NewGuid());
+            string relativeFilepath = string.Format("new-file-{0}.txt", Path.GetRandomFileName());
             Touch(repo.Info.WorkingDirectory, relativeFilepath, "brand new content\n");
             repo.Stage(relativeFilepath);
         }

--- a/LibGit2Sharp.Tests/CommitFixture.cs
+++ b/LibGit2Sharp.Tests/CommitFixture.cs
@@ -26,7 +26,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCorrectlyCountCommitsWhenSwitchingToAnotherBranch()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 // Hard reset and then remove untracked files
@@ -61,7 +61,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanEnumerateCommitsInDetachedHeadState()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 ObjectId parentOfHead = repo.Head.Tip.Parents.First().Id;
@@ -111,7 +111,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void QueryingTheCommitHistoryFromACorruptedReferenceThrows()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 CreateCorruptedDeadBeefHead(repo.Info.Path);
@@ -255,7 +255,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanEnumerateFromDetachedHead()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repoClone = new Repository(path))
             {
                 // Hard reset and then remove untracked files
@@ -400,7 +400,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanEnumerateCommitsFromATagWhichPointsToATree()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 string headTreeSha = repo.Head.Tip.Tree.Sha;
@@ -575,7 +575,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CommitParentsAreMergeHeads()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 repo.Reset(ResetMode.Hard, "c47800");
@@ -786,7 +786,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanAmendACommitWithMoreThanOneParent()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 var mergedCommit = repo.Lookup<Commit>("be3563a");
@@ -842,7 +842,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanRetrieveChildrenOfASpecificCommit()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 const string parentSha = "5b5b025afb0b4c913b4c338a42934a3863bf3644";
@@ -874,7 +874,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCorrectlyDistinguishAuthorFromCommitter()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 var author = new Signature("Wilbert van Dolleweerd", "getit@xs4all.nl",
@@ -914,7 +914,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanNotCommitAnEmptyCommit()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 repo.Reset(ResetMode.Hard);
@@ -927,7 +927,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCommitAnEmptyCommitWhenForced()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 repo.Reset(ResetMode.Hard);
@@ -941,7 +941,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanNotAmendAnEmptyCommit()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 repo.Reset(ResetMode.Hard);
@@ -958,7 +958,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanAmendAnEmptyCommitWhenForced()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 repo.Reset(ResetMode.Hard);
@@ -976,7 +976,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCommitAnEmptyCommitWhenMerging()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 repo.Reset(ResetMode.Hard);
@@ -997,7 +997,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanAmendAnEmptyMergeCommit()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 repo.Reset(ResetMode.Hard);

--- a/LibGit2Sharp.Tests/ConfigurationFixture.cs
+++ b/LibGit2Sharp.Tests/ConfigurationFixture.cs
@@ -67,7 +67,8 @@ namespace LibGit2Sharp.Tests
 
             var options = BuildFakeConfigs(scd);
 
-            using (var repo = new Repository(BareTestRepoPath, options))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path, options))
             {
                 Assert.True(repo.Config.HasConfig(ConfigurationLevel.Global));
                 Assert.Equal(42, repo.Config.Get<int>("Wow.Man-I-am-totally-global").Value);
@@ -83,7 +84,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanReadBooleanValue()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Assert.True(repo.Config.Get<bool>("core.ignorecase").Value);
                 Assert.True(repo.Config.GetValueOrDefault<bool>("core.ignorecase"));
@@ -97,7 +99,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanReadIntValue()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Assert.Equal(2, repo.Config.Get<int>("unittests.intsetting").Value);
                 Assert.Equal(2, repo.Config.GetValueOrDefault<int>("unittests.intsetting"));
@@ -112,7 +115,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanReadLongValue()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Assert.Equal(15234, repo.Config.Get<long>("unittests.longsetting").Value);
                 Assert.Equal(15234, repo.Config.GetValueOrDefault<long>("unittests.longsetting"));
@@ -126,7 +130,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanReadStringValue()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Assert.Equal("+refs/heads/*:refs/remotes/origin/*", repo.Config.Get<string>("remote.origin.fetch").Value);
                 Assert.Equal("+refs/heads/*:refs/remotes/origin/*", repo.Config.Get<string>("remote", "origin", "fetch").Value);
@@ -168,7 +173,8 @@ namespace LibGit2Sharp.Tests
             string configPath = CreateConfigurationWithDummyUser(Constants.Signature);
             var options = new RepositoryOptions { GlobalConfigurationLocation = configPath };
 
-            using (var repo = new Repository(StandardTestRepoPath, options))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path, options))
             {
                 var entry = repo.Config.FirstOrDefault<ConfigurationEntry<string>>(e => e.Key == "user.name");
                 Assert.NotNull(entry);
@@ -179,7 +185,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanEnumerateLocalConfig()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 var entry = repo.Config.FirstOrDefault<ConfigurationEntry<string>>(e => e.Key == "core.ignorecase");
                 Assert.NotNull(entry);
@@ -190,7 +197,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanEnumerateLocalConfigContainingAKeyWithNoValue()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var entry = repo.Config
                     .Single<ConfigurationEntry<string>>(c => c.Level == ConfigurationLevel.Local && c.Key == "core.pager");
@@ -202,7 +210,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanFindInLocalConfig()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 var matches = repo.Config.Find("unit");
 
@@ -218,7 +227,8 @@ namespace LibGit2Sharp.Tests
             string configPath = CreateConfigurationWithDummyUser(Constants.Signature);
             var options = new RepositoryOptions { GlobalConfigurationLocation = configPath };
 
-            using (var repo = new Repository(StandardTestRepoPath, options))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path, options))
             {
                 var matches = repo.Config.Find(@"\.name", ConfigurationLevel.Global);
 
@@ -310,7 +320,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void ReadingUnsupportedTypeThrows()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentException>(() => repo.Config.Get<short>("unittests.setting"));
                 Assert.Throws<ArgumentException>(() => repo.Config.Get<Configuration>("unittests.setting"));
@@ -320,7 +331,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void ReadingValueThatDoesntExistReturnsNull()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Assert.Null(repo.Config.Get<string>("unittests.ghostsetting"));
                 Assert.Null(repo.Config.Get<int>("unittests.ghostsetting"));
@@ -332,7 +344,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void SettingUnsupportedTypeThrows()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentException>(() => repo.Config.Set("unittests.setting", (short)123));
                 Assert.Throws<ArgumentException>(() => repo.Config.Set("unittests.setting", repo.Config));
@@ -371,7 +384,8 @@ namespace LibGit2Sharp.Tests
 
             var options = BuildFakeConfigs(scd);
 
-            using (var repo = new Repository(BareTestRepoPath, options))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path, options))
             {
                 Assert.True(repo.Config.HasConfig(ConfigurationLevel.System));
 

--- a/LibGit2Sharp.Tests/ConfigurationFixture.cs
+++ b/LibGit2Sharp.Tests/ConfigurationFixture.cs
@@ -46,7 +46,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanUnsetAnEntryFromTheLocalConfiguration()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 Assert.Null(repo.Config.Get<bool>("unittests.boolsetting"));
@@ -231,7 +231,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanSetBooleanValue()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 repo.Config.Set("unittests.boolsetting", true);
@@ -252,7 +252,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanSetIntValue()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 repo.Config.Set("unittests.intsetting", 3);
@@ -264,7 +264,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanSetLongValue()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 repo.Config.Set("unittests.longsetting", (long)451);
@@ -276,7 +276,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanSetStringValue()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 repo.Config.Set("unittests.stringsetting", "val");
@@ -288,7 +288,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanSetAndReadUnicodeStringValue()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 repo.Config.Set("unittests.stringsetting", "Juliën");
@@ -346,7 +346,7 @@ namespace LibGit2Sharp.Tests
 
             var options = BuildFakeConfigs(scd);
 
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path, options))
             {
                 Assert.True(repo.Config.HasConfig(ConfigurationLevel.Local));

--- a/LibGit2Sharp.Tests/ConflictFixture.cs
+++ b/LibGit2Sharp.Tests/ConflictFixture.cs
@@ -66,7 +66,7 @@ namespace LibGit2Sharp.Tests
         public void CanResolveConflictsByRemovingFromTheIndex(
             bool removeFromWorkdir, string filename, bool existsBeforeRemove, bool existsAfterRemove, FileStatus lastStatus, int removedIndexEntries)
         {
-            var path = CloneMergedTestRepo();
+            var path = SandboxMergedTestRepo();
             using (var repo = new Repository(path))
             {
                 int count = repo.Index.Count;
@@ -92,7 +92,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanGetOriginalNamesOfRenameConflicts()
         {
-            var path = CloneMergeRenamesTestRepo();
+            var path = SandboxMergeRenamesTestRepo();
             using (var repo = new Repository(path))
             {
                 var expected = RenameConflictData;

--- a/LibGit2Sharp.Tests/ConflictFixture.cs
+++ b/LibGit2Sharp.Tests/ConflictFixture.cs
@@ -92,7 +92,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanGetOriginalNamesOfRenameConflicts()
         {
-            var path = SandboxMergeRenamesTestRepo();
+            var path = Sandbox(MergeRenamesTestRepoWorkingDirPath);
             using (var repo = new Repository(path))
             {
                 var expected = RenameConflictData;
@@ -115,7 +115,8 @@ namespace LibGit2Sharp.Tests
         [Theory, PropertyData("ConflictData")]
         public void CanRetrieveSingleConflictByPath(string filepath, string ancestorId, string ourId, string theirId)
         {
-            using (var repo = new Repository(MergedTestRepoWorkingDirPath))
+            var path = SandboxMergedTestRepo();
+            using (var repo = new Repository(path))
             {
                 Conflict conflict = repo.Index.Conflicts[filepath];
                 Assert.NotNull(conflict);
@@ -162,7 +163,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanRetrieveAllConflicts()
         {
-            using (var repo = new Repository(MergedTestRepoWorkingDirPath))
+            var path = SandboxMergedTestRepo();
+            using (var repo = new Repository(path))
             {
                 var expected = repo.Index.Conflicts.Select(c => new[] { GetPath(c), GetId(c.Ancestor), GetId(c.Ours), GetId(c.Theirs) }).ToArray();
                 Assert.Equal(expected, ConflictData);

--- a/LibGit2Sharp.Tests/CurrentOperationFixture.cs
+++ b/LibGit2Sharp.Tests/CurrentOperationFixture.cs
@@ -41,7 +41,7 @@ namespace LibGit2Sharp.Tests
         [InlineData("rebase-merge/whatever", CurrentOperation.RebaseMerge)]
         public void CurrentOperationHasExpectedPendingOperationValues(string stateFile, CurrentOperation expectedState)
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
 
             Touch(Path.Combine(path, ".git"), stateFile);
 

--- a/LibGit2Sharp.Tests/CurrentOperationFixture.cs
+++ b/LibGit2Sharp.Tests/CurrentOperationFixture.cs
@@ -23,7 +23,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CurrentOperationInNoneForABareRepo()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Equal(CurrentOperation.None, repo.Info.CurrentOperation);
             }

--- a/LibGit2Sharp.Tests/DiffBlobToBlobFixture.cs
+++ b/LibGit2Sharp.Tests/DiffBlobToBlobFixture.cs
@@ -10,7 +10,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void ComparingABlobAgainstItselfReturnsNoDifference()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 var blob = repo.Lookup<Blob>("7909961");
 
@@ -25,7 +26,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCompareTwoVersionsOfABlobWithADiffOfTwoHunks()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 var oldblob = repo.Lookup<Blob>("7909961");
                 var newblob = repo.Lookup<Blob>("4e935b7");
@@ -91,7 +93,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCompareABlobAgainstANullBlob()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 var blob = repo.Lookup<Blob>("7909961");
 
@@ -112,7 +115,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void ComparingTwoNullBlobsReturnsAnEmptyContentChanges()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 ContentChanges changes = repo.Diff.Compare((Blob)null, (Blob)null);
 

--- a/LibGit2Sharp.Tests/DiffBlobToBlobFixture.cs
+++ b/LibGit2Sharp.Tests/DiffBlobToBlobFixture.cs
@@ -72,7 +72,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCompareATextualBlobAgainstABinaryBlob()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 Blob binBlob = CreateBinaryBlob(repo);

--- a/LibGit2Sharp.Tests/DiffTreeToTargetFixture.cs
+++ b/LibGit2Sharp.Tests/DiffTreeToTargetFixture.cs
@@ -66,7 +66,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCompareAMoreComplexTreeAgainstTheWorkdir()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Tree tree = repo.Head.Tip.Tree;
 
@@ -270,7 +271,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCompareAMoreComplexTreeAgainstTheIndex()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Tree tree = repo.Head.Tip.Tree;
 
@@ -297,7 +299,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCompareASubsetofTheTreeAgainstTheIndex()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Tree tree = repo.Head.Tip.Tree;
 
@@ -321,7 +324,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCompareASubsetofTheTreeAgainstTheIndexWithLaxExplicitPathsValidationAndANonExistentPath()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Tree tree = repo.Head.Tip.Tree;
 
@@ -338,7 +342,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void ComparingASubsetofTheTreeAgainstTheIndexWithStrictExplicitPathsValidationAndANonExistentPathThrows()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Tree tree = repo.Head.Tip.Tree;
 
@@ -402,7 +407,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void ComparingATreeInABareRepositoryAgainstTheWorkDirOrTheIndexThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<BareRepositoryException>(
                     () => repo.Diff.Compare<TreeChanges>(repo.Head.Tip.Tree, DiffTargets.WorkingDirectory));

--- a/LibGit2Sharp.Tests/DiffTreeToTreeFixture.cs
+++ b/LibGit2Sharp.Tests/DiffTreeToTreeFixture.cs
@@ -89,7 +89,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanDetectABinaryChange()
         {
-            using (var repo = new Repository(CloneStandardTestRepo()))
+            using (var repo = new Repository(SandboxStandardTestRepo()))
             {
                 const string filename = "binfile.foo";
                 var filepath = Path.Combine(repo.Info.WorkingDirectory, filename);
@@ -115,7 +115,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanDetectABinaryDeletion()
         {
-            using (var repo = new Repository(CloneStandardTestRepo()))
+            using (var repo = new Repository(SandboxStandardTestRepo()))
             {
                 const string filename = "binfile.foo";
                 var filepath = Path.Combine(repo.Info.WorkingDirectory, filename);
@@ -1000,7 +1000,7 @@ namespace LibGit2Sharp.Tests
         {
             const string file = "1/branch_file.txt";
 
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 TreeEntry entry = repo.Head[file];

--- a/LibGit2Sharp.Tests/DiffTreeToTreeFixture.cs
+++ b/LibGit2Sharp.Tests/DiffTreeToTreeFixture.cs
@@ -15,7 +15,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void ComparingATreeAgainstItselfReturnsNoDifference()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Tree tree = repo.Head.Tip.Tree;
 
@@ -31,7 +32,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void RetrievingANonExistentFileChangeReturnsNull()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Tree tree = repo.Head.Tip.Tree;
 
@@ -49,7 +51,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCompareACommitTreeAgainstItsParent()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Tree commitTree = repo.Head.Tip.Tree;
                 Tree parentCommitTree = repo.Head.Tip.Parents.Single().Tree;
@@ -151,7 +154,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCompareASubsetofTheTreeAgainstOneOfItsAncestor()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Tree tree = repo.Head.Tip.Tree;
                 Tree ancestor = repo.Lookup<Commit>("9fd738e").Tree;
@@ -181,7 +185,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCompareACommitTreeAgainstATreeWithNoCommonAncestor()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Tree commitTree = repo.Head.Tip.Tree;
                 Tree commitTreeWithDifferentAncestor = repo.Branches["refs/remotes/origin/test"].Tip.Tree;
@@ -206,7 +211,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCompareATreeAgainstAnotherTreeWithLaxExplicitPathsValidationAndNonExistentPath()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Tree commitTree = repo.Head.Tip.Tree;
                 Tree commitTreeWithDifferentAncestor = repo.Branches["refs/remotes/origin/test"].Tip.Tree;
@@ -224,7 +230,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void ComparingATreeAgainstAnotherTreeWithStrictExplicitPathsValidationThrows()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Tree commitTree = repo.Head.Tip.Tree;
                 Tree commitTreeWithDifferentAncestor = repo.Branches["refs/remotes/origin/test"].Tip.Tree;
@@ -256,7 +263,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void DetectsTheRenamingOfAModifiedFileByDefault()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Tree rootCommitTree = repo.Lookup<Commit>("f8d44d7").Tree;
                 Tree commitTreeWithRenamedFile = repo.Lookup<Commit>("4be51d6").Tree;
@@ -771,7 +779,8 @@ namespace LibGit2Sharp.Tests
         [InlineData(4, 193)]
         public void CanCompareTwoVersionsOfAFileWithATrailingNewlineDeletion(int contextLines, int expectedPatchLength)
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Tree rootCommitTree = repo.Lookup<Commit>("f8d44d7").Tree;
                 Tree commitTreeWithUpdatedFile = repo.Lookup<Commit>("ec9e401").Tree;
@@ -866,7 +875,8 @@ namespace LibGit2Sharp.Tests
                 Similarity = SimilarityOptions.None,
             };
 
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Tree rootCommitTree = repo.Lookup<Commit>("f8d44d7").Tree;
                 Tree mergedCommitTree = repo.Lookup<Commit>("7252fe2").Tree;
@@ -964,7 +974,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCompareATreeAgainstANullTree()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Tree tree = repo.Branches["refs/remotes/origin/test"].Tip.Tree;
 
@@ -987,7 +998,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void ComparingTwoNullTreesReturnsAnEmptyTreeChanges()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 var changes = repo.Diff.Compare<TreeChanges>(default(Tree), default(Tree));
 
@@ -1100,7 +1112,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CallingCompareWithAnUnsupportedGenericParamThrows()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<LibGit2SharpException>(() => repo.Diff.Compare<string>(default(Tree), default(Tree)));
                 Assert.Throws<LibGit2SharpException>(() => repo.Diff.Compare<string>());

--- a/LibGit2Sharp.Tests/DiffWorkdirToIndexFixture.cs
+++ b/LibGit2Sharp.Tests/DiffWorkdirToIndexFixture.cs
@@ -30,7 +30,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCompareTheWorkDirAgainstTheIndex()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 var changes = repo.Diff.Compare<TreeChanges>();
 
@@ -45,7 +46,8 @@ namespace LibGit2Sharp.Tests
         [InlineData("really-i-cant-exist.txt", FileStatus.Nonexistent)]
         public void CanCompareTheWorkDirAgainstTheIndexWithLaxUnmatchedExplicitPathsValidation(string relativePath, FileStatus currentStatus)
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Assert.Equal(currentStatus, repo.RetrieveStatus(relativePath));
 
@@ -62,7 +64,8 @@ namespace LibGit2Sharp.Tests
         [InlineData("really-i-cant-exist.txt", FileStatus.Nonexistent)]
         public void ComparingTheWorkDirAgainstTheIndexWithStrictUnmatchedExplicitPathsValidationAndANonExistentPathspecThrows(string relativePath, FileStatus currentStatus)
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Assert.Equal(currentStatus, repo.RetrieveStatus(relativePath));
 
@@ -77,7 +80,8 @@ namespace LibGit2Sharp.Tests
         {
             var callback = new AssertUnmatchedPathspecsCallbackIsCalled();
 
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Assert.Equal(currentStatus, repo.RetrieveStatus(relativePath));
 
@@ -171,7 +175,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCompareTheWorkDirAgainstTheIndexWithUntrackedFiles()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 var changes = repo.Diff.Compare<TreeChanges>(null, true);
 

--- a/LibGit2Sharp.Tests/DiffWorkdirToIndexFixture.cs
+++ b/LibGit2Sharp.Tests/DiffWorkdirToIndexFixture.cs
@@ -105,7 +105,7 @@ namespace LibGit2Sharp.Tests
         {
             const string file = "1/branch_file.txt";
 
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 TreeEntry entry = repo.Head[file];

--- a/LibGit2Sharp.Tests/FilterBranchFixture.cs
+++ b/LibGit2Sharp.Tests/FilterBranchFixture.cs
@@ -15,7 +15,7 @@ namespace LibGit2Sharp.Tests
 
         public FilterBranchFixture()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             repo = new Repository(path);
         }
 

--- a/LibGit2Sharp.Tests/IgnoreFixture.cs
+++ b/LibGit2Sharp.Tests/IgnoreFixture.cs
@@ -11,7 +11,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void TemporaryRulesShouldApplyUntilCleared()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 Touch(repo.Info.WorkingDirectory, "Foo.cs", "Bar");
@@ -31,7 +31,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void IsPathIgnoredShouldVerifyWhetherPathIsIgnored()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 Touch(repo.Info.WorkingDirectory, "Foo.cs", "Bar");
@@ -70,7 +70,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCheckIfAPathIsIgnoredUsingThePreferedPlatformDirectorySeparatorChar()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 Touch(repo.Info.WorkingDirectory, ".gitignore", "/NewFolder\n/NewFolder/NewFolder");

--- a/LibGit2Sharp.Tests/IgnoreFixture.cs
+++ b/LibGit2Sharp.Tests/IgnoreFixture.cs
@@ -51,7 +51,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CallingIsPathIgnoredWithBadParamsThrows()
         {
-            using (var repo = new Repository(StandardTestRepoWorkingDirPath))
+            string path = SandboxStandardTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentException>(() => repo.Ignore.IsPathIgnored(string.Empty));
                 Assert.Throws<ArgumentNullException>(() => repo.Ignore.IsPathIgnored(null));
@@ -61,7 +62,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void AddingATemporaryRuleWithBadParamsThrows()
         {
-            using (var repo = new Repository(StandardTestRepoWorkingDirPath))
+            string path = SandboxStandardTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentNullException>(() => repo.Ignore.AddTemporaryRules(null));
             }

--- a/LibGit2Sharp.Tests/IndexFixture.cs
+++ b/LibGit2Sharp.Tests/IndexFixture.cs
@@ -28,7 +28,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCountEntriesInIndex()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Assert.Equal(expectedEntries.Count(), repo.Index.Count);
             }
@@ -37,7 +38,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanEnumerateIndex()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Assert.Equal(expectedEntries,
                     repo.Index.Select(e => e.Path).OrderBy(p => p, StringComparer.Ordinal).ToArray());
@@ -47,7 +49,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanFetchAnIndexEntryByItsName()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 IndexEntry entry = repo.Index["README"];
                 Assert.Equal("README", entry.Path);
@@ -65,7 +68,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void FetchingAnUnknownIndexEntryReturnsNull()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 IndexEntry entry = repo.Index["I-do-not-exist.txt"];
                 Assert.Null(entry);
@@ -75,7 +79,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void ReadIndexWithBadParamsFails()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentNullException>(() => { IndexEntry entry = repo.Index[null]; });
                 Assert.Throws<ArgumentException>(() => { IndexEntry entry = repo.Index[string.Empty]; });
@@ -178,9 +183,10 @@ namespace LibGit2Sharp.Tests
             InvalidMoveUseCases(sourcePath, sourceStatus, destPaths);
         }
 
-        private static void InvalidMoveUseCases(string sourcePath, FileStatus sourceStatus, IEnumerable<string> destPaths)
+        private void InvalidMoveUseCases(string sourcePath, FileStatus sourceStatus, IEnumerable<string> destPaths)
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var repoPath = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(repoPath))
             {
                 Assert.Equal(sourceStatus, repo.RetrieveStatus(sourcePath));
 
@@ -224,7 +230,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanReadIndexEntryAttributes()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Assert.Equal(Mode.NonExecutableFile, repo.Index["README"].Mode);
                 Assert.Equal(Mode.ExecutableFile, repo.Index["1/branch_file.txt"].Mode);

--- a/LibGit2Sharp.Tests/IndexFixture.cs
+++ b/LibGit2Sharp.Tests/IndexFixture.cs
@@ -139,7 +139,7 @@ namespace LibGit2Sharp.Tests
         [InlineData("modified_unstaged_file.txt", FileStatus.Modified, "deleted_unstaged_file.txt", FileStatus.Missing, FileStatus.Removed, FileStatus.Staged)]
         public void CanMoveAnExistingFileOverANonExistingFile(string sourcePath, FileStatus sourceStatus, string destPath, FileStatus destStatus, FileStatus sourcePostStatus, FileStatus destPostStatus)
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 Assert.Equal(sourceStatus, repo.RetrieveStatus(sourcePath));
@@ -282,7 +282,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanResetFullyMergedIndexFromTree()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
 
             const string testFile = "new_tracked_file.txt";
 
@@ -313,7 +313,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanResetIndexWithUnmergedEntriesFromTree()
         {
-            string path = CloneMergedTestRepo();
+            string path = SandboxMergedTestRepo();
 
             const string testFile = "one.txt";
 
@@ -344,7 +344,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanClearTheIndex()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             const string testFile = "1.txt";
 
             // It is sufficient to check just one of the stage area changes, such as the modified file,

--- a/LibGit2Sharp.Tests/MergeFixture.cs
+++ b/LibGit2Sharp.Tests/MergeFixture.cs
@@ -24,7 +24,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void AFullyMergedRepoOnlyContainsStagedIndexEntries()
         {
-            using (var repo = new Repository(StandardTestRepoWorkingDirPath))
+            string path = SandboxStandardTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Equal(true, repo.Index.IsFullyMerged);
 
@@ -38,7 +39,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void SoftResetARepoWithUnmergedEntriesThrows()
         {
-            using (var repo = new Repository(MergedTestRepoWorkingDirPath))
+            var path = SandboxMergedTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Equal(false, repo.Index.IsFullyMerged);
 
@@ -52,7 +54,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CommitAgainARepoWithUnmergedEntriesThrows()
         {
-            using (var repo = new Repository(MergedTestRepoWorkingDirPath))
+            var path = SandboxMergedTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Equal(false, repo.Index.IsFullyMerged);
 

--- a/LibGit2Sharp.Tests/MergeFixture.cs
+++ b/LibGit2Sharp.Tests/MergeFixture.cs
@@ -65,7 +65,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanRetrieveTheBranchBeingMerged()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 const string firstBranch = "9fd738e8f7967c078dceed8190330fc8648ee56a";
@@ -86,7 +86,7 @@ namespace LibGit2Sharp.Tests
             const string secondBranchFileName = "second branch file.txt";
             const string sharedBranchFileName = "first+second branch file.txt";
 
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
 
             using (var repo = new Repository(path))
             {
@@ -136,7 +136,7 @@ namespace LibGit2Sharp.Tests
         {
             const string sharedBranchFileName = "first+second branch file.txt";
 
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 var firstBranch = repo.CreateBranch("FirstBranch");
@@ -163,7 +163,7 @@ namespace LibGit2Sharp.Tests
             const string firstBranchFileName = "first branch file.txt";
             const string sharedBranchFileName = "first+second branch file.txt";
 
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 // Reset the index and the working tree.
@@ -220,7 +220,7 @@ namespace LibGit2Sharp.Tests
             const string secondBranchFileName = "second branch file.txt";
             const string sharedBranchFileName = "first+second branch file.txt";
 
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 var firstBranch = repo.CreateBranch("FirstBranch");
@@ -260,7 +260,7 @@ namespace LibGit2Sharp.Tests
             const string secondBranchFileName = "second branch file.bin";
             const string sharedBranchFileName = "first+second branch file.bin";
 
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 var firstBranch = repo.CreateBranch("FirstBranch");
@@ -300,7 +300,7 @@ namespace LibGit2Sharp.Tests
         [InlineData(false, FastForwardStrategy.FastForwardOnly, fastForwardBranchInitialId, MergeStatus.FastForward)]
         public void CanFastForwardCommit(bool fromDetachedHead, FastForwardStrategy fastForwardStrategy, string expectedCommitId, MergeStatus expectedMergeStatus)
         {
-            string path = CloneMergeTestRepo();
+            string path = SandboxMergeTestRepo();
             using (var repo = new Repository(path))
             {
                 if(fromDetachedHead)
@@ -326,7 +326,7 @@ namespace LibGit2Sharp.Tests
         [InlineData(false, FastForwardStrategy.NoFastFoward, MergeStatus.NonFastForward)]
         public void CanNonFastForwardMergeCommit(bool fromDetachedHead, FastForwardStrategy fastForwardStrategy, MergeStatus expectedMergeStatus)
         {
-            string path = CloneMergeTestRepo();
+            string path = SandboxMergeTestRepo();
             using (var repo = new Repository(path))
             {
                 if (fromDetachedHead)
@@ -347,7 +347,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void MergeReportsCheckoutProgress()
         {
-            string repoPath = CloneMergeTestRepo();
+            string repoPath = SandboxMergeTestRepo();
             using (var repo = new Repository(repoPath))
             {
                 Commit commitToMerge = repo.Branches["normal_merge"].Tip;
@@ -368,7 +368,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void MergeReportsCheckoutNotifications()
         {
-            string repoPath = CloneMergeTestRepo();
+            string repoPath = SandboxMergeTestRepo();
             using (var repo = new Repository(repoPath))
             {
                 Commit commitToMerge = repo.Branches["normal_merge"].Tip;
@@ -392,7 +392,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void FastForwardMergeReportsCheckoutProgress()
         {
-            string repoPath = CloneMergeTestRepo();
+            string repoPath = SandboxMergeTestRepo();
             using (var repo = new Repository(repoPath))
             {
                 Commit commitToMerge = repo.Branches["fast_forward"].Tip;
@@ -413,7 +413,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void FastForwardMergeReportsCheckoutNotifications()
         {
-            string repoPath = CloneMergeTestRepo();
+            string repoPath = SandboxMergeTestRepo();
             using (var repo = new Repository(repoPath))
             {
                 Commit commitToMerge = repo.Branches["fast_forward"].Tip;
@@ -446,7 +446,7 @@ namespace LibGit2Sharp.Tests
             // but the merge will fail with conflicts if this
             // change is not detected as a rename.
 
-            string repoPath = CloneMergeTestRepo();
+            string repoPath = SandboxMergeTestRepo();
             using (var repo = new Repository(repoPath))
             {
                 Branch currentBranch = repo.Checkout("rename_source");
@@ -463,7 +463,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void FastForwardNonFastForwardableMergeThrows()
         {
-            string path = CloneMergeTestRepo();
+            string path = SandboxMergeTestRepo();
             using (var repo = new Repository(path))
             {
                 Commit commitToMerge = repo.Branches["normal_merge"].Tip;
@@ -474,7 +474,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanForceFastForwardMergeThroughConfig()
         {
-            string path = CloneMergeTestRepo();
+            string path = SandboxMergeTestRepo();
             using (var repo = new Repository(path))
             {
                 repo.Config.Set("merge.ff", "only");
@@ -487,7 +487,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanMergeAndNotCommit()
         {
-            string path = CloneMergeTestRepo();
+            string path = SandboxMergeTestRepo();
             using (var repo = new Repository(path))
             {
                 Commit commitToMerge = repo.Branches["normal_merge"].Tip;
@@ -508,7 +508,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanForceNonFastForwardMerge()
         {
-            string path = CloneMergeTestRepo();
+            string path = SandboxMergeTestRepo();
             using (var repo = new Repository(path))
             {
                 Commit commitToMerge = repo.Branches["fast_forward"].Tip;
@@ -524,7 +524,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanForceNonFastForwardMergeThroughConfig()
         {
-            string path = CloneMergeTestRepo();
+            string path = SandboxMergeTestRepo();
             using (var repo = new Repository(path))
             {
                 repo.Config.Set("merge.ff", "false");
@@ -542,7 +542,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void VerifyUpToDateMerge()
         {
-            string path = CloneMergeTestRepo();
+            string path = SandboxMergeTestRepo();
             using (var repo = new Repository(path))
             {
                 Commit commitToMerge = repo.Branches["master"].Tip;
@@ -562,7 +562,7 @@ namespace LibGit2Sharp.Tests
         [InlineData("fast_forward", FastForwardStrategy.Default, MergeStatus.FastForward)]
         public void CanMergeCommittish(string committish, FastForwardStrategy strategy, MergeStatus expectedMergeStatus)
         {
-            string path = CloneMergeTestRepo();
+            string path = SandboxMergeTestRepo();
             using (var repo = new Repository(path))
             {
                 MergeResult result = repo.Merge(committish, Constants.Signature, new MergeOptions() { FastForwardStrategy = strategy });
@@ -585,7 +585,7 @@ namespace LibGit2Sharp.Tests
             // due to merge conflicts.
             string committishToMerge = "fast_forward";
 
-            using (var repo = new Repository(CloneMergeTestRepo()))
+            using (var repo = new Repository(SandboxMergeTestRepo()))
             {
                 Touch(repo.Info.WorkingDirectory, "b.txt", "this is an alternate change");
 
@@ -606,7 +606,7 @@ namespace LibGit2Sharp.Tests
             const string conflictFile = "a.txt";
             const string conflictBranchName = "conflicts";
 
-            string path = CloneMergeTestRepo();
+            string path = SandboxMergeTestRepo();
             using (var repo = new Repository(path))
             {
                 Branch branch = repo.Branches[conflictBranchName];
@@ -657,7 +657,7 @@ namespace LibGit2Sharp.Tests
             const string conflictFile = "a.txt";
             const string conflictBranchName = "conflicts";
 
-            string path = CloneMergeTestRepo();
+            string path = SandboxMergeTestRepo();
             using (var repo = InitIsolatedRepository(path))
             {
                 Branch branch = repo.Branches[conflictBranchName];
@@ -709,7 +709,7 @@ namespace LibGit2Sharp.Tests
         [InlineData("fast_forward", FastForwardStrategy.Default, MergeStatus.FastForward)]
         public void CanMergeBranch(string branchName, FastForwardStrategy strategy, MergeStatus expectedMergeStatus)
         {
-            string path = CloneMergeTestRepo();
+            string path = SandboxMergeTestRepo();
             using (var repo = new Repository(path))
             {
                 Branch branch = repo. Branches[branchName];
@@ -723,7 +723,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanMergeIntoOrphanedBranch()
         {
-            string path = CloneMergeTestRepo();
+            string path = SandboxMergeTestRepo();
             using (var repo = new Repository(path))
             {
                 repo.Refs.Add("HEAD", "refs/heads/orphan", true);

--- a/LibGit2Sharp.Tests/MockingFixture.cs
+++ b/LibGit2Sharp.Tests/MockingFixture.cs
@@ -18,7 +18,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCountCommitsWithConcreteRepository()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var commitCounter = new CommitCounter(repo);
                 Assert.Equal(7, commitCounter.NumberOfCommits);

--- a/LibGit2Sharp.Tests/NoteFixture.cs
+++ b/LibGit2Sharp.Tests/NoteFixture.cs
@@ -15,7 +15,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void RetrievingNotesFromANonExistingGitObjectYieldsNoResult()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var notes = repo.Notes[ObjectId.Zero];
 
@@ -26,7 +27,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void RetrievingNotesFromAGitObjectWhichHasNoNoteYieldsNoResult()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var notes = repo.Notes[new ObjectId("4c062a6361ae6959e06292c1fa5e2822d9c96345")];
 
@@ -56,7 +58,8 @@ namespace LibGit2Sharp.Tests
         {
             var expectedMessages = new [] { "Just Note, don't you understand?\n", "Nope\n", "Not Nope, Note!\n" };
 
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var notes = repo.Notes[new ObjectId("4a202b346bb0fb0db7eff3cffeb3c70babbd2045")];
 
@@ -68,7 +71,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanRetrieveASpecificNoteFromAKnownNamespace()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var singleNote = repo.Notes["answer", new ObjectId("4a202b346bb0fb0db7eff3cffeb3c70babbd2045")];
                 Assert.Equal("Nope\n", singleNote.Message);
@@ -80,7 +84,8 @@ namespace LibGit2Sharp.Tests
         {
             var expectedNamespaces = new[] { "answer", "answer2", "commits", };
 
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Equal(expectedNamespaces,
                              repo.Notes.Namespaces.OrderBy(n => n, StringComparer.Ordinal).ToArray());
@@ -288,7 +293,8 @@ namespace LibGit2Sharp.Tests
                 new { Blob = "1a550e416326cdb4a8e127a04dd69d7a01b11cf4", Target = "4a202b346bb0fb0db7eff3cffeb3c70babbd2045" },
             };
 
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Equal(expectedNotes,
                              SortedNotes(repo.Notes["commits"], n => new { Blob = n.BlobId.Sha, Target = n.TargetObjectId.Sha }));

--- a/LibGit2Sharp.Tests/NoteFixture.cs
+++ b/LibGit2Sharp.Tests/NoteFixture.cs
@@ -110,7 +110,7 @@ namespace LibGit2Sharp.Tests
         {
             var expectedNamespaces = new[] { "Just Note, don't you understand?\n", "Nope\n", "Not Nope, Note!\n" };
 
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 var commit = repo.Lookup<Commit>("4a202b346bb0fb0db7eff3cffeb3c70babbd2045");
@@ -127,7 +127,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanAddANoteOnAGitObject()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 var commit = repo.Lookup<Commit>("9fd738e8f7967c078dceed8190330fc8648ee56a");
@@ -144,7 +144,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CreatingANoteWhichAlreadyExistsOverwritesThePreviousNote()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 var commit = repo.Lookup<Commit>("5b5b025afb0b4c913b4c338a42934a3863bf3644");
@@ -165,7 +165,7 @@ namespace LibGit2Sharp.Tests
         {
             string configPath = CreateConfigurationWithDummyUser(Constants.Signature);
             var options = new RepositoryOptions { GlobalConfigurationLocation = configPath };
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
 
             using (var repo = new Repository(path, options))
             {
@@ -185,7 +185,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCompareTwoUniqueNotes()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 var commit = repo.Lookup<Commit>("9fd738e8f7967c078dceed8190330fc8648ee56a");
@@ -220,7 +220,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanRemoveANoteFromAGitObject()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 var commit = repo.Lookup<Commit>("8496071c1b46c854b31185ea97743be6a8774479");
@@ -248,7 +248,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void RemovingANonExistingNoteDoesntThrow()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 var commit = repo.Lookup<Commit>("5b5b025afb0b4c913b4c338a42934a3863bf3644");
@@ -262,7 +262,7 @@ namespace LibGit2Sharp.Tests
         {
             string configPath = CreateConfigurationWithDummyUser(Constants.Signature);
             RepositoryOptions options = new RepositoryOptions() { GlobalConfigurationLocation = configPath };
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
 
             using (var repo = new Repository(path, options))
             {

--- a/LibGit2Sharp.Tests/ObjectDatabaseFixture.cs
+++ b/LibGit2Sharp.Tests/ObjectDatabaseFixture.cs
@@ -202,7 +202,7 @@ namespace LibGit2Sharp.Tests
         [InlineData("1")]
         public void CanCreateATreeByAlteringAnExistingOne(string targetPath)
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 var blob = repo.Lookup<Blob>(new ObjectId("a8233120f6ad708f843d861ce2b7228ec4e3dec6"));
@@ -218,7 +218,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCreateATreeByRemovingEntriesFromExistingOne()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 TreeDefinition td = TreeDefinition.From(repo.Head.Tip.Tree)
@@ -239,7 +239,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void RemovingANonExistingEntryFromATreeDefinitionHasNoSideEffect()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 Tree head = repo.Head.Tip.Tree;
@@ -275,7 +275,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanReplaceAnExistingTreeWithAnotherPersitedTree()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 TreeDefinition td = TreeDefinition.From(repo.Head.Tip.Tree);
@@ -296,7 +296,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCreateATreeContainingABlobFromAFileInTheWorkingDirectory()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 Assert.Equal(FileStatus.Nonexistent, repo.RetrieveStatus("hello.txt"));
@@ -328,7 +328,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCreateATreeContainingAGitLinkFromAnUntrackedSubmoduleInTheWorkingDirectory()
         {
-            string path = CloneSubmoduleTestRepo();
+            string path = SandboxSubmoduleTestRepo();
             using (var repo = new Repository(path))
             {
                 const string submodulePath = "sm_added_and_uncommited";
@@ -394,7 +394,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCreateATreeFromIndex()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
 
             using (var repo = new Repository(path))
             {
@@ -416,7 +416,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCreateACommit()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 Branch head = repo.Head;
@@ -456,7 +456,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCreateATagAnnotationPointingToAGitObject()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 var blob = repo.Head.Tip["README"].Target as Blob;
@@ -549,7 +549,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCreateATagAnnotationWithAnEmptyMessage()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 var tagAnnotation = repo.ObjectDatabase.CreateTagAnnotation(
@@ -621,7 +621,7 @@ namespace LibGit2Sharp.Tests
              * dea509d097ce692e167dfc6a48a7a280cc5e877e
              */
 
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 repo.Config.Set("core.abbrev", 4);

--- a/LibGit2Sharp.Tests/ObjectDatabaseFixture.cs
+++ b/LibGit2Sharp.Tests/ObjectDatabaseFixture.cs
@@ -17,7 +17,8 @@ namespace LibGit2Sharp.Tests
         [InlineData("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", false)]
         public void CanTellIfObjectsExists(string sha, bool shouldExists)
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var oid = new ObjectId(sha);
 
@@ -370,7 +371,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CannotCreateATreeContainingABlobFromARelativePathAgainstABareRepository()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var td = new TreeDefinition()
                     .Add("1/new file", "hello.txt", Mode.NonExecutableFile);
@@ -382,7 +384,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CreatingATreeFromIndexWithUnmergedEntriesThrows()
         {
-            using (var repo = new Repository(MergedTestRepoWorkingDirPath))
+            var path = SandboxMergedTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.False(repo.Index.IsFullyMerged);
 
@@ -482,7 +485,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanEnumerateTheGitObjectsFromBareRepository()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 int count = 0;
 
@@ -504,7 +508,8 @@ namespace LibGit2Sharp.Tests
         [InlineData("\0\0\0")]
         public void CreatingACommitWithMessageContainingZeroByteThrows(string message)
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentException>(() => repo.ObjectDatabase.CreateCommit(
                     Constants.Signature, Constants.Signature, message, repo.Head.Tip.Tree, Enumerable.Empty<Commit>(), false));
@@ -519,7 +524,8 @@ namespace LibGit2Sharp.Tests
         [InlineData("\0\0\0")]
         public void CreatingATagAnnotationWithNameOrMessageContainingZeroByteThrows(string input)
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentException>(() => repo.ObjectDatabase.CreateTagAnnotation(
                     input, repo.Head.Tip, Constants.Signature, "message"));
@@ -531,7 +537,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CreatingATagAnnotationWithBadParametersThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentNullException>(() => repo.ObjectDatabase.CreateTagAnnotation(
                     null, repo.Head.Tip, Constants.Signature, "message"));
@@ -566,7 +573,8 @@ namespace LibGit2Sharp.Tests
             string sinceSha, string untilSha,
             string expectedAncestorSha, int? expectedAheadBy, int? expectedBehindBy)
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var since = repo.Lookup<Commit>(sinceSha);
                 var until = repo.Lookup<Commit>(untilSha);
@@ -585,7 +593,8 @@ namespace LibGit2Sharp.Tests
             string sinceSha, string untilSha,
             int? expectedAheadBy, int? expectedBehindBy)
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var since = repo.Lookup<Commit>(sinceSha);
                 var until = repo.Lookup<Commit>(untilSha);
@@ -601,7 +610,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CalculatingHistoryDivergenceWithBadParamsThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentNullException>(
                     () => repo.ObjectDatabase.CalculateHistoryDivergence(repo.Head.Tip, null));

--- a/LibGit2Sharp.Tests/OdbBackendFixture.cs
+++ b/LibGit2Sharp.Tests/OdbBackendFixture.cs
@@ -188,7 +188,7 @@ namespace LibGit2Sharp.Tests
              * dea509d097ce692e167dfc6a48a7a280cc5e877e
              */
 
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 repo.ObjectDatabase.AddBackend(new MockOdbBackend(), 5);

--- a/LibGit2Sharp.Tests/PatchStatsFixture.cs
+++ b/LibGit2Sharp.Tests/PatchStatsFixture.cs
@@ -8,7 +8,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanExtractStatisticsFromDiff()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 var oldTree = repo.Lookup<Commit>("origin/packed-test").Tree;
                 var newTree = repo.Lookup<Commit>("HEAD").Tree;

--- a/LibGit2Sharp.Tests/PushFixture.cs
+++ b/LibGit2Sharp.Tests/PushFixture.cs
@@ -17,7 +17,7 @@ namespace LibGit2Sharp.Tests
         {
             var scd = BuildSelfCleaningDirectory();
 
-            string originalRepoPath = CloneBareTestRepo();
+            string originalRepoPath = SandboxBareTestRepo();
             string clonedRepoPath = Repository.Clone(originalRepoPath, scd.DirectoryPath);
 
             using (var originalRepo = new Repository(originalRepoPath))

--- a/LibGit2Sharp.Tests/PushFixture.cs
+++ b/LibGit2Sharp.Tests/PushFixture.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Linq;
 using LibGit2Sharp.Tests.TestHelpers;
 using Xunit;
@@ -159,7 +160,7 @@ namespace LibGit2Sharp.Tests
         private Commit AddCommitToRepo(IRepository repository)
         {
 
-            string random = Guid.NewGuid().ToString();
+            string random = Path.GetRandomFileName();
             string filename = random + ".txt";
 
             Touch(repository.Info.WorkingDirectory, filename, random);

--- a/LibGit2Sharp.Tests/RefSpecFixture.cs
+++ b/LibGit2Sharp.Tests/RefSpecFixture.cs
@@ -11,7 +11,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCountRefSpecs()
         {
-            var path = CloneStandardTestRepo();
+            var path = SandboxStandardTestRepo();
             using (var repo = InitIsolatedRepository(path))
             {
                 var remote = repo.Network.Remotes["origin"];
@@ -22,7 +22,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanIterateOverRefSpecs()
         {
-            var path = CloneStandardTestRepo();
+            var path = SandboxStandardTestRepo();
             using (var repo = InitIsolatedRepository(path))
             {
                 var remote = repo.Network.Remotes["origin"];
@@ -39,7 +39,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void FetchAndPushRefSpecsComposeRefSpecs()
         {
-            var path = CloneStandardTestRepo();
+            var path = SandboxStandardTestRepo();
             using (var repo = InitIsolatedRepository(path))
             {
                 var remote = repo.Network.Remotes["origin"];
@@ -53,7 +53,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanReadRefSpecDetails()
         {
-            var path = CloneStandardTestRepo();
+            var path = SandboxStandardTestRepo();
             using (var repo = InitIsolatedRepository(path))
             {
                 var remote = repo.Network.Remotes["origin"];
@@ -73,7 +73,7 @@ namespace LibGit2Sharp.Tests
         [InlineData(new string[0], new string[] { "refs/ghi:refs/jkl/mno" })]
         public void CanReplaceRefSpecs(string[] newFetchRefSpecs, string[] newPushRefSpecs)
         {
-            var path = CloneStandardTestRepo();
+            var path = SandboxStandardTestRepo();
             using (var repo = InitIsolatedRepository(path))
             {
                 var remote = repo.Network.Remotes["origin"];
@@ -103,7 +103,7 @@ namespace LibGit2Sharp.Tests
         {
             var fetchRefSpecs = new string[] { "refs/their/heads/*:refs/my/heads/*", "+refs/their/tag:refs/my/tag" };
 
-            var path = CloneStandardTestRepo();
+            var path = SandboxStandardTestRepo();
             using (var repo = InitIsolatedRepository(path))
             {
                 var remote = repo.Network.Remotes["origin"];
@@ -126,7 +126,7 @@ namespace LibGit2Sharp.Tests
         {
             string newRefSpec = "+refs/heads/test:refs/heads/other-test";
 
-            var path = CloneStandardTestRepo();
+            var path = SandboxStandardTestRepo();
             using (var repo = InitIsolatedRepository(path))
             {
                 var remote = repo.Network.Remotes["origin"];
@@ -150,7 +150,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanClearRefSpecs()
         {
-            var path = CloneStandardTestRepo();
+            var path = SandboxStandardTestRepo();
             using (var repo = InitIsolatedRepository(path))
             {
                 var remote = repo.Network.Remotes["origin"];
@@ -178,7 +178,7 @@ namespace LibGit2Sharp.Tests
         [InlineData("refs/ whitespace:refs/test")]
         public void SettingInvalidRefSpecsThrows(string refSpec)
         {
-            var path = CloneStandardTestRepo();
+            var path = SandboxStandardTestRepo();
             using (var repo = InitIsolatedRepository(path))
             {
                 var remote = repo.Network.Remotes["origin"];

--- a/LibGit2Sharp.Tests/ReferenceFixture.cs
+++ b/LibGit2Sharp.Tests/ReferenceFixture.cs
@@ -21,7 +21,7 @@ namespace LibGit2Sharp.Tests
         {
             const string name = "refs/heads/unit_test";
 
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 EnableRefLog(repo);
@@ -46,7 +46,7 @@ namespace LibGit2Sharp.Tests
             const string name = "refs/heads/extendedShaSyntaxRulz";
             const string logMessage = "Create new ref";
 
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 EnableRefLog(repo);
@@ -70,7 +70,7 @@ namespace LibGit2Sharp.Tests
         {
             const string name = "refs/heads/extendedShaSyntaxRulz";
 
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 Assert.Throws<LibGit2SharpException>(() => repo.Refs.Add(name, "master^42"));
@@ -83,7 +83,7 @@ namespace LibGit2Sharp.Tests
             const string name = "refs/heads/unit_test";
             const string target = "refs/heads/master";
 
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 var newRef = (SymbolicReference)repo.Refs.Add(name, target);
@@ -99,7 +99,7 @@ namespace LibGit2Sharp.Tests
             const string target = "refs/heads/master";
             const string logMessage = "unit_test reference init";
 
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 EnableRefLog(repo);
@@ -126,7 +126,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void BlindlyCreatingADirectReferenceOverAnExistingOneThrows()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 Assert.Throws<NameConflictException>(() => repo.Refs.Add("refs/heads/master", "be3563ae3f795b2b4353bcce3a527ad0a4f7f644"));
@@ -136,7 +136,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void BlindlyCreatingASymbolicReferenceOverAnExistingOneThrows()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 Assert.Throws<NameConflictException>(() => repo.Refs.Add("HEAD", "refs/heads/br2"));
@@ -150,7 +150,7 @@ namespace LibGit2Sharp.Tests
             const string target = "4c062a6361ae6959e06292c1fa5e2822d9c96345";
             const string logMessage = "Create new ref";
 
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 EnableRefLog(repo);
@@ -177,7 +177,7 @@ namespace LibGit2Sharp.Tests
             const string target = "refs/heads/br2";
             const string logMessage = "Create new ref";
 
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 EnableRefLog(repo);
@@ -237,7 +237,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanRemoveAReference()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 repo.Refs.Remove("refs/heads/packed");
@@ -247,7 +247,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanRemoveANonExistingReference()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 const string unknown = "refs/heads/dahlbyk/has/hawkeyes";
@@ -261,7 +261,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void ARemovedReferenceCannotBeLookedUp()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 const string refName = "refs/heads/test";
@@ -274,7 +274,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void RemovingAReferenceDecreasesTheRefsCount()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 const string refName = "refs/heads/test";
@@ -313,7 +313,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanListAllReferencesEvenCorruptedOnes()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 CreateCorruptedDeadBeefHead(repo.Info.Path);
@@ -409,7 +409,7 @@ namespace LibGit2Sharp.Tests
         public void CanUpdateTargetOfADirectReference()
         {
             const string masterRef = "refs/heads/master";
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 string sha = repo.Refs["refs/heads/test"].ResolveToDirectReference().Target.Sha;
@@ -429,7 +429,7 @@ namespace LibGit2Sharp.Tests
         public void CanUpdateTargetOfADirectReferenceWithAnAbbreviatedSha()
         {
             const string masterRef = "refs/heads/master";
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 string sha = repo.Refs["refs/heads/test"].ResolveToDirectReference().Target.Sha;
@@ -449,7 +449,7 @@ namespace LibGit2Sharp.Tests
         public void CanUpdateTargetOfASymbolicReference()
         {
             const string name = "refs/heads/unit_test";
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 var newRef = (SymbolicReference)repo.Refs.Add(name, "refs/heads/master");
@@ -467,7 +467,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanUpdateHeadWithARevparseSpec()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 Branch test = repo.Branches["test"];
@@ -485,7 +485,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanUpdateHeadWithEitherAnObjectIdOrAReference()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 EnableRefLog(repo);
@@ -522,7 +522,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanUpdateTargetOfADirectReferenceWithARevparseSpec()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 EnableRefLog(repo);
@@ -553,7 +553,7 @@ namespace LibGit2Sharp.Tests
         public void UpdatingADirectRefWithSymbolFails()
         {
             const string name = "refs/heads/unit_test";
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 var newRef = (SymbolicReference)repo.Refs.Add(name, "refs/heads/master");
@@ -570,7 +570,7 @@ namespace LibGit2Sharp.Tests
         public void CanUpdateTargetOfADirectReferenceWithAShortReferenceNameAsARevparseSpec()
         {
             const string masterRef = "refs/heads/master";
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 Reference updatedMaster = repo.Refs.UpdateTarget(masterRef, "heads/test");
@@ -603,7 +603,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanRenameAReferenceToADeeperReferenceHierarchy()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 const string newName = "refs/tags/test/deep";
@@ -617,7 +617,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanRenameAReferenceToAUpperReferenceHierarchy()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 const string newName = "refs/heads/o/sole";
@@ -633,7 +633,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanRenameAReferenceToADifferentReferenceHierarchy()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 const string oldName = "refs/tags/test";
@@ -665,7 +665,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanRenameAndOverWriteAExistingReference()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 const string oldName = "refs/heads/packed";
@@ -690,7 +690,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void RenamingAReferenceDoesNotDecreaseTheRefsCount()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 const string oldName = "refs/tags/test";
@@ -712,7 +712,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanLookupARenamedReference()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 const string oldName = "refs/tags/test";
@@ -759,7 +759,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanUpdateTheTargetOfASymbolicReferenceWithAnotherSymbolicReference()
         {
-            string repoPath = CloneBareTestRepo();
+            string repoPath = SandboxBareTestRepo();
 
             using (var repo = new Repository(repoPath))
             {

--- a/LibGit2Sharp.Tests/ReferenceFixture.cs
+++ b/LibGit2Sharp.Tests/ReferenceFixture.cs
@@ -200,7 +200,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void AddWithEmptyStringForTargetThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentException>(() => repo.Refs.Add("refs/heads/newref", string.Empty));
             }
@@ -209,7 +210,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void AddWithEmptyStringThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentException>(() => repo.Refs.Add(string.Empty, "refs/heads/master"));
             }
@@ -218,7 +220,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void AddWithNullForTargetThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentNullException>(() => repo.Refs.Add("refs/heads/newref", (string)null));
                 Assert.Throws<ArgumentNullException>(() => repo.Refs.Add("refs/heads/newref", (ObjectId)null));
@@ -228,7 +231,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void AddWithNullStringThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentNullException>(() => repo.Refs.Add(null, "refs/heads/master"));
             }
@@ -294,7 +298,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void RemoveWithEmptyNameThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentException>(() => repo.Refs.Remove(string.Empty));
             }
@@ -303,7 +308,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void RemoveWithNullNameThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentNullException>(() => repo.Refs.Remove((string)null));
                 Assert.Throws<ArgumentNullException>(() => repo.Refs.Remove((Reference)null));
@@ -327,7 +333,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanResolveHeadByName()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var head = (SymbolicReference)repo.Refs.Head;
                 Assert.NotNull(head);
@@ -348,7 +355,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanResolveReferenceToALightweightTag()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var lwTag = (DirectReference)repo.Refs["refs/tags/lw"];
                 Assert.NotNull(lwTag);
@@ -362,7 +370,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanResolveReferenceToAnAnnotatedTag()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var annTag = (DirectReference)repo.Refs["refs/tags/test"];
                 Assert.NotNull(annTag);
@@ -376,7 +385,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanResolveRefsByName()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var master = (DirectReference)repo.Refs["refs/heads/master"];
                 Assert.NotNull(master);
@@ -390,7 +400,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void ResolvingWithEmptyStringThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentException>(() => { Reference head = repo.Refs[string.Empty]; });
             }
@@ -399,7 +410,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void ResolvingWithNullThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentNullException>(() => { Reference head = repo.Refs[null]; });
             }
@@ -581,7 +593,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void UpdatingAReferenceTargetWithBadParametersFails()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentException>(() => repo.Refs.UpdateTarget(string.Empty, "refs/heads/packed"));
                 Assert.Throws<ArgumentException>(() => repo.Refs.UpdateTarget("refs/heads/master", string.Empty));
@@ -594,7 +607,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void UpdatingADirectReferenceTargetWithARevparsePointingAtAnUnknownObjectFails()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<LibGit2SharpException>(() => repo.Refs.UpdateTarget(repo.Refs["refs/heads/master"], "refs/heads/nope"));
             }
@@ -656,7 +670,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void RenamingANonExistingReferenceThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<LibGit2SharpException>(() => repo.Refs.Rename("refs/tags/i-am-void", "refs/atic/tagtest"));
             }
@@ -681,7 +696,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void BlindlyOverwritingAExistingReferenceThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<NameConflictException>(() => repo.Refs.Rename("refs/heads/packed", "refs/heads/br2"));
             }
@@ -728,7 +744,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanFilterReferencesWithAGlob()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Equal(13, repo.Refs.FromGlob("*").Count());
                 Assert.Equal(5, repo.Refs.FromGlob("refs/heads/*").Count());
@@ -750,17 +767,13 @@ namespace LibGit2Sharp.Tests
         [InlineData("/", false)]
         public void CanTellIfAReferenceIsValid(string refname, bool expectedResult)
         {
-            using (var repo = new Repository(BareTestRepoPath))
-            {
-                Assert.Equal(expectedResult, Reference.IsValidName(refname));
-            }
+            Assert.Equal(expectedResult, Reference.IsValidName(refname));
         }
 
         [Fact]
         public void CanUpdateTheTargetOfASymbolicReferenceWithAnotherSymbolicReference()
         {
             string repoPath = SandboxBareTestRepo();
-
             using (var repo = new Repository(repoPath))
             {
                 Reference symbolicRef = repo.Refs.Add("refs/heads/unit_test", "refs/heads/master");
@@ -775,7 +788,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void LookingForLowerCaseHeadThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<InvalidSpecificationException>(() => repo.Refs["head"]);
             }
@@ -789,14 +803,16 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanIdentifyReferenceKind()
         {
-            using (var repo = new Repository(StandardTestRepoWorkingDirPath))
+            string path = SandboxStandardTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.True(repo.Refs["refs/heads/master"].IsLocalBranch());
                 Assert.True(repo.Refs["refs/remotes/origin/master"].IsRemoteTrackingBranch());
                 Assert.True(repo.Refs["refs/tags/lw"].IsTag());
             }
 
-            using (var repo = new Repository(BareTestRepoPath))
+            path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.True(repo.Refs["refs/notes/commits"].IsNote());
             }
@@ -805,7 +821,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanQueryReachability()
         {
-            using (var repo = new Repository(StandardTestRepoWorkingDirPath))
+            string path = SandboxStandardTestRepo();
+            using (var repo = new Repository(path))
             {
                 var result = repo.Refs.ReachableFrom(
                     new[] { repo.Lookup<Commit>("f8d44d7"), repo.Lookup<Commit>("6dcf9bf") });
@@ -827,7 +844,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanQueryReachabilityAmongASubsetOfreferences()
         {
-            using (var repo = new Repository(StandardTestRepoWorkingDirPath))
+            string path = SandboxStandardTestRepo();
+            using (var repo = new Repository(path))
             {
                 var result = repo.Refs.ReachableFrom(
                     repo.Refs.Where(r => r.IsTag()),
@@ -847,7 +865,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanHandleInvalidArguments()
         {
-            using (var repo = new Repository(StandardTestRepoWorkingDirPath))
+            string path = SandboxStandardTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentNullException>(() => repo.Refs.ReachableFrom(null));
                 Assert.Throws<ArgumentNullException>(() => repo.Refs.ReachableFrom(null, repo.Commits.Take(2)));

--- a/LibGit2Sharp.Tests/ReflogFixture.cs
+++ b/LibGit2Sharp.Tests/ReflogFixture.cs
@@ -112,7 +112,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CommitOnDetachedHeadShouldInsertReflogEntry()
         {
-            string repoPath = CloneStandardTestRepo();
+            string repoPath = SandboxStandardTestRepo();
 
             using (var repo = new Repository(repoPath))
             {

--- a/LibGit2Sharp.Tests/ReflogFixture.cs
+++ b/LibGit2Sharp.Tests/ReflogFixture.cs
@@ -13,8 +13,8 @@ namespace LibGit2Sharp.Tests
         {
             const int expectedReflogEntriesCount = 3;
 
-
-            using (var repo = new Repository(StandardTestRepoWorkingDirPath))
+            string path = SandboxStandardTestRepo();
+            using (var repo = new Repository(path))
             {
                 var reflog = repo.Refs.Log(repo.Refs.Head);
 
@@ -34,7 +34,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void ReflogOfUnbornReferenceIsEmpty()
         {
-            using (var repo = new Repository(StandardTestRepoWorkingDirPath))
+            string path = SandboxStandardTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Empty(repo.Refs.Log("refs/heads/toto"));
             }
@@ -43,7 +44,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void ReadingReflogOfInvalidReferenceNameThrows()
         {
-            using (var repo = new Repository(StandardTestRepoWorkingDirPath))
+            string path = SandboxStandardTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<InvalidSpecificationException>(() => repo.Refs.Log("toto").Count());
             }

--- a/LibGit2Sharp.Tests/RemoteFixture.cs
+++ b/LibGit2Sharp.Tests/RemoteFixture.cs
@@ -10,7 +10,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanGetRemoteOrigin()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Remote origin = repo.Network.Remotes["origin"];
                 Assert.NotNull(origin);
@@ -23,7 +24,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void GettingRemoteThatDoesntExistReturnsNull()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Assert.Null(repo.Network.Remotes["test"]);
             }
@@ -32,7 +34,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanEnumerateTheRemotes()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 int count = 0;
 
@@ -160,7 +163,8 @@ namespace LibGit2Sharp.Tests
         [InlineData("/")]
         public void AddingARemoteWithAnInvalidNameThrows(string name)
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 const string url = "https://github.com/libgit2/libgit2sharp.git";
 
@@ -180,7 +184,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void DoesNotThrowWhenARemoteHasNoUrlSet()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 var noUrlRemote = repo.Network.Remotes["no_url"];
                 Assert.NotNull(noUrlRemote);
@@ -231,7 +236,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanDeleteNonExistingRemote()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Assert.Null(repo.Network.Remotes["i_dont_exist"]);
                 repo.Network.Remotes.Remove("i_dont_exist");
@@ -261,7 +267,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void RenamingNonExistingRemoteThrows()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<NotFoundException>(() =>
                 {

--- a/LibGit2Sharp.Tests/RemoteFixture.cs
+++ b/LibGit2Sharp.Tests/RemoteFixture.cs
@@ -53,7 +53,7 @@ namespace LibGit2Sharp.Tests
         [InlineData(TagFetchMode.None)]
         public void CanSetTagFetchMode(TagFetchMode tagFetchMode)
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 const string name = "upstream";
@@ -73,7 +73,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanSetRemoteUrl()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 const string name = "upstream";
@@ -94,7 +94,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCheckEqualityOfRemote()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 Remote oneOrigin = repo.Network.Remotes["origin"];
@@ -116,7 +116,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CreatingANewRemoteAddsADefaultRefSpec()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 const string name = "upstream";
@@ -139,7 +139,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanAddANewRemoteWithAFetchRefSpec()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 const string name = "pull-requests";
@@ -194,7 +194,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CreatingARemoteAddsADefaultFetchRefSpec()
         {
-            var path = CloneStandardTestRepo();
+            var path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 var remote = repo.Network.Remotes.Add("one", "http://github.com/up/stream");
@@ -205,7 +205,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCreateARemoteWithASpecifiedFetchRefSpec()
         {
-            var path = CloneStandardTestRepo();
+            var path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 var remote = repo.Network.Remotes.Add("two", "http://github.com/up/stream", "+refs/heads/*:refs/remotes/grmpf/*");
@@ -216,7 +216,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanDeleteExistingRemote()
         {
-            var path = CloneStandardTestRepo();
+            var path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 Assert.NotNull(repo.Network.Remotes["origin"]);
@@ -241,7 +241,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanRenameExistingRemote()
         {
-            var path = CloneStandardTestRepo();
+            var path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 Assert.NotNull(repo.Network.Remotes["origin"]);
@@ -273,7 +273,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void ReportsRemotesWithNonDefaultRefSpecs()
         {
-            var path = CloneStandardTestRepo();
+            var path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 Assert.NotNull(repo.Network.Remotes["origin"]);
@@ -295,7 +295,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void DoesNotReportRemotesWithAlreadyExistingRefSpec()
         {
-            var path = CloneStandardTestRepo();
+            var path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 Assert.NotNull(repo.Network.Remotes["origin"]);
@@ -318,7 +318,7 @@ namespace LibGit2Sharp.Tests
             const string name = "upstream";
             const string url = "https://github.com/libgit2/libgit2sharp.git";
 
-            var path = CloneStandardTestRepo();
+            var path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 Assert.NotNull(repo.Network.Remotes["origin"]);

--- a/LibGit2Sharp.Tests/RemoveFixture.cs
+++ b/LibGit2Sharp.Tests/RemoveFixture.cs
@@ -142,7 +142,8 @@ namespace LibGit2Sharp.Tests
         {
             for (int i = 0; i < 2; i++)
             {
-                using (var repo = new Repository(StandardTestRepoPath))
+                var path = SandboxStandardTestRepoGitDir();
+                using (var repo = new Repository(path))
                 {
                     Assert.Null(repo.Index[relativePath]);
                     Assert.Equal(status, repo.RetrieveStatus(relativePath));
@@ -161,7 +162,8 @@ namespace LibGit2Sharp.Tests
         {
             for (int i = 0; i < 2; i++)
             {
-                using (var repo = new Repository(StandardTestRepoPath))
+                var path = SandboxStandardTestRepoGitDir();
+                using (var repo = new Repository(path))
                 {
                     Assert.Null(repo.Index[relativePath]);
                     Assert.Equal(status, repo.RetrieveStatus(relativePath));
@@ -175,7 +177,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void RemovingFileWithBadParamsThrows()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentException>(() => repo.Remove(string.Empty));
                 Assert.Throws<ArgumentNullException>(() => repo.Remove((string)null));

--- a/LibGit2Sharp.Tests/RemoveFixture.cs
+++ b/LibGit2Sharp.Tests/RemoveFixture.cs
@@ -47,7 +47,7 @@ namespace LibGit2Sharp.Tests
         public void CanRemoveAnUnalteredFileFromTheIndexWithoutRemovingItFromTheWorkingDirectory(
             bool removeFromWorkdir, string filename, bool throws, FileStatus initialStatus, bool existsBeforeRemove, bool existsAfterRemove, FileStatus lastStatus)
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 int count = repo.Index.Count;
@@ -83,7 +83,7 @@ namespace LibGit2Sharp.Tests
         {
             const string filename = "modified_staged_file.txt";
 
-            var path = CloneStandardTestRepo();
+            var path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 string fullpath = Path.Combine(repo.Info.WorkingDirectory, filename);
@@ -101,7 +101,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanRemoveAFolderThroughUsageOfPathspecsForNewlyAddedFiles()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 repo.Stage(Touch(repo.Info.WorkingDirectory, "2/subdir1/2.txt", "whone"));
@@ -122,7 +122,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanRemoveAFolderThroughUsageOfPathspecsForFilesAlreadyInTheIndexAndInTheHEAD()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 int count = repo.Index.Count;

--- a/LibGit2Sharp.Tests/RepositoryFixture.cs
+++ b/LibGit2Sharp.Tests/RepositoryFixture.cs
@@ -543,14 +543,11 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void DiscoverReturnsNullWhenNoRepoCanBeFound()
         {
-            string path = Path.GetTempFileName();
-            string suffix = "." + Guid.NewGuid().ToString().Substring(0, 7);
+            string path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
-            SelfCleaningDirectory scd = BuildSelfCleaningDirectory(path + suffix);
+            SelfCleaningDirectory scd = BuildSelfCleaningDirectory(path);
             Directory.CreateDirectory(scd.RootedDirectoryPath);
             Assert.Null(Repository.Discover(scd.RootedDirectoryPath));
-
-            File.Delete(path);
         }
 
         [Fact]

--- a/LibGit2Sharp.Tests/RepositoryFixture.cs
+++ b/LibGit2Sharp.Tests/RepositoryFixture.cs
@@ -37,7 +37,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void AccessingTheIndexInABareRepoThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<BareRepositoryException>(() => repo.Index);
             }
@@ -257,7 +258,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanOpenBareRepositoryThroughAFullPathToTheGitDir()
         {
-            string path = Path.GetFullPath(BareTestRepoPath);
+            string relPath = SandboxBareTestRepo();
+            string path = Path.GetFullPath(relPath);
             using (var repo = new Repository(path))
             {
                 Assert.NotNull(repo);
@@ -268,7 +270,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanOpenStandardRepositoryThroughAWorkingDirPath()
         {
-            using (var repo = new Repository(StandardTestRepoWorkingDirPath))
+            string path = SandboxStandardTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.NotNull(repo);
                 Assert.NotNull(repo.Info.WorkingDirectory);
@@ -278,7 +281,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void OpeningStandardRepositoryThroughTheGitDirGuessesTheWorkingDirPath()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Assert.NotNull(repo);
                 Assert.NotNull(repo.Info.WorkingDirectory);
@@ -288,7 +292,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanOpenRepository()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.NotNull(repo.Info.Path);
                 Assert.Null(repo.Info.WorkingDirectory);
@@ -313,7 +318,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanLookupACommitByTheNameOfABranch()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 GitObject gitObject = repo.Lookup("refs/heads/master");
                 Assert.NotNull(gitObject);
@@ -324,7 +330,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanLookupACommitByTheNameOfALightweightTag()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 GitObject gitObject = repo.Lookup("refs/tags/lw");
                 Assert.NotNull(gitObject);
@@ -335,7 +342,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanLookupATagAnnotationByTheNameOfAnAnnotatedTag()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 GitObject gitObject = repo.Lookup("refs/tags/e90810b");
                 Assert.NotNull(gitObject);
@@ -346,7 +354,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanLookupObjects()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.NotNull(repo.Lookup(commitSha));
                 Assert.NotNull(repo.Lookup<Commit>(commitSha));
@@ -357,7 +366,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanLookupSameObjectTwiceAndTheyAreEqual()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 GitObject commit = repo.Lookup(commitSha);
                 GitObject commit2 = repo.Lookup(commitSha);
@@ -369,7 +379,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void LookupObjectByWrongShaReturnsNull()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Null(repo.Lookup(Constants.UnknownSha));
                 Assert.Null(repo.Lookup<GitObject>(Constants.UnknownSha));
@@ -379,7 +390,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void LookupObjectByWrongTypeReturnsNull()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.NotNull(repo.Lookup(commitSha));
                 Assert.NotNull(repo.Lookup<Commit>(commitSha));
@@ -390,7 +402,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void LookupObjectByUnknownReferenceNameReturnsNull()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Null(repo.Lookup("refs/heads/chopped/off"));
                 Assert.Null(repo.Lookup<GitObject>(Constants.UnknownSha));
@@ -427,7 +440,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanLookupUsingRevparseSyntax()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Null(repo.Lookup<Tree>("master^"));
 
@@ -444,7 +458,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanResolveAmbiguousRevparseSpecs()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var o1 = repo.Lookup("e90810b"); // This resolves to a tag
                 Assert.Equal("7b4384978d2493e851f9cca7858815fac9b10980", o1.Sha);
@@ -456,7 +471,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void LookingUpWithBadParamsThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentException>(() => repo.Lookup(string.Empty));
                 Assert.Throws<ArgumentException>(() => repo.Lookup<GitObject>(string.Empty));
@@ -470,7 +486,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void LookingUpWithATooShortShaThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<AmbiguousSpecificationException>(() => repo.Lookup("e90"));
             }
@@ -479,7 +496,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void LookingUpAGitLinkThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentException>(() => repo.Lookup<GitLink>("e90810b"));
             }
@@ -516,8 +534,10 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanDiscoverAStandardRepoGivenTheWorkingDirPath()
         {
-            string path = Repository.Discover(StandardTestRepoWorkingDirPath);
-            Assert.Equal(Path.GetFullPath(StandardTestRepoPath + Path.DirectorySeparatorChar), path);
+            string path = Sandbox(StandardTestRepoWorkingDirPath);
+
+            string found = Repository.Discover(path);
+            Assert.Equal(Path.GetFullPath(string.Format("{0}{1}.git{1}", path, Path.DirectorySeparatorChar)), found);
         }
 
         [Fact]
@@ -607,12 +627,14 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanDetectShallowness()
         {
-            using (var repo = new Repository(ShallowTestRepoPath))
+            var path = Sandbox(ShallowTestRepoPath);
+            using (var repo = new Repository(path))
             {
                 Assert.True(repo.Info.IsShallow);
             }
 
-            using (var repo = new Repository(StandardTestRepoPath))
+            path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Assert.False(repo.Info.IsShallow);
             }

--- a/LibGit2Sharp.Tests/RepositoryFixture.cs
+++ b/LibGit2Sharp.Tests/RepositoryFixture.cs
@@ -536,7 +536,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanDetectIfTheHeadIsOrphaned()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 string branchName = repo.Head.CanonicalName;
@@ -554,7 +554,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void QueryingTheRemoteForADetachedHeadBranchReturnsNull()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 repo.Checkout(repo.Head.Tip.Sha, new CheckoutOptions() { CheckoutModifiers = CheckoutModifiers.Force });

--- a/LibGit2Sharp.Tests/RepositoryOptionsFixture.cs
+++ b/LibGit2Sharp.Tests/RepositoryOptionsFixture.cs
@@ -31,7 +31,8 @@ namespace LibGit2Sharp.Tests
 
             var options = new RepositoryOptions { WorkingDirectoryPath = newWorkdir, IndexPath = newIndex };
 
-            using (var repo = new Repository(BareTestRepoPath, options))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path, options))
             {
                 var st = repo.RetrieveStatus("1/branch_file.txt");
                 Assert.Equal(FileStatus.Missing, st);
@@ -43,7 +44,8 @@ namespace LibGit2Sharp.Tests
         {
             var options = new RepositoryOptions { WorkingDirectoryPath = newWorkdir, IndexPath = newIndex };
 
-            using (var repo = new Repository(BareTestRepoPath, options))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path, options))
             {
                 var st = repo.RetrieveStatus("1/branch_file.txt");
                 Assert.Equal(FileStatus.Removed, st);
@@ -95,8 +97,9 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void OpeningABareRepoWithoutProvidingBothWorkDirAndIndexThrows()
         {
-            Assert.Throws<ArgumentException>(() => new Repository(BareTestRepoPath, new RepositoryOptions {IndexPath = newIndex}));
-            Assert.Throws<ArgumentException>(() => new Repository(BareTestRepoPath, new RepositoryOptions {WorkingDirectoryPath = newWorkdir}));
+            string path = SandboxBareTestRepo();
+            Assert.Throws<ArgumentException>(() => new Repository(path, new RepositoryOptions {IndexPath = newIndex}));
+            Assert.Throws<ArgumentException>(() => new Repository(path, new RepositoryOptions {WorkingDirectoryPath = newWorkdir}));
         }
 
         [Fact]
@@ -163,7 +166,8 @@ namespace LibGit2Sharp.Tests
                 SystemConfigurationLocation = systemLocation,
             };
 
-            using (var repo = new Repository(BareTestRepoPath, options))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path, options))
             {
                 Assert.True(repo.Config.HasConfig(ConfigurationLevel.Global));
                 Assert.Equal(name, repo.Config.Get<string>("user.name").Value);

--- a/LibGit2Sharp.Tests/RepositoryOptionsFixture.cs
+++ b/LibGit2Sharp.Tests/RepositoryOptionsFixture.cs
@@ -53,7 +53,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanProvideADifferentWorkDirToAStandardRepo()
         {
-            var path1 = CloneStandardTestRepo();
+            var path1 = SandboxStandardTestRepo();
             using (var repo = new Repository(path1))
             {
                 Assert.Equal(FileStatus.Unaltered, repo.RetrieveStatus("1/branch_file.txt"));
@@ -61,7 +61,7 @@ namespace LibGit2Sharp.Tests
 
             var options = new RepositoryOptions { WorkingDirectoryPath = newWorkdir };
 
-            var path2 = CloneStandardTestRepo();
+            var path2 = SandboxStandardTestRepo();
             using (var repo = new Repository(path2, options))
             {
                 Assert.Equal(FileStatus.Missing, repo.RetrieveStatus("1/branch_file.txt"));
@@ -71,7 +71,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanProvideADifferentIndexToAStandardRepo()
         {
-            var path1 = CloneStandardTestRepo();
+            var path1 = SandboxStandardTestRepo();
             using (var repo = new Repository(path1))
             {
                 Assert.Equal(FileStatus.Untracked, repo.RetrieveStatus("new_untracked_file.txt"));
@@ -85,7 +85,7 @@ namespace LibGit2Sharp.Tests
 
             var options = new RepositoryOptions { IndexPath = newIndex };
 
-            var path2 = CloneStandardTestRepo();
+            var path2 = SandboxStandardTestRepo();
             using (var repo = new Repository(path2, options))
             {
                 Assert.Equal(FileStatus.Added, repo.RetrieveStatus("new_untracked_file.txt"));
@@ -102,7 +102,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanSneakAdditionalCommitsIntoAStandardRepoWithoutAlteringTheWorkdirOrTheIndex()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 Branch head = repo.Head;

--- a/LibGit2Sharp.Tests/ResetHeadFixture.cs
+++ b/LibGit2Sharp.Tests/ResetHeadFixture.cs
@@ -25,7 +25,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void SoftResetToTheHeadOfARepositoryDoesNotChangeTheTargetOfTheHead()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 Branch oldHead = repo.Head;
@@ -39,7 +39,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void SoftResetToAParentCommitChangesTheTargetOfTheHead()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 var headCommit = repo.Head.Tip;
@@ -53,7 +53,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void SoftResetSetsTheHeadToTheDereferencedCommitOfAChainedTag()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 Tag tag = repo.Tags["test"];
@@ -222,7 +222,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void HardResetUpdatesTheContentOfTheWorkingDirectory()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 var names = new DirectoryInfo(repo.Info.WorkingDirectory).GetFileSystemInfos().Select(fsi => fsi.Name).ToList();

--- a/LibGit2Sharp.Tests/ResetHeadFixture.cs
+++ b/LibGit2Sharp.Tests/ResetHeadFixture.cs
@@ -65,7 +65,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void ResettingWithBadParamsThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentNullException>(() => repo.Reset(ResetMode.Soft, (string)null));
                 Assert.Throws<ArgumentNullException>(() => repo.Reset(ResetMode.Soft, (Commit)null));
@@ -204,7 +205,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void MixedResetInABareRepositoryThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<BareRepositoryException>(() => repo.Reset(ResetMode.Mixed));
             }
@@ -213,7 +215,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void HardResetInABareRepositoryThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<BareRepositoryException>(() => repo.Reset(ResetMode.Hard));
             }

--- a/LibGit2Sharp.Tests/ResetIndexFixture.cs
+++ b/LibGit2Sharp.Tests/ResetIndexFixture.cs
@@ -32,7 +32,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void ResettingInABareRepositoryThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<BareRepositoryException>(() => repo.Reset());
             }

--- a/LibGit2Sharp.Tests/ResetIndexFixture.cs
+++ b/LibGit2Sharp.Tests/ResetIndexFixture.cs
@@ -61,7 +61,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void ResetTheIndexWithTheHeadUnstagesEverything()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 RepositoryStatus oldStatus = repo.RetrieveStatus();
@@ -82,7 +82,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanResetTheIndexToTheContentOfACommitWithCommittishAsArgument()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 repo.Reset("be3563a");
@@ -100,7 +100,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanResetTheIndexToTheContentOfACommitWithCommitAsArgument()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 repo.Reset(repo.Lookup<Commit>("be3563a"));
@@ -118,7 +118,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanResetTheIndexToASubsetOfTheContentOfACommitWithCommittishAsArgument()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 repo.Reset("5b5b025", new[]{ "new.txt" });
@@ -131,7 +131,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanResetTheIndexToASubsetOfTheContentOfACommitWithCommitAsArgumentAndLaxUnmatchedExplicitPathsValidation()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 repo.Reset(repo.Lookup<Commit>("5b5b025"), new[] { "new.txt", "non-existent-path-28.txt" },
@@ -145,7 +145,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void ResettingTheIndexToASubsetOfTheContentOfACommitWithCommitAsArgumentAndStrictUnmatchedPathspecsValidationThrows()
         {
-            using (var repo = new Repository(CloneStandardTestRepo()))
+            using (var repo = new Repository(SandboxStandardTestRepo()))
             {
                 Assert.Throws<UnmatchedPathException>(() =>
                     repo.Reset(repo.Lookup<Commit>("5b5b025"), new[] { "new.txt", "non-existent-path-28.txt" }, new ExplicitPathsOptions()));
@@ -155,7 +155,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanResetTheIndexWhenARenameExists()
         {
-            using (var repo = new Repository(CloneStandardTestRepo()))
+            using (var repo = new Repository(SandboxStandardTestRepo()))
             {
                 repo.Move("branch_file.txt", "renamed_branch_file.txt");
                 repo.Reset(repo.Lookup<Commit>("32eab9c"));
@@ -168,7 +168,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanResetSourceOfARenameInIndex()
         {
-            using (var repo = new Repository(CloneStandardTestRepo()))
+            using (var repo = new Repository(SandboxStandardTestRepo()))
             {
                 repo.Move("branch_file.txt", "renamed_branch_file.txt");
 
@@ -189,7 +189,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanResetTargetOfARenameInIndex()
         {
-            using (var repo = new Repository(CloneStandardTestRepo()))
+            using (var repo = new Repository(SandboxStandardTestRepo()))
             {
                 repo.Move("branch_file.txt", "renamed_branch_file.txt");
 

--- a/LibGit2Sharp.Tests/RevertFixture.cs
+++ b/LibGit2Sharp.Tests/RevertFixture.cs
@@ -17,7 +17,7 @@ namespace LibGit2Sharp.Tests
             const string revertBranchName = "refs/heads/revert";
             const string revertedFile = "a.txt";
 
-            string path = CloneRevertTestRepo();
+            string path = SandboxRevertTestRepo();
             using (var repo = new Repository(path))
             {
                 // Checkout the revert branch.
@@ -64,7 +64,7 @@ namespace LibGit2Sharp.Tests
             const string revertBranchName = "refs/heads/revert";
             const string revertedFile = "a.txt";
 
-            string path = CloneRevertTestRepo();
+            string path = SandboxRevertTestRepo();
             using (var repo = new Repository(path))
             {
                 string modifiedFileFullPath = Path.Combine(repo.Info.WorkingDirectory, revertedFile);
@@ -108,7 +108,7 @@ namespace LibGit2Sharp.Tests
             // and the file whose contents we expect to be reverted.
             const string revertBranchName = "refs/heads/revert";
 
-            string path = CloneRevertTestRepo();
+            string path = SandboxRevertTestRepo();
             using (var repo = new Repository(path))
             {
                 // Checkout the revert branch.
@@ -146,7 +146,7 @@ namespace LibGit2Sharp.Tests
             const string revertBranchName = "refs/heads/revert";
             const string conflictedFilePath = "a.txt";
 
-            string path = CloneRevertTestRepo();
+            string path = SandboxRevertTestRepo();
             using (var repo = new Repository(path))
             {
                 // Checkout the revert branch.
@@ -198,7 +198,7 @@ namespace LibGit2Sharp.Tests
         {
             const string revertBranchName = "refs/heads/revert";
 
-            string repoPath = CloneRevertTestRepo();
+            string repoPath = SandboxRevertTestRepo();
             using (var repo = new Repository(repoPath))
             {
                 // Checkout the revert branch.
@@ -223,7 +223,7 @@ namespace LibGit2Sharp.Tests
         {
             const string revertBranchName = "refs/heads/revert";
 
-            string repoPath = CloneRevertTestRepo();
+            string repoPath = SandboxRevertTestRepo();
             using (var repo = new Repository(repoPath))
             {
                 // Checkout the revert branch.
@@ -263,7 +263,7 @@ namespace LibGit2Sharp.Tests
             const string expectedBlobId = "0ff3bbb9c8bba2291654cd64067fa417ff54c508";
             const string modifiedFilePath = "d_renamed.txt";
 
-            string repoPath = CloneRevertTestRepo();
+            string repoPath = SandboxRevertTestRepo();
             using (var repo = new Repository(repoPath))
             {
                 Branch currentBranch = repo.Checkout(revertBranchName);
@@ -320,7 +320,7 @@ namespace LibGit2Sharp.Tests
             const string revertBranchName = "refs/heads/revert_merge";
             const string commitIdToRevert = "2747045";
 
-            string repoPath = CloneRevertTestRepo();
+            string repoPath = SandboxRevertTestRepo();
             using (var repo = new Repository(repoPath))
             {
                 Branch branch = repo.Checkout(revertBranchName);
@@ -379,7 +379,7 @@ namespace LibGit2Sharp.Tests
             const string revertBranchName = "refs/heads/revert_merge";
             const string commitIdToRevert = "2747045";
 
-            string repoPath = CloneRevertTestRepo();
+            string repoPath = SandboxRevertTestRepo();
             using (var repo = new Repository(repoPath))
             {
                 Branch branch = repo.Checkout(revertBranchName);
@@ -400,7 +400,7 @@ namespace LibGit2Sharp.Tests
             // The branch name to perform the revert on
             const string revertBranchName = "refs/heads/revert";
 
-            string path = CloneRevertTestRepo();
+            string path = SandboxRevertTestRepo();
             using (var repo = new Repository(path))
             {
                 // Checkout the revert branch.
@@ -441,7 +441,7 @@ namespace LibGit2Sharp.Tests
             // The branch name to perform the revert on
             const string revertBranchName = "refs/heads/revert";
 
-            string path = CloneRevertTestRepo();
+            string path = SandboxRevertTestRepo();
             using (var repo = new Repository(path))
             {
                 // Checkout the revert branch.

--- a/LibGit2Sharp.Tests/ShadowCopyFixture.cs
+++ b/LibGit2Sharp.Tests/ShadowCopyFixture.cs
@@ -17,7 +17,7 @@ namespace LibGit2Sharp.Tests
             Assembly assembly = type.Assembly;
 
             // Build a new domain which will shadow copy assemblies
-            string cachePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            string cachePath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             Directory.CreateDirectory(cachePath);
 
             var setup = new AppDomainSetup

--- a/LibGit2Sharp.Tests/StageFixture.cs
+++ b/LibGit2Sharp.Tests/StageFixture.cs
@@ -62,7 +62,8 @@ namespace LibGit2Sharp.Tests
         [InlineData("deleted_staged_file.txt", FileStatus.Removed)]
         public void StagingAnUnknownFileThrowsIfExplicitPath(string relativePath, FileStatus status)
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Assert.Null(repo.Index[relativePath]);
                 Assert.Equal(status, repo.RetrieveStatus(relativePath));
@@ -76,7 +77,8 @@ namespace LibGit2Sharp.Tests
         [InlineData("deleted_staged_file.txt", FileStatus.Removed)]
         public void CanStageAnUnknownFileWithLaxUnmatchedExplicitPathsValidation(string relativePath, FileStatus status)
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Assert.Null(repo.Index[relativePath]);
                 Assert.Equal(status, repo.RetrieveStatus(relativePath));
@@ -93,7 +95,8 @@ namespace LibGit2Sharp.Tests
         [InlineData("deleted_staged_file.txt", FileStatus.Removed)]
         public void StagingAnUnknownFileWithLaxExplicitPathsValidationDoesntThrow(string relativePath, FileStatus status)
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Assert.Null(repo.Index[relativePath]);
                 Assert.Equal(status, repo.RetrieveStatus(relativePath));
@@ -239,7 +242,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void StagingFileWithBadParamsThrows()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentException>(() => repo.Stage(string.Empty));
                 Assert.Throws<ArgumentNullException>(() => repo.Stage((string)null));

--- a/LibGit2Sharp.Tests/StageFixture.cs
+++ b/LibGit2Sharp.Tests/StageFixture.cs
@@ -18,7 +18,7 @@ namespace LibGit2Sharp.Tests
         [InlineData("new_tracked_file.txt", FileStatus.Added, true, FileStatus.Added, true, 0)]
         public void CanStage(string relativePath, FileStatus currentStatus, bool doesCurrentlyExistInTheIndex, FileStatus expectedStatusOnceStaged, bool doesExistInTheIndexOnceStaged, int expectedIndexCountVariation)
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 int count = repo.Index.Count;
@@ -36,7 +36,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanStageTheUpdationOfAStagedFile()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 int count = repo.Index.Count;
@@ -106,7 +106,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanStageTheRemovalOfAStagedFile()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 int count = repo.Index.Count;
@@ -132,7 +132,7 @@ namespace LibGit2Sharp.Tests
         [InlineData("!bang/unit_test.txt")]
         public void CanStageANewFileInAPersistentManner(string filename)
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 Assert.Equal(FileStatus.Nonexistent, repo.RetrieveStatus(filename));
@@ -167,7 +167,7 @@ namespace LibGit2Sharp.Tests
             //InconclusiveIf(() => IsFileSystemCaseSensitive && ignorecase,
             //    "Skipping 'ignorecase = true' test on case-sensitive file system.");
 
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
 
             using (var repo = new Repository(path))
             {
@@ -204,7 +204,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanStageANewFileWithARelativePathContainingNativeDirectorySeparatorCharacters()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 int count = repo.Index.Count;
@@ -227,7 +227,7 @@ namespace LibGit2Sharp.Tests
         public void StagingANewFileWithAFullPathWhichEscapesOutOfTheWorkingDirThrows()
         {
             SelfCleaningDirectory scd = BuildSelfCleaningDirectory();
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 string fullPath = Touch(scd.RootedDirectoryPath, "unit_test.txt", "some contents");
@@ -276,7 +276,7 @@ namespace LibGit2Sharp.Tests
         [InlineData("new_*file.txt", 1)]
         public void CanStageWithPathspec(string relativePath, int expectedIndexCountVariation)
         {
-            using (var repo = new Repository(CloneStandardTestRepo()))
+            using (var repo = new Repository(SandboxStandardTestRepo()))
             {
                 int count = repo.Index.Count;
 
@@ -289,7 +289,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanStageWithMultiplePathspecs()
         {
-            using (var repo = new Repository(CloneStandardTestRepo()))
+            using (var repo = new Repository(SandboxStandardTestRepo()))
             {
                 int count = repo.Index.Count;
 
@@ -304,7 +304,7 @@ namespace LibGit2Sharp.Tests
         [InlineData("ignored_folder/file.txt")]
         public void CanIgnoreIgnoredPaths(string path)
         {
-            using (var repo = new Repository(CloneStandardTestRepo()))
+            using (var repo = new Repository(SandboxStandardTestRepo()))
             {
                 Touch(repo.Info.WorkingDirectory, ".gitignore", "ignored_file.txt\nignored_folder/\n");
                 Touch(repo.Info.WorkingDirectory, path, "This file is ignored.");
@@ -320,7 +320,7 @@ namespace LibGit2Sharp.Tests
         [InlineData("ignored_folder/file.txt")]
         public void CanStageIgnoredPaths(string path)
         {
-            using (var repo = new Repository(CloneStandardTestRepo()))
+            using (var repo = new Repository(SandboxStandardTestRepo()))
             {
                 Touch(repo.Info.WorkingDirectory, ".gitignore", "ignored_file.txt\nignored_folder/\n");
                 Touch(repo.Info.WorkingDirectory, path, "This file is ignored.");

--- a/LibGit2Sharp.Tests/StashFixture.cs
+++ b/LibGit2Sharp.Tests/StashFixture.cs
@@ -263,7 +263,8 @@ namespace LibGit2Sharp.Tests
         [InlineData(-42)]
         public void GettingStashWithBadIndexThrows(int badIndex)
         {
-            using (var repo = new Repository(StandardTestRepoWorkingDirPath))
+            string path = SandboxStandardTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentOutOfRangeException>(() => repo.Stashes[badIndex]);
             }
@@ -274,7 +275,8 @@ namespace LibGit2Sharp.Tests
         [InlineData(42)]
         public void GettingAStashThatDoesNotExistReturnsNull(int bigIndex)
         {
-            using (var repo = new Repository(StandardTestRepoWorkingDirPath))
+            string path = SandboxStandardTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Null(repo.Stashes[bigIndex]);
             }

--- a/LibGit2Sharp.Tests/StashFixture.cs
+++ b/LibGit2Sharp.Tests/StashFixture.cs
@@ -12,7 +12,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CannotAddStashAgainstBareRepository()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 var stasher = Constants.Signature;
@@ -24,7 +24,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanAddAndRemoveStash()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 var stasher = Constants.Signature;
@@ -83,7 +83,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void AddingAStashWithNoMessageGeneratesADefaultOne()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 var stasher = Constants.Signature;
@@ -102,7 +102,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void AddStashWithBadParamsShouldThrows()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentNullException>(() => repo.Stashes.Add(default(Signature), options: StashModifiers.Default));
@@ -112,7 +112,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void StashingAgainstCleanWorkDirShouldReturnANullStash()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 var stasher = Constants.Signature;
@@ -129,7 +129,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanStashWithoutOptions()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 var stasher = Constants.Signature;
@@ -158,7 +158,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanStashAndKeepIndex()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 var stasher = Constants.Signature;
@@ -179,7 +179,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanStashIgnoredFiles()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 const string gitIgnore = ".gitignore";
@@ -209,7 +209,7 @@ namespace LibGit2Sharp.Tests
         [InlineData(-42)]
         public void RemovingStashWithBadParamShouldThrow(int badIndex)
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentException>(() => repo.Stashes.Remove(badIndex));
@@ -219,7 +219,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanGetStashByIndexer()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 var stasher = Constants.Signature;

--- a/LibGit2Sharp.Tests/StatusFixture.cs
+++ b/LibGit2Sharp.Tests/StatusFixture.cs
@@ -13,7 +13,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanRetrieveTheStatusOfAFile()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 FileStatus status = repo.RetrieveStatus("new_tracked_file.txt");
                 Assert.Equal(FileStatus.Added, status);
@@ -95,7 +96,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void RetrievingTheStatusOfADirectoryThrows()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<AmbiguousSpecificationException>(() => { FileStatus status = repo.RetrieveStatus("1"); });
             }

--- a/LibGit2Sharp.Tests/StatusFixture.cs
+++ b/LibGit2Sharp.Tests/StatusFixture.cs
@@ -26,7 +26,7 @@ namespace LibGit2Sharp.Tests
         [InlineData(StatusShowOption.IndexOnly, FileStatus.Nonexistent)]
         public void CanLimitStatusToWorkDirOnly(StatusShowOption show, FileStatus expected)
         {
-            var clone = CloneStandardTestRepo();
+            var clone = SandboxStandardTestRepo();
 
             using (var repo = new Repository(clone))
             {
@@ -43,7 +43,7 @@ namespace LibGit2Sharp.Tests
         [InlineData(StatusShowOption.IndexOnly, FileStatus.Added)]
         public void CanLimitStatusToIndexOnly(StatusShowOption show, FileStatus expected)
         {
-            var clone = CloneStandardTestRepo();
+            var clone = SandboxStandardTestRepo();
 
             using (var repo = new Repository(clone))
             {
@@ -81,7 +81,7 @@ namespace LibGit2Sharp.Tests
         [InlineData("dir!/file.txt")]
         public void CanRetrieveTheStatusOfAnUntrackedFile(string filePath)
         {
-            var clone = CloneStandardTestRepo();
+            var clone = SandboxStandardTestRepo();
 
             using (var repo = new Repository(clone))
             {
@@ -104,7 +104,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanRetrieveTheStatusOfTheWholeWorkingDirectory()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 const string file = "modified_staged_file.txt";
@@ -148,7 +148,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanRetrieveTheStatusOfRenamedFilesInWorkDir()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 Touch(repo.Info.WorkingDirectory, "old_name.txt",
@@ -177,7 +177,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanRetrieveTheStatusOfRenamedFilesInIndex()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 File.Move(
@@ -315,7 +315,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void RetrievingTheStatusOfTheRepositoryHonorsTheGitIgnoreDirectives()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 string relativePath = Path.Combine("1", "look-ma.txt");
@@ -457,7 +457,7 @@ namespace LibGit2Sharp.Tests
         {
             char dirSep = Path.DirectorySeparatorChar;
 
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 Touch(repo.Info.WorkingDirectory, "bin/look-ma.txt", "I'm going to be ignored!");
@@ -490,7 +490,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanRetrieveStatusOfFilesInSubmodule()
         {
-            var path = CloneSubmoduleTestRepo();
+            var path = SandboxSubmoduleTestRepo();
             using (var repo = new Repository(path))
             {
                 string[] expected = new string[] {
@@ -510,7 +510,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanExcludeStatusOfFilesInSubmodule()
         {
-            var path = CloneSubmoduleTestRepo();
+            var path = SandboxSubmoduleTestRepo();
             using (var repo = new Repository(path))
             {
                 string[] expected = new string[] {
@@ -525,7 +525,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanRetrieveTheStatusOfARelativeWorkingDirectory()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 const string file = "just_a_dir/other.txt";
@@ -547,7 +547,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanRetrieveTheStatusOfMultiplePathSpec()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 const string file = "just_a_dir/other.txt";
@@ -565,7 +565,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanRetrieveTheStatusOfAGlobSpec()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 const string file = "just_a_dir/other.txt";

--- a/LibGit2Sharp.Tests/SubmoduleFixture.cs
+++ b/LibGit2Sharp.Tests/SubmoduleFixture.cs
@@ -12,7 +12,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void RetrievingSubmoduleForNormalDirectoryReturnsNull()
         {
-            var path = CloneSubmoduleTestRepo();
+            var path = SandboxSubmoduleTestRepo();
             using (var repo = new Repository(path))
             {
                 var submodule = repo.Submodules["just_a_dir"];
@@ -31,7 +31,7 @@ namespace LibGit2Sharp.Tests
         [InlineData("sm_unchanged", SubmoduleStatus.InConfig | SubmoduleStatus.InHead | SubmoduleStatus.InIndex | SubmoduleStatus.InWorkDir)]
         public void CanRetrieveTheStatusOfASubmodule(string name, SubmoduleStatus expectedStatus)
         {
-            var path = CloneSubmoduleTestRepo();
+            var path = SandboxSubmoduleTestRepo();
             using (var repo = new Repository(path))
             {
                 var submodule = repo.Submodules[name];
@@ -55,7 +55,7 @@ namespace LibGit2Sharp.Tests
         [InlineData("sm_unchanged", "480095882d281ed676fe5b863569520e54a7d5c0", "480095882d281ed676fe5b863569520e54a7d5c0", "480095882d281ed676fe5b863569520e54a7d5c0")]
         public void CanRetrieveTheCommitIdsOfASubmodule(string name, string headId, string indexId, string workDirId)
         {
-            var path = CloneSubmoduleTestRepo();
+            var path = SandboxSubmoduleTestRepo();
             using (var repo = new Repository(path))
             {
                 var submodule = repo.Submodules[name];
@@ -92,7 +92,7 @@ namespace LibGit2Sharp.Tests
                 "sm_unchanged",
             };
 
-            var path = CloneSubmoduleTestRepo();
+            var path = SandboxSubmoduleTestRepo();
             using (var repo = new Repository(path))
             {
                 var submodules = repo.Submodules.OrderBy(s => s.Name, StringComparer.Ordinal);
@@ -111,7 +111,7 @@ namespace LibGit2Sharp.Tests
         {
             submodulePath += appendPathSeparator ? Path.DirectorySeparatorChar : default(char?);
 
-            var path = CloneSubmoduleTestRepo();
+            var path = SandboxSubmoduleTestRepo();
             using (var repo = new Repository(path))
             {
                 var submodule = repo.Submodules[submodulePath];
@@ -134,7 +134,7 @@ namespace LibGit2Sharp.Tests
         {
             submodulePath += appendPathSeparator ? Path.DirectorySeparatorChar : default(char?);
 
-            var path = CloneSubmoduleTestRepo();
+            var path = SandboxSubmoduleTestRepo();
             using (var repo = new Repository(path))
             {
                 var submodule = repo.Submodules[submodulePath];

--- a/LibGit2Sharp.Tests/TagFixture.cs
+++ b/LibGit2Sharp.Tests/TagFixture.cs
@@ -255,7 +255,8 @@ namespace LibGit2Sharp.Tests
         // Ported from cgit (https://github.com/git/git/blob/1c08bf50cfcf924094eca56c2486a90e2bf1e6e2/t/t7004-tag.sh#L42)
         public void CreatingATagForAnUnknowReferenceThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<LibGit2SharpException>(() => repo.ApplyTag("mytagnorev", "aaaaaaaaaaa"));
             }
@@ -265,7 +266,8 @@ namespace LibGit2Sharp.Tests
         // Ported from cgit (https://github.com/git/git/blob/1c08bf50cfcf924094eca56c2486a90e2bf1e6e2/t/t7004-tag.sh#L42)
         public void CreatingATagForAnUnknowObjectIdThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<LibGit2SharpException>(() => repo.ApplyTag("mytagnorev", Constants.UnknownSha));
             }
@@ -325,7 +327,8 @@ namespace LibGit2Sharp.Tests
         // Ported from cgit (https://github.com/git/git/blob/1c08bf50cfcf924094eca56c2486a90e2bf1e6e2/t/t7004-tag.sh#L90)
         public void CreatingATagWithANonValidNameShouldFail()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentException>(() => repo.ApplyTag(""));
                 Assert.Throws<InvalidSpecificationException>(() => repo.ApplyTag(".othertag"));
@@ -375,7 +378,8 @@ namespace LibGit2Sharp.Tests
         public void CanReadTagWithoutTagger()
         {
             // Not all tags have a tagger.
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Tag tag = repo.Tags["tag_without_tagger"];
 
@@ -450,7 +454,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void BlindlyCreatingALightweightTagOverAnExistingOneThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<NameConflictException>(() => repo.Tags.Add("e90810b", "refs/heads/br2"));
             }
@@ -459,7 +464,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void BlindlyCreatingAnAnnotatedTagOverAnExistingOneThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<NameConflictException>(() => repo.Tags.Add("e90810b", "refs/heads/br2", signatureNtk, "a nice message"));
             }
@@ -468,7 +474,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void AddTagWithADuplicateNameThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<NameConflictException>(() => repo.Tags.Add("test", tagTestSha, signatureTim, "message"));
             }
@@ -477,7 +484,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void AddTagWithEmptyNameThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentException>(() => repo.Tags.Add(string.Empty, "refs/heads/master", signatureTim, "message"));
             }
@@ -486,7 +494,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void AddTagWithEmptyTargetThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentException>(() => repo.Tags.Add("test_tag", string.Empty, signatureTim, "message"));
             }
@@ -495,7 +504,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void AddTagWithNotExistingTargetThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<LibGit2SharpException>(() => repo.Tags.Add("test_tag", Constants.UnknownSha, signatureTim, "message"));
             }
@@ -504,7 +514,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void AddTagWithNullMessageThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentNullException>(() => repo.Tags.Add("test_tag", "refs/heads/master", signatureTim, null));
             }
@@ -513,7 +524,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void AddTagWithNullNameThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentNullException>(() => repo.Tags.Add(null, "refs/heads/master", signatureTim, "message"));
             }
@@ -522,7 +534,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void AddTagWithNullSignatureThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentNullException>(() => repo.Tags.Add("test_tag", "refs/heads/master", null, "message"));
             }
@@ -531,7 +544,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void AddTagWithNullTargetThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentNullException>(() => repo.Tags.Add("test_tag", (GitObject)null, signatureTim, "message"));
                 Assert.Throws<ArgumentNullException>(() => repo.Tags.Add("test_tag", (string)null, signatureTim, "message"));
@@ -606,7 +620,8 @@ namespace LibGit2Sharp.Tests
         // Ported from cgit (https://github.com/git/git/blob/1c08bf50cfcf924094eca56c2486a90e2bf1e6e2/t/t7004-tag.sh#L108)
         public void RemovingAnUnknownTagShouldFail()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<LibGit2SharpException>(() => repo.Tags.Remove("unknown-tag"));
             }
@@ -615,7 +630,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void GetTagByNameWithBadParamsThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Tag tag;
                 Assert.Throws<ArgumentNullException>(() => tag = repo.Tags[null]);
@@ -626,7 +642,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanListTags()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Equal(expectedTags, SortedTags(repo.Tags, t => t.Name));
 
@@ -650,7 +667,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanLookupALightweightTag()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Tag tag = repo.Tags["lw"];
                 Assert.NotNull(tag);
@@ -665,7 +683,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanLookupATagByItsCanonicalName()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Tag tag = repo.Tags["refs/tags/lw"];
                 Assert.NotNull(tag);
@@ -683,7 +702,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanLookupAnAnnotatedTag()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Tag tag = repo.Tags["e90810b"];
                 Assert.NotNull(tag);
@@ -703,7 +723,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void LookupEmptyTagNameThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentException>(() => { Tag t = repo.Tags[string.Empty]; });
             }
@@ -712,7 +733,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void LookupNullTagNameThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentNullException>(() => { Tag t = repo.Tags[null]; });
             }

--- a/LibGit2Sharp.Tests/TagFixture.cs
+++ b/LibGit2Sharp.Tests/TagFixture.cs
@@ -20,7 +20,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanAddALightWeightTagFromSha()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 Tag newTag = repo.Tags.Add("i_am_lightweight", commitE90810BSha);
@@ -33,7 +33,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanAddALightWeightTagFromAGitObject()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 GitObject obj = repo.Lookup(commitE90810BSha);
@@ -48,7 +48,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanAddALightWeightTagFromAbbreviatedSha()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 Tag newTag = repo.Tags.Add("i_am_lightweight", commitE90810BSha.Substring(0, 17));
@@ -60,7 +60,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanAddALightweightTagFromABranchName()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 Tag newTag = repo.Tags.Add("i_am_lightweight", "refs/heads/master");
@@ -72,7 +72,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanAddALightweightTagFromARevparseSpec()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 Tag newTag = repo.Tags.Add("i_am_lightweight", "master^1^2");
@@ -85,7 +85,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanAddAndOverwriteALightweightTag()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 Tag newTag = repo.Tags.Add("e90810b", commitE90810BSha, true);
@@ -97,7 +97,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanAddATagWithNameContainingASlash()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 const string lwTagName = "i/am/deep";
@@ -120,7 +120,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CreatingATagWithNameMatchingAnAlreadyExistingReferenceHierarchyThrows()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 repo.ApplyTag("i/am/deep");
@@ -132,7 +132,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanAddAnAnnotatedTagFromABranchName()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 Tag newTag = repo.Tags.Add("unit_test", "refs/heads/master", signatureTim, "a new tag");
@@ -144,7 +144,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanAddAnAnnotatedTagFromSha()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 Tag newTag = repo.Tags.Add("unit_test", tagTestSha, signatureTim, "a new tag");
@@ -158,7 +158,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanAddAnAnnotatedTagFromObject()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 GitObject obj = repo.Lookup(tagTestSha);
@@ -173,7 +173,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanAddAnAnnotatedTagFromARevparseSpec()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 Tag newTag = repo.Tags.Add("unit_test", "master^1^2", signatureTim, "a new tag");
@@ -187,7 +187,7 @@ namespace LibGit2Sharp.Tests
         // Ported from cgit (https://github.com/git/git/blob/1c08bf50cfcf924094eca56c2486a90e2bf1e6e2/t/t7004-tag.sh#L359)
         public void CanAddAnAnnotatedTagWithAnEmptyMessage()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 Tag newTag = repo.ApplyTag("empty-annotated-tag", signatureNtk, string.Empty);
@@ -200,7 +200,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanAddAndOverwriteAnAnnotatedTag()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 Tag newTag = repo.Tags.Add("e90810b", tagTestSha, signatureTim, "a new tag", true);
@@ -215,7 +215,7 @@ namespace LibGit2Sharp.Tests
             const string tagName = "nullTAGen";
             const string tagMessage = "I've been tagged!";
 
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 Tag newTag = repo.Tags.Add(tagName, commitE90810BSha, signatureNtk, tagMessage);
@@ -275,7 +275,7 @@ namespace LibGit2Sharp.Tests
         // Ported from cgit (https://github.com/git/git/blob/1c08bf50cfcf924094eca56c2486a90e2bf1e6e2/t/t7004-tag.sh#L48)
         public void CanAddATagForImplicitHead()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 Tag tag = repo.ApplyTag("mytag");
@@ -291,7 +291,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanAddATagForImplicitHeadInDetachedState()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 repo.Checkout(repo.Head.Tip);
@@ -312,7 +312,7 @@ namespace LibGit2Sharp.Tests
         // Ported from cgit (https://github.com/git/git/blob/1c08bf50cfcf924094eca56c2486a90e2bf1e6e2/t/t7004-tag.sh#L87)
         public void CreatingADuplicateTagThrows()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 repo.ApplyTag("mytag");
@@ -339,7 +339,7 @@ namespace LibGit2Sharp.Tests
         // Ported from cgit (https://github.com/git/git/blob/1c08bf50cfcf924094eca56c2486a90e2bf1e6e2/t/t7004-tag.sh#L101)
         public void CanAddATagUsingHead()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 Tag tag = repo.ApplyTag("mytag", "HEAD");
@@ -355,7 +355,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanAddATagPointingToATree()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 Commit headCommit = repo.Head.Tip;
@@ -393,7 +393,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanAddATagPointingToABlob()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 var blob = repo.Lookup<Blob>("a823312");
@@ -411,7 +411,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CreatingALightweightTagPointingToATagAnnotationGeneratesAnAnnotatedTagReusingThePointedAtTagAnnotation()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 Tag annotatedTag = repo.Tags["e90810b"];
@@ -431,7 +431,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanAddAnAnnotatedTagPointingToATagAnnotation()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 Tag annotatedTag = repo.Tags["e90810b"];
@@ -541,7 +541,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanRemoveATagThroughItsName()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 repo.Tags.Remove("e90810b");
@@ -551,7 +551,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanRemoveATagThroughItsCanonicalName()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 repo.Tags.Remove("refs/tags/e90810b");
@@ -561,7 +561,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanRemoveATag()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 Tag tag = repo.Tags["e90810b"];
@@ -572,7 +572,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void ARemovedTagCannotBeLookedUp()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 const string tagName = "e90810b";
@@ -585,7 +585,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void RemovingATagDecreasesTheTagsCount()
         {
-            string path = CloneBareTestRepo();
+            string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
                 const string tagName = "e90810b";

--- a/LibGit2Sharp.Tests/TestHelpers/BaseFixture.cs
+++ b/LibGit2Sharp.Tests/TestHelpers/BaseFixture.cs
@@ -120,43 +120,43 @@ namespace LibGit2Sharp.Tests.TestHelpers
             return new SelfCleaningDirectory(this, path);
         }
 
-        protected string CloneBareTestRepo()
+        protected string SandboxBareTestRepo()
         {
-            return Clone(BareTestRepoPath);
+            return Sandbox(BareTestRepoPath);
         }
 
-        protected string CloneStandardTestRepo()
+        protected string SandboxStandardTestRepo()
         {
-            return Clone(StandardTestRepoWorkingDirPath);
+            return Sandbox(StandardTestRepoWorkingDirPath);
         }
 
-        protected string CloneMergedTestRepo()
+        protected string SandboxMergedTestRepo()
         {
-            return Clone(MergedTestRepoWorkingDirPath);
+            return Sandbox(MergedTestRepoWorkingDirPath);
         }
 
-        protected string CloneMergeRenamesTestRepo()
+        protected string SandboxMergeRenamesTestRepo()
         {
-            return Clone(MergeRenamesTestRepoWorkingDirPath);
+            return Sandbox(MergeRenamesTestRepoWorkingDirPath);
         }
 
-        protected string CloneMergeTestRepo()
+        protected string SandboxMergeTestRepo()
         {
-            return Clone(MergeTestRepoWorkingDirPath);
+            return Sandbox(MergeTestRepoWorkingDirPath);
         }
 
-        protected string CloneRevertTestRepo()
+        protected string SandboxRevertTestRepo()
         {
-            return Clone(RevertTestRepoWorkingDirPath);
+            return Sandbox(RevertTestRepoWorkingDirPath);
         }
 
-        public string CloneSubmoduleTestRepo()
+        public string SandboxSubmoduleTestRepo()
         {
             var submoduleTarget = Path.Combine(ResourcesDirectory.FullName, "submodule_target_wd");
-            return Clone(SubmoduleTestRepoWorkingDirPath, submoduleTarget);
+            return Sandbox(SubmoduleTestRepoWorkingDirPath, submoduleTarget);
         }
 
-        private string Clone(string sourceDirectoryPath, params string[] additionalSourcePaths)
+        private string Sandbox(string sourceDirectoryPath, params string[] additionalSourcePaths)
         {
             var scd = BuildSelfCleaningDirectory();
             var source = new DirectoryInfo(sourceDirectoryPath);

--- a/LibGit2Sharp.Tests/TestHelpers/BaseFixture.cs
+++ b/LibGit2Sharp.Tests/TestHelpers/BaseFixture.cs
@@ -27,8 +27,6 @@ namespace LibGit2Sharp.Tests.TestHelpers
         {
             // Do the set up in the static ctor so it only happens once
             SetUpTestEnvironment();
-
-            DirectoryHelper.DeleteSubdirectories(Constants.TemporaryReposPath);
         }
 
         public static string BareTestRepoPath { get; private set; }
@@ -40,6 +38,7 @@ namespace LibGit2Sharp.Tests.TestHelpers
         public static string MergeRenamesTestRepoWorkingDirPath { get; private set; }
         public static string RevertTestRepoWorkingDirPath { get; private set; }
         public static string SubmoduleTestRepoWorkingDirPath { get; private set; }
+        private static string SubmoduleTargetTestRepoWorkingDirPath { get; set; }
         public static DirectoryInfo ResourcesDirectory { get; private set; }
 
         public static bool IsFileSystemCaseSensitive { get; private set; }
@@ -54,32 +53,25 @@ namespace LibGit2Sharp.Tests.TestHelpers
         {
             IsFileSystemCaseSensitive = IsFileSystemCaseSensitiveInternal();
 
-            var source = new DirectoryInfo(@"../../Resources");
-            ResourcesDirectory = new DirectoryInfo(string.Format(@"Resources/{0}", Guid.NewGuid()));
-            var parent = new DirectoryInfo(@"Resources");
-
-            if (parent.Exists)
-            {
-                DirectoryHelper.DeleteSubdirectories(parent.FullName);
-            }
-
-            DirectoryHelper.CopyFilesRecursively(source, ResourcesDirectory);
+            const string sourceRelativePath = @"../../Resources";
+            ResourcesDirectory = new DirectoryInfo(sourceRelativePath);
 
             // Setup standard paths to our test repositories
-            BareTestRepoPath = Path.Combine(ResourcesDirectory.FullName, "testrepo.git");
-            StandardTestRepoWorkingDirPath = Path.Combine(ResourcesDirectory.FullName, "testrepo_wd");
-            StandardTestRepoPath = Path.Combine(StandardTestRepoWorkingDirPath, ".git");
-            ShallowTestRepoPath = Path.Combine(ResourcesDirectory.FullName, "shallow.git");
-            MergedTestRepoWorkingDirPath = Path.Combine(ResourcesDirectory.FullName, "mergedrepo_wd");
-            MergeRenamesTestRepoWorkingDirPath = Path.Combine(ResourcesDirectory.FullName, "mergerenames_wd");
-            MergeTestRepoWorkingDirPath = Path.Combine(ResourcesDirectory.FullName, "merge_testrepo_wd");
-            RevertTestRepoWorkingDirPath = Path.Combine(ResourcesDirectory.FullName, "revert_testrepo_wd");
-            SubmoduleTestRepoWorkingDirPath = Path.Combine(ResourcesDirectory.FullName, "submodule_wd");
+            BareTestRepoPath = Path.Combine(sourceRelativePath, "testrepo.git");
+            StandardTestRepoWorkingDirPath = Path.Combine(sourceRelativePath, "testrepo_wd");
+            StandardTestRepoPath = Path.Combine(StandardTestRepoWorkingDirPath, "dot_git");
+            ShallowTestRepoPath = Path.Combine(sourceRelativePath, "shallow.git");
+            MergedTestRepoWorkingDirPath = Path.Combine(sourceRelativePath, "mergedrepo_wd");
+            MergeRenamesTestRepoWorkingDirPath = Path.Combine(sourceRelativePath, "mergerenames_wd");
+            MergeTestRepoWorkingDirPath = Path.Combine(sourceRelativePath, "merge_testrepo_wd");
+            RevertTestRepoWorkingDirPath = Path.Combine(sourceRelativePath, "revert_testrepo_wd");
+            SubmoduleTestRepoWorkingDirPath = Path.Combine(sourceRelativePath, "submodule_wd");
+            SubmoduleTargetTestRepoWorkingDirPath = Path.Combine(sourceRelativePath, "submodule_target_wd");
         }
 
         private static bool IsFileSystemCaseSensitiveInternal()
         {
-            var mixedPath = Path.Combine(Constants.TemporaryReposPath, "mIxEdCase");
+            var mixedPath = Path.Combine(Constants.TemporaryReposPath, "mIxEdCase-" + Path.GetRandomFileName());
 
             if (Directory.Exists(mixedPath))
             {
@@ -135,9 +127,9 @@ namespace LibGit2Sharp.Tests.TestHelpers
             return Sandbox(MergedTestRepoWorkingDirPath);
         }
 
-        protected string SandboxMergeRenamesTestRepo()
+        protected string SandboxStandardTestRepoGitDir()
         {
-            return Sandbox(MergeRenamesTestRepoWorkingDirPath);
+            return Sandbox(Path.Combine(StandardTestRepoWorkingDirPath));
         }
 
         protected string SandboxMergeTestRepo()
@@ -152,11 +144,10 @@ namespace LibGit2Sharp.Tests.TestHelpers
 
         public string SandboxSubmoduleTestRepo()
         {
-            var submoduleTarget = Path.Combine(ResourcesDirectory.FullName, "submodule_target_wd");
-            return Sandbox(SubmoduleTestRepoWorkingDirPath, submoduleTarget);
+            return Sandbox(SubmoduleTestRepoWorkingDirPath, SubmoduleTargetTestRepoWorkingDirPath);
         }
 
-        private string Sandbox(string sourceDirectoryPath, params string[] additionalSourcePaths)
+        protected string Sandbox(string sourceDirectoryPath, params string[] additionalSourcePaths)
         {
             var scd = BuildSelfCleaningDirectory();
             var source = new DirectoryInfo(sourceDirectoryPath);

--- a/LibGit2Sharp.Tests/TestHelpers/SelfCleaningDirectory.cs
+++ b/LibGit2Sharp.Tests/TestHelpers/SelfCleaningDirectory.cs
@@ -28,7 +28,7 @@ namespace LibGit2Sharp.Tests.TestHelpers
 
         protected static string BuildTempPath()
         {
-            return Path.Combine(Constants.TemporaryReposPath, Guid.NewGuid().ToString().Substring(0, 8));
+            return Path.Combine(Constants.TemporaryReposPath, Path.GetRandomFileName());
         }
     }
 }

--- a/LibGit2Sharp.Tests/TreeDefinitionFixture.cs
+++ b/LibGit2Sharp.Tests/TreeDefinitionFixture.cs
@@ -18,7 +18,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanBuildATreeDefinitionFromATree()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 TreeDefinition td = TreeDefinition.From(repo.Head.Tip.Tree);
                 Assert.NotNull(td);
@@ -34,7 +35,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void RequestingANonExistingEntryReturnsNull()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 TreeDefinition td = TreeDefinition.From(repo.Head.Tip.Tree);
 
@@ -48,7 +50,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void RequestingAnEntryWithBadParamsThrows()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 TreeDefinition td = TreeDefinition.From(repo.Head.Tip.Tree);
 
@@ -70,7 +73,8 @@ namespace LibGit2Sharp.Tests
         [InlineData("1",                 "040000", TreeEntryTargetType.Tree, "7f76480d939dc401415927ea7ef25c676b8ddb8f")]
         public void CanRetrieveEntries(string path, string expectedAttributes, TreeEntryTargetType expectedType, string expectedSha)
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string repoPath = SandboxBareTestRepo();
+            using (var repo = new Repository(repoPath))
             {
                 TreeDefinition td = TreeDefinition.From(repo.Head.Tip.Tree);
 
@@ -100,7 +104,8 @@ namespace LibGit2Sharp.Tests
         [InlineData("1", "2/3")]
         public void CanAddAnExistingTreeEntryDefinition(string sourcePath, string targetPath)
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 TreeDefinition td = TreeDefinition.From(repo.Head.Tip.Tree);
                 Assert.Null(td[targetPath]);
@@ -121,7 +126,8 @@ namespace LibGit2Sharp.Tests
             const string sourcePath = "sm_unchanged";
             const string targetPath = "sm_from_td";
 
-            using (var repo = new Repository(SubmoduleTestRepoWorkingDirPath))
+            var path = SandboxSubmoduleTestRepo();
+            using (var repo = new Repository(path))
             {
                 TreeDefinition td = TreeDefinition.From(repo.Head.Tip.Tree);
                 Assert.Null(td[targetPath]);
@@ -148,7 +154,8 @@ namespace LibGit2Sharp.Tests
         [InlineData("1", "2/3")]
         public void CanAddAnExistingTreeEntry(string sourcePath, string targetPath)
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var tree = repo.Head.Tip.Tree;
                 var td = TreeDefinition.From(tree);
@@ -172,7 +179,8 @@ namespace LibGit2Sharp.Tests
         {
             const string sourcePath = "sm_unchanged";
 
-            using (var repo = new Repository(SubmoduleTestRepoWorkingDirPath))
+            var path = SandboxSubmoduleTestRepo();
+            using (var repo = new Repository(path))
             {
                 var tree = repo.Head.Tip.Tree;
                 var td = TreeDefinition.From(tree);
@@ -195,7 +203,8 @@ namespace LibGit2Sharp.Tests
         [InlineData("45b983be36b73c0788dc9cbcb76cbb80fc7bb057", "another_one.txt")]
         public void CanAddAnExistingBlob(string blobSha, string targetPath)
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 TreeDefinition td = TreeDefinition.From(repo.Head.Tip.Tree);
                 Assert.Null(td[targetPath]);
@@ -218,7 +227,8 @@ namespace LibGit2Sharp.Tests
         {
             const string submodulePath = "sm_unchanged";
 
-            using (var repo = new Repository(SubmoduleTestRepoWorkingDirPath))
+            var path = SandboxSubmoduleTestRepo();
+            using (var repo = new Repository(path))
             {
                 var submodule = repo.Submodules[submodulePath];
                 Assert.NotNull(submodule);
@@ -246,7 +256,8 @@ namespace LibGit2Sharp.Tests
             const string treeSha = "7f76480d939dc401415927ea7ef25c676b8ddb8f";
             const string targetPath = "1/2";
 
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 TreeDefinition td = TreeDefinition.From(repo.Head.Tip.Tree);
 
@@ -271,7 +282,8 @@ namespace LibGit2Sharp.Tests
             const string blobSha = "a8233120f6ad708f843d861ce2b7228ec4e3dec6";
             const string targetPath = "1";
 
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 TreeDefinition td = TreeDefinition.From(repo.Head.Tip.Tree);
                 Assert.Equal(TreeEntryTargetType.Tree, td[targetPath].TargetType);
@@ -301,7 +313,8 @@ namespace LibGit2Sharp.Tests
         {
             const string treeSha = "7f76480d939dc401415927ea7ef25c676b8ddb8f";
 
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 TreeDefinition td = TreeDefinition.From(repo.Head.Tip.Tree);
                 Assert.NotNull(td[targetPath]);
@@ -327,7 +340,8 @@ namespace LibGit2Sharp.Tests
             var commitId = (ObjectId)"480095882d281ed676fe5b863569520e54a7d5c0";
             const string targetPath = "just_a_dir";
 
-            using (var repo = new Repository(SubmoduleTestRepoWorkingDirPath))
+            var path = SandboxSubmoduleTestRepo();
+            using (var repo = new Repository(path))
             {
                 TreeDefinition td = TreeDefinition.From(repo.Head.Tip.Tree);
                 Assert.Equal(TreeEntryTargetType.Tree, td[targetPath].TargetType);
@@ -353,7 +367,8 @@ namespace LibGit2Sharp.Tests
             const string treeSha = "607d96653d4d0a4f733107f7890c2e67b55b620d";
             const string targetPath = "sm_unchanged";
 
-            using (var repo = new Repository(SubmoduleTestRepoWorkingDirPath))
+            var path = SandboxSubmoduleTestRepo();
+            using (var repo = new Repository(path))
             {
                 TreeDefinition td = TreeDefinition.From(repo.Head.Tip.Tree);
                 Assert.NotNull(td[targetPath]);
@@ -380,7 +395,8 @@ namespace LibGit2Sharp.Tests
             var commitId = (ObjectId)"480095882d281ed676fe5b863569520e54a7d5c0";
             const string targetPath = "just_a_file";
 
-            using (var repo = new Repository(SubmoduleTestRepoWorkingDirPath))
+            var path = SandboxSubmoduleTestRepo();
+            using (var repo = new Repository(path))
             {
                 TreeDefinition td = TreeDefinition.From(repo.Head.Tip.Tree);
                 Assert.NotNull(td[targetPath]);
@@ -403,7 +419,8 @@ namespace LibGit2Sharp.Tests
             const string blobSha = "42cfb95cd01bf9225b659b5ee3edcc78e8eeb478";
             const string targetPath = "sm_unchanged";
 
-            using (var repo = new Repository(SubmoduleTestRepoWorkingDirPath))
+            var path = SandboxSubmoduleTestRepo();
+            using (var repo = new Repository(path))
             {
                 TreeDefinition td = TreeDefinition.From(repo.Head.Tip.Tree);
                 Assert.NotNull(td[targetPath]);
@@ -427,7 +444,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanNotReplaceAnExistingTreeWithATreeBeingAssembled()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 TreeDefinition td = TreeDefinition.From(repo.Head.Tip.Tree);
                 Assert.Equal(TreeEntryTargetType.Tree, td["1"].TargetType);
@@ -446,7 +464,8 @@ namespace LibGit2Sharp.Tests
             const string blobSha = "a8233120f6ad708f843d861ce2b7228ec4e3dec6";
             const string targetPath = "1/another_branch_file.txt";
 
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 TreeDefinition td = TreeDefinition.From(repo.Head.Tip.Tree);
 
@@ -464,7 +483,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanAddAnExistingBlobEntryWithAnExistingTree()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 TreeDefinition td = TreeDefinition.From(repo.Head.Tip.Tree);
                 TreeEntryDefinition original = td["README"];

--- a/LibGit2Sharp.Tests/TreeFixture.cs
+++ b/LibGit2Sharp.Tests/TreeFixture.cs
@@ -204,7 +204,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanParseSymlinkTreeEntries()
         {
-            var path = CloneBareTestRepo();
+            var path = SandboxBareTestRepo();
 
             using (var repo = new Repository(path))
             {

--- a/LibGit2Sharp.Tests/TreeFixture.cs
+++ b/LibGit2Sharp.Tests/TreeFixture.cs
@@ -13,7 +13,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanCompareTwoTreeEntries()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var tree = repo.Lookup<Tree>(sha);
                 TreeEntry treeEntry1 = tree["README"];
@@ -26,7 +27,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanConvertEntryToBlob()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var tree = repo.Lookup<Tree>(sha);
                 TreeEntry treeEntry = tree["README"];
@@ -39,7 +41,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanConvertEntryToTree()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var tree = repo.Lookup<Tree>(sha);
                 TreeEntry treeEntry = tree["1"];
@@ -52,7 +55,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanEnumerateBlobs()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var tree = repo.Lookup<Tree>(sha);
 
@@ -68,7 +72,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanEnumerateSubTrees()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var tree = repo.Lookup<Tree>(sha);
 
@@ -84,7 +89,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanEnumerateTreeEntries()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var tree = repo.Lookup<Tree>(sha);
                 Assert.Equal(tree.Count, tree.Count());
@@ -96,7 +102,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanGetEntryByName()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var tree = repo.Lookup<Tree>(sha);
                 TreeEntry treeEntry = tree["README"];
@@ -108,7 +115,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void GettingAnUknownTreeEntryReturnsNull()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var tree = repo.Lookup<Tree>(sha);
                 TreeEntry treeEntry = tree["I-do-not-exist"];
@@ -119,7 +127,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanGetEntryCountFromTree()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var tree = repo.Lookup<Tree>(sha);
                 Assert.Equal(4, tree.Count);
@@ -129,7 +138,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanReadEntryAttributes()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var tree = repo.Lookup<Tree>(sha);
                 Assert.Equal(Mode.NonExecutableFile, tree["README"].Mode);
@@ -139,7 +149,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanReadTheTreeData()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 var tree = repo.Lookup<Tree>(sha);
                 Assert.NotNull(tree);
@@ -149,7 +160,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void TreeDataIsPresent()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 GitObject tree = repo.Lookup(sha);
                 Assert.NotNull(tree);
@@ -159,7 +171,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanRetrieveTreeEntryPath()
         {
-            using (var repo = new Repository(BareTestRepoPath))
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
             {
                 /* From a commit tree */
                 var commitTree = repo.Lookup<Commit>("4c062a6").Tree;

--- a/LibGit2Sharp.Tests/UnstageFixture.cs
+++ b/LibGit2Sharp.Tests/UnstageFixture.cs
@@ -13,7 +13,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void StagingANewVersionOfAFileThenUnstagingItRevertsTheBlobToTheVersionOfHead()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 int count = repo.Index.Count;
@@ -40,7 +40,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanStageAndUnstageAnIgnoredFile()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 Touch(repo.Info.WorkingDirectory, ".gitignore", "*.ign" + Environment.NewLine);
@@ -69,7 +69,7 @@ namespace LibGit2Sharp.Tests
             string relativePath, FileStatus currentStatus, bool doesCurrentlyExistInTheIndex,
             FileStatus expectedStatusOnceStaged, bool doesExistInTheIndexOnceStaged, int expectedIndexCountVariation)
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 int count = repo.Index.Count;
@@ -89,7 +89,7 @@ namespace LibGit2Sharp.Tests
         [InlineData("where-am-I.txt", FileStatus.Nonexistent)]
         public void UnstagingUnknownPathsWithStrictUnmatchedExplicitPathsValidationThrows(string relativePath, FileStatus currentStatus)
         {
-            using (var repo = new Repository(CloneStandardTestRepo()))
+            using (var repo = new Repository(SandboxStandardTestRepo()))
             {
                 Assert.Equal(currentStatus, repo.RetrieveStatus(relativePath));
 
@@ -102,7 +102,7 @@ namespace LibGit2Sharp.Tests
         [InlineData("where-am-I.txt", FileStatus.Nonexistent)]
         public void CanUnstageUnknownPathsWithLaxUnmatchedExplicitPathsValidation(string relativePath, FileStatus currentStatus)
         {
-            using (var repo = new Repository(CloneStandardTestRepo()))
+            using (var repo = new Repository(SandboxStandardTestRepo()))
             {
                 Assert.Equal(currentStatus, repo.RetrieveStatus(relativePath));
 
@@ -114,7 +114,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanUnstageTheRemovalOfAFile()
         {
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 int count = repo.Index.Count;
@@ -159,7 +159,7 @@ namespace LibGit2Sharp.Tests
         [InlineData("where-am-I.txt", FileStatus.Nonexistent)]
         public void UnstagingUnknownPathsAgainstAnOrphanedHeadWithStrictUnmatchedExplicitPathsValidationThrows(string relativePath, FileStatus currentStatus)
         {
-            using (var repo = new Repository(CloneStandardTestRepo()))
+            using (var repo = new Repository(SandboxStandardTestRepo()))
             {
                 repo.Refs.UpdateTarget("HEAD", "refs/heads/orphaned");
                 Assert.True(repo.Info.IsHeadUnborn);
@@ -175,7 +175,7 @@ namespace LibGit2Sharp.Tests
         [InlineData("where-am-I.txt", FileStatus.Nonexistent)]
         public void CanUnstageUnknownPathsAgainstAnOrphanedHeadWithLaxUnmatchedExplicitPathsValidation(string relativePath, FileStatus currentStatus)
         {
-            using (var repo = new Repository(CloneStandardTestRepo()))
+            using (var repo = new Repository(SandboxStandardTestRepo()))
             {
                 repo.Refs.UpdateTarget("HEAD", "refs/heads/orphaned");
                 Assert.True(repo.Info.IsHeadUnborn);
@@ -192,7 +192,7 @@ namespace LibGit2Sharp.Tests
         public void UnstagingANewFileWithAFullPathWhichEscapesOutOfTheWorkingDirThrows()
         {
             SelfCleaningDirectory scd = BuildSelfCleaningDirectory();
-            string path = CloneStandardTestRepo();
+            string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
                 DirectoryInfo di = Directory.CreateDirectory(scd.DirectoryPath);
@@ -237,7 +237,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanUnstageSourceOfARename()
         {
-            using (var repo = new Repository(CloneStandardTestRepo()))
+            using (var repo = new Repository(SandboxStandardTestRepo()))
             {
                 repo.Move("branch_file.txt", "renamed_branch_file.txt");
 
@@ -258,7 +258,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanUnstageTargetOfARename()
         {
-            using (var repo = new Repository(CloneStandardTestRepo()))
+            using (var repo = new Repository(SandboxStandardTestRepo()))
             {
                 repo.Move("branch_file.txt", "renamed_branch_file.txt");
 
@@ -278,7 +278,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanUnstageBothSidesOfARename()
         {
-            using (var repo = new Repository(CloneStandardTestRepo()))
+            using (var repo = new Repository(SandboxStandardTestRepo()))
             {
                 repo.Move("branch_file.txt", "renamed_branch_file.txt");
                 repo.Unstage(new string[] { "branch_file.txt", "renamed_branch_file.txt" });

--- a/LibGit2Sharp.Tests/UnstageFixture.cs
+++ b/LibGit2Sharp.Tests/UnstageFixture.cs
@@ -225,7 +225,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void UnstagingFileWithBadParamsThrows()
         {
-            using (var repo = new Repository(StandardTestRepoPath))
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentException>(() => repo.Unstage(string.Empty));
                 Assert.Throws<ArgumentNullException>(() => repo.Unstage((string)null));

--- a/LibGit2Sharp.v2.ncrunchsolution
+++ b/LibGit2Sharp.v2.ncrunchsolution
@@ -1,8 +1,8 @@
 <SolutionConfiguration>
   <FileVersion>1</FileVersion>
   <InferProjectReferencesUsingAssemblyNames>false</InferProjectReferencesUsingAssemblyNames>
-  <AllowParallelTestExecution>false</AllowParallelTestExecution>
-  <AllowTestsToRunInParallelWithThemselves>false</AllowTestsToRunInParallelWithThemselves>
+  <AllowParallelTestExecution>true</AllowParallelTestExecution>
+  <AllowTestsToRunInParallelWithThemselves>true</AllowTestsToRunInParallelWithThemselves>
   <FrameworkUtilisationTypeForNUnit>UseDynamicAnalysis</FrameworkUtilisationTypeForNUnit>
   <FrameworkUtilisationTypeForGallio>UseStaticAnalysis</FrameworkUtilisationTypeForGallio>
   <FrameworkUtilisationTypeForMSpec>UseStaticAnalysis</FrameworkUtilisationTypeForMSpec>


### PR DESCRIPTION
Currently, when you try to run the tests in parallel they run into file contention issues where one of the tests will take out a lock on some file and then another test fails because it can't open the file.  Finding an optimal solution would require more knowledge than I have, but my first thought would be to have each test copy the resources it needs before using them, rather than having multiple tests utilize the same set of resources.