### PR TITLE
Use latest Mono on Travis CI Linux platform

### DIFF
--- a/CI/travis.linux.install.deps.sh
+++ b/CI/travis.linux.install.deps.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 set -ev
 
-sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/tpokorra:/mono/xUbuntu_12.04/ /' >> /etc/apt/sources.list.d/mono-opt.list"
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 
-curl http://download.opensuse.org/repositories/home:/tpokorra:/mono/xUbuntu_12.04/Release.key | sudo apt-key add -
+echo "deb http://download.mono-project.com/repo/debian wheezy main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list
+echo "deb http://download.mono-project.com/repo/debian wheezy-libtiff-compat main" | sudo tee -a /etc/apt/sources.list.d/mono-xamarin.list
 
 sudo apt-get update
-sudo apt-get install mono-opt cmake
+sudo apt-get install mono-devel cmake


### PR DESCRIPTION
By taking a look at recent builds, I've noticed that MacOs X ones were running Mono 3.6, whereas Linux were running Mono 3.10.

Hopefully, this change should now align both builds.