### PR TITLE
PullOptions: Introduce `Fetch` option

### DIFF
--- a/LibGit2Sharp/Network.cs
+++ b/LibGit2Sharp/Network.cs
@@ -343,7 +343,11 @@ namespace LibGit2Sharp
                 throw new LibGit2SharpException("No upstream remote for the current branch.");
             }
 
-            Fetch(currentBranch.Remote, options.FetchOptions);
+            if (options.Fetch)
+            {
+                Fetch(currentBranch.Remote, options.FetchOptions);
+            }
+
             return repository.MergeFetchHeads(merger, options.MergeOptions);
         }
 

--- a/LibGit2Sharp/PullOptions.cs
+++ b/LibGit2Sharp/PullOptions.cs
@@ -14,7 +14,17 @@ namespace LibGit2Sharp
         /// Constructor.
         /// </summary>
         public PullOptions()
-        { }
+        {
+            Fetch = true;
+        }
+
+        /// <summary>
+        /// Whether a fetch should be performed or not.  This is true by
+        /// default, meaning a pull will perform a fetch then merge the
+        /// branch that was fetched.  If you have previously performed a
+        /// fetch yourself and want to merge that data, this may be false.
+        /// </summary>
+        public bool Fetch { get; set; }
 
         /// <summary>
         /// Parameters controlling Fetch behavior.


### PR DESCRIPTION
Introduce a `Fetch` option to `Pull` so that one can perform the mechanics of a `Pull` except the actual fetching from the remote.  This allows one to break up the fetch and the merge portion of the pull into two separate steps, which might be helpful if you execute code in some executor that wants to split network-heavy and filesystem-heavy operations up into two different contexts.