### PR TITLE
Lazily load the index

### DIFF
--- a/LibGit2Sharp.Tests/RepositoryOptionsFixture.cs
+++ b/LibGit2Sharp.Tests/RepositoryOptionsFixture.cs
@@ -53,6 +53,18 @@ namespace LibGit2Sharp.Tests
         }
 
         [Fact]
+        public void CanOpenABareRepoWithOptions()
+        {
+            var options = new RepositoryOptions { GlobalConfigurationLocation = null };
+
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path, options))
+            {
+                Assert.True(repo.Info.IsBare);
+            }
+        }
+
+        [Fact]
         public void CanProvideADifferentWorkDirToAStandardRepo()
         {
             var path1 = SandboxStandardTestRepo();

--- a/LibGit2Sharp/Repository.cs
+++ b/LibGit2Sharp/Repository.cs
@@ -76,7 +76,10 @@ namespace LibGit2Sharp
                             "When overriding the opening of a bare repository, both RepositoryOptions.WorkingDirectoryPath an RepositoryOptions.IndexPath have to be provided.");
                     }
 
-                    isBare = false;
+                    if (!isWorkDirNull)
+                    {
+                        isBare = false;
+                    }
 
                     if (!isIndexNull)
                     {


### PR DESCRIPTION
We perform a number of operations on a repo without actually needing to open the index.  On a very large repository, not bothering to read the index can be a minor but helpful perf gain.