### PR TITLE
Expose more low level Index operations

### DIFF
--- a/LibGit2Sharp.Tests/IndexFixture.cs
+++ b/LibGit2Sharp.Tests/IndexFixture.cs
@@ -412,6 +412,25 @@ namespace LibGit2Sharp.Tests
         }
 
         [Fact]
+        public void CanAddAnEntryToTheIndexFromABlob()
+        {
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
+            {
+                const string targetIndexEntryPath = "1.txt";
+                var before = repo.RetrieveStatus(targetIndexEntryPath);
+                Assert.Equal(FileStatus.Unaltered, before);
+
+                var blob = repo.Lookup<Blob>("a8233120f6ad708f843d861ce2b7228ec4e3dec6");
+
+                repo.Index.Add(blob, targetIndexEntryPath, Mode.NonExecutableFile);
+
+                var after = repo.RetrieveStatus(targetIndexEntryPath);
+                Assert.Equal(FileStatus.Staged | FileStatus.Modified, after);
+            }
+        }
+
+        [Fact]
         public void AddingAnEntryToTheIndexFromAUnknwonFileInTheWorkdirThrows()
         {
             var path = SandboxStandardTestRepoGitDir();

--- a/LibGit2Sharp.Tests/IndexFixture.cs
+++ b/LibGit2Sharp.Tests/IndexFixture.cs
@@ -373,5 +373,24 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(FileStatus.Removed | FileStatus.Untracked, repo.RetrieveStatus(testFile));
             }
         }
+
+        [Theory]
+        [InlineData("new_tracked_file.txt", FileStatus.Added, FileStatus.Untracked)]
+        [InlineData("modified_staged_file.txt", FileStatus.Staged, FileStatus.Removed | FileStatus.Untracked)]
+        [InlineData("i_dont_exist.txt", FileStatus.Nonexistent, FileStatus.Nonexistent)]
+        public void CanRemoveAnEntryFromTheIndex(string pathInTheIndex, FileStatus expectedBeforeStatus, FileStatus expectedAfterStatus)
+        {
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
+            {
+                var before = repo.RetrieveStatus(pathInTheIndex);
+                Assert.Equal(expectedBeforeStatus, before);
+
+                repo.Index.Remove(pathInTheIndex);
+
+                var after = repo.RetrieveStatus(pathInTheIndex);
+                Assert.Equal(expectedAfterStatus, after);
+            }
+        }
     }
 }

--- a/LibGit2Sharp.Tests/IndexFixture.cs
+++ b/LibGit2Sharp.Tests/IndexFixture.cs
@@ -392,5 +392,37 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(expectedAfterStatus, after);
             }
         }
+
+        [Theory]
+        [InlineData("new_untracked_file.txt", FileStatus.Untracked, FileStatus.Added)]
+        [InlineData("modified_unstaged_file.txt", FileStatus.Modified, FileStatus.Staged)]
+        public void CanAddAnEntryToTheIndexFromAFileInTheWorkdir(string pathInTheWorkdir, FileStatus expectedBeforeStatus, FileStatus expectedAfterStatus)
+        {
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
+            {
+                var before = repo.RetrieveStatus(pathInTheWorkdir);
+                Assert.Equal(expectedBeforeStatus, before);
+
+                repo.Index.Add(pathInTheWorkdir);
+
+                var after = repo.RetrieveStatus(pathInTheWorkdir);
+                Assert.Equal(expectedAfterStatus, after);
+            }
+        }
+
+        [Fact]
+        public void AddingAnEntryToTheIndexFromAUnknwonFileInTheWorkdirThrows()
+        {
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
+            {
+                const string filePath = "i_dont_exist.txt";
+                var before = repo.RetrieveStatus(filePath);
+                Assert.Equal(FileStatus.Nonexistent, before);
+
+                Assert.Throws<NotFoundException>(() => repo.Index.Add(filePath));
+            }
+        }
     }
 }

--- a/LibGit2Sharp/Index.cs
+++ b/LibGit2Sharp/Index.cs
@@ -178,6 +178,26 @@ namespace LibGit2Sharp
             UpdatePhysicalIndex();
         }
 
+        /// <summary>
+        /// Adds a file from the workdir in the <see cref="Index"/>.
+        /// <para>
+        ///   If an entry with the same path already exists in the <see cref="Index"/>,
+        ///   the newly added one will overwrite it.
+        /// </para>
+        /// </summary>
+        /// <param name="pathInTheWorkdir">The path, in the working directory, of the file to be added.</param>
+        public virtual void Add(string pathInTheWorkdir)
+        {
+            if (pathInTheWorkdir == null)
+            {
+                throw new ArgumentNullException("pathInTheWorkdir");
+            }
+
+            Proxy.git_index_add_bypath(handle, pathInTheWorkdir);
+
+            UpdatePhysicalIndex();
+        }
+
         private void UpdatePhysicalIndex()
         {
             Proxy.git_index_write(handle);

--- a/LibGit2Sharp/Index.cs
+++ b/LibGit2Sharp/Index.cs
@@ -157,11 +157,9 @@ namespace LibGit2Sharp
             UpdatePhysicalIndex();
         }
 
-        private string RemoveFromIndex(string relativePath)
+        private void RemoveFromIndex(string relativePath)
         {
             Proxy.git_index_remove_bypath(handle, relativePath);
-
-            return relativePath;
         }
 
         private void UpdatePhysicalIndex()

--- a/LibGit2Sharp/Index.cs
+++ b/LibGit2Sharp/Index.cs
@@ -162,6 +162,22 @@ namespace LibGit2Sharp
             Proxy.git_index_remove_bypath(handle, relativePath);
         }
 
+        /// <summary>
+        /// Removes a specified entry from the index.
+        /// </summary>
+        /// <param name="indexEntryPath">The path of the <see cref="Index"/> entry to be removed.</param>
+        public virtual void Remove(string indexEntryPath)
+        {
+            if (indexEntryPath == null)
+            {
+                throw new ArgumentNullException("indexEntryPath");
+            }
+
+            RemoveFromIndex(indexEntryPath);
+
+            UpdatePhysicalIndex();
+        }
+
         private void UpdatePhysicalIndex()
         {
             Proxy.git_index_write(handle);


### PR DESCRIPTION
Besides adding/removing index entries by paths, this also introduces a way to add to the `Index` a `Blob`. 

This should facilitate scenarios such as partial staging (#195) for instance.

An additional commit contains a test that demonstrates how to perform a `git add --all` and some code to fix the current implementation of `repo.Stage()`.