### PR TITLE
Clarify branch tracking related tests

### DIFF
--- a/LibGit2Sharp.Tests/BranchFixture.cs
+++ b/LibGit2Sharp.Tests/BranchFixture.cs
@@ -683,10 +683,12 @@ namespace LibGit2Sharp.Tests
             string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
-                Branch branch = repo.CreateBranch(testBranchName);
+                Branch trackedBranch = repo.Branches[trackedBranchName];
+                Assert.True(trackedBranch.IsRemote);
+
+                Branch branch = repo.CreateBranch(testBranchName, trackedBranch.Tip);
                 Assert.False(branch.IsTracking);
 
-                Branch trackedBranch = repo.Branches[trackedBranchName];
                 repo.Branches.Update(branch,
                     b => b.TrackedBranch = trackedBranch.CanonicalName);
 
@@ -743,10 +745,12 @@ namespace LibGit2Sharp.Tests
             string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
-                Branch branch = repo.CreateBranch(testBranchName);
+                Branch trackedBranch = repo.Branches[trackedBranchName];
+                Assert.True(trackedBranch.IsRemote);
+
+                Branch branch = repo.CreateBranch(testBranchName, trackedBranch.Tip);
                 Assert.False(branch.IsTracking);
 
-                Branch trackedBranch = repo.Branches[trackedBranchName];
                 Branch updatedBranch = repo.Branches.Update(branch,
                     b => b.Remote = remoteName,
                     b => b.UpstreamBranch = upstreamBranchName);
@@ -773,10 +777,11 @@ namespace LibGit2Sharp.Tests
             string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
-                Branch branch = repo.CreateBranch(testBranchName);
-                Assert.False(branch.IsTracking);
-
                 Branch trackedBranch = repo.Branches[localTrackedBranchName];
+                Assert.False(trackedBranch.IsRemote);
+
+                Branch branch = repo.CreateBranch(testBranchName, trackedBranch.Tip);
+                Assert.False(branch.IsTracking);
 
                 repo.Branches.Update(branch,
                     b => b.TrackedBranch = trackedBranch.CanonicalName);
@@ -811,11 +816,13 @@ namespace LibGit2Sharp.Tests
             string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
-                Branch branch = repo.CreateBranch(testBranchName);
+                Branch trackedBranch = repo.Branches[trackedBranchName];
+
+                Branch branch = repo.CreateBranch(testBranchName, trackedBranch.Tip);
                 Assert.False(branch.IsTracking);
 
                 branch = repo.Branches.Update(branch,
-                    b => b.TrackedBranch = trackedBranchName);
+                    b => b.TrackedBranch = trackedBranch.CanonicalName);
 
                 // Got the updated branch from the Update() method
                 Assert.True(branch.IsTracking);


### PR DESCRIPTION
Although that's not what they exercise, some of those tests are used in order to get some guidance regarding the creation of a local branch from a remote tracking branch. And the way they're wrote actually is misleading in the sense that the created local branch point to HEAD.

This PR is an attempt at making this more clear to the reader.

Related to #903