### PR TITLE
Prevent the git_trace callback from being garbage collected

### DIFF
--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -2959,6 +2959,18 @@ namespace LibGit2Sharp.Core
 
         #region git_trace_
 
+        /// <summary>
+        /// Install/Enable logging inside of LibGit2 to send messages back to LibGit2Sharp.
+        ///
+        /// Since the given callback will be passed into and retained by C code,
+        /// it is very important that you pass an actual delegate here (and don't
+        /// let the compiler create/cast a temporary one for you).  Furthermore, you
+        /// must hold a reference to this delegate until you turn off logging.
+        ///
+        /// This callback is unlike other callbacks because logging persists in the
+        /// process until disabled; in contrast, most callbacks are only defined for
+        /// the duration of the down-call.
+        /// </summary>
         public static void git_trace_set(LogLevel level, NativeMethods.git_trace_cb callback)
         {
             using (ThreadAffinity())

--- a/LibGit2Sharp/GlobalSettings.cs
+++ b/LibGit2Sharp/GlobalSettings.cs
@@ -97,7 +97,7 @@ namespace LibGit2Sharp
                 }
                 else
                 {
-                    Proxy.git_trace_set(value.Level, value.GitTraceHandler);
+                    Proxy.git_trace_set(value.Level, value.GitTraceCallback);
 
                     Log.Write(LogLevel.Info, "Logging enabled at level {0}", value.Level);
                 }

--- a/LibGit2Sharp/LogConfiguration.cs
+++ b/LibGit2Sharp/LogConfiguration.cs
@@ -27,6 +27,9 @@ namespace LibGit2Sharp
 
             Level = level;
             Handler = handler;
+
+            // Explicitly create (and hold a reference to) a callback-delegate to wrap GitTraceHandler().
+            GitTraceCallback = GitTraceHandler;
         }
 
         private LogConfiguration()
@@ -35,8 +38,14 @@ namespace LibGit2Sharp
 
         internal LogLevel Level { get; private set; }
         internal LogHandler Handler { get; private set; }
+        internal NativeMethods.git_trace_cb GitTraceCallback { get; private set; }
 
-        internal void GitTraceHandler(LogLevel level, IntPtr msg)
+        /// <summary>
+        /// This private method will be called from LibGit2 (from C code via
+        /// the GitTraceCallback delegate) to route LibGit2 log messages to
+        /// the same LogHandler as LibGit2Sharp messages.
+        /// </summary>
+        private void GitTraceHandler(LogLevel level, IntPtr msg)
         {
             string message = LaxUtf8Marshaler.FromNative(msg);
             Handler(level, message);


### PR DESCRIPTION
Here is a better fix for the problem with the git_trace_cb being GC'd.

Thanks to @jamill for the suggestion that the call in GlobalSettings to Proxy.git_trace_set() might be secretly creating a temporary delegate for the GitTraceHandler method.