### PR TITLE
Make GlobalSettings.Version rely on the AssemblyInformationalVersion data

### DIFF
--- a/LibGit2Sharp.Tests/GlobalSettingsFixture.cs
+++ b/LibGit2Sharp.Tests/GlobalSettingsFixture.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+﻿using System;
+using System.Text.RegularExpressions;
 using LibGit2Sharp.Tests.TestHelpers;
 using Xunit;
 
@@ -26,26 +27,31 @@ namespace LibGit2Sharp.Tests
             string versionInfo = GlobalSettings.Version.ToString();
 
             // The GlobalSettings.Version returned string should contain :
-            //      version:'0.17.0' LibGit2Sharp version number.
+            //      version: '0.17.0[.198[-pre]]' LibGit2Sharp version number.
             //      git2SharpHash:'unknown' ( when compiled from source ) else LibGit2Sharp library hash.
             //      git2hash: '06d772d' LibGit2 library hash.
             //      arch: 'x86' or 'amd64' LibGit2 target.
             //      git2Features: 'Threads, Ssh' LibGit2 features compiled with.
-            string regex = @"^(?<version>\d{1,}\.\d{1,2}\.\d{1,3})-(?<git2SharpHash>\w+)-(?<git2Hash>\w+) \((?<arch>\w+) - (?<git2Features>(?:\w*(?:, )*\w+)*)\)$";
+            string regex = @"^(?<version>\d{1,}\.\d{1,2}\.\d{1,3}(\.\d{1,5}(-pre)?)?)-(?<git2SharpHash>\w+)-(?<git2Hash>\w+) \((?<arch>\w+) - (?<git2Features>(?:\w*(?:, )*\w+)*)\)$";
 
             Assert.NotNull(versionInfo);
 
             Match regexResult = Regex.Match(versionInfo, regex);
 
             Assert.True(regexResult.Success, "The following version string format is enforced:" +
-                                             "Major.Minor.Patch-LibGit2Sharp_abbrev_hash-libgit2_abbrev_hash (x86|amd64 - features)");
+                                             "Major.Minor.Patch[.Build['-pre']]-LibGit2Sharp_abbrev_hash-libgit2_abbrev_hash (x86|amd64 - features)");
 
             GroupCollection matchGroups = regexResult.Groups;
 
             // Check that all groups are valid
-            foreach (Group group in matchGroups)
+            for (int i = 0; i < matchGroups.Count; i++)
             {
-                Assert.True(group.Success);
+                if (i == 1 || i == 2) // Build number and '-pre' are optional
+                {
+                    continue;
+                }
+
+                Assert.True(matchGroups[i].Success);
             }
         }
     }

--- a/LibGit2Sharp/Version.cs
+++ b/LibGit2Sharp/Version.cs
@@ -1,5 +1,7 @@
-﻿using System.Globalization;
+﻿using System;
+using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using LibGit2Sharp.Core;
 
@@ -24,14 +26,30 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
-        /// Returns the <see cref="System.Version" /> of the 
+        /// Returns the <see cref="System.Version" /> of the
         /// the LibGit2Sharp library.
         /// </summary>
+        [Obsolete("This property will be removed in the next release. Please use InformationalVersion instead.")]
         public virtual System.Version MajorMinorPatch
         {
             get
             {
                 return assembly.GetName().Version;
+            }
+        }
+
+        /// <summary>
+        /// Returns version of the LibGit2Sharp library.
+        /// </summary>
+        public virtual string InformationalVersion
+        {
+            get
+            {
+                var attribute = (AssemblyInformationalVersionAttribute)assembly
+                   .GetCustomAttributes(typeof(AssemblyInformationalVersionAttribute), false)
+                   .Single();
+
+                return attribute.InformationalVersion;
             }
         }
 
@@ -49,7 +67,7 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
-        /// Returns the SHA hash for the libgit2 library. 
+        /// Returns the SHA hash for the libgit2 library.
         /// </summary>
         public virtual string LibGit2CommitSha
         {
@@ -90,7 +108,7 @@ namespace LibGit2Sharp
             return string.Format(
                 CultureInfo.InvariantCulture,
                 "{0}-{1}-{2} ({3} - {4})",
-                MajorMinorPatch.ToString(3),
+                InformationalVersion,
                 LibGit2SharpCommitSha,
                 LibGit2CommitSha,
                 NativeMethods.ProcessorArchitecture,

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,9 +33,9 @@ install:
     $Version = "$($Env:APPVEYOR_BUILD_VERSION)$($VersionSuffix)"
     $Env:ASSEMBLY_INFORMATIONAL_VERSION = $Version
     Write-Host "Assembly informational version = $($Env:ASSEMBLY_INFORMATIONAL_VERSION)"
-    $ShouldBuildNuget = "$($env:APPVEYOR_PULL_REQUEST_NUMBER -eq $null)"
-    $Env:SHOULD_BUILD_NUGET = $ShouldBuildNuget
-    Write-Host "Should build Nuget = $($Env:SHOULD_BUILD_NUGET)"
+    $ShouldPublishNugetArtifact = "$($env:APPVEYOR_PULL_REQUEST_NUMBER -eq $null)"
+    $Env:SHOULD_PUBLISH_NUGET_ARTIFACT = $ShouldPublishNugetArtifact
+    Write-Host "Should publish Nuget artifact = $($Env:SHOULD_PUBLISH_NUGET_ARTIFACT)"
 
 assembly_info:
   patch: true
@@ -59,9 +59,10 @@ test_script:
 
 on_success:
 - ps: |
-    If ($Env:SHOULD_BUILD_NUGET -eq $True)
+- ps: |
+    & "C:\projects\libgit2sharp\nuget.package\BuildNugetPackage.ps1" "$env:APPVEYOR_REPO_COMMIT"
+    If ($Env:SHOULD_PUBLISH_NUGET_ARTIFACT -eq $True)
     {
-      & "C:\projects\libgit2sharp\nuget.package\BuildNugetPackage.ps1" "$env:APPVEYOR_REPO_COMMIT"
       Get-ChildItem "C:\projects\libgit2sharp\LibGit2sharp\*.nupkg" | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
     }
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,6 +61,8 @@ on_success:
 - ps: |
 - ps: |
     & "C:\projects\libgit2sharp\nuget.package\BuildNugetPackage.ps1" "$env:APPVEYOR_REPO_COMMIT"
+    Add-Type -Path "C:\projects\libgit2sharp\LibGit2Sharp\bin\Release\LibGit2Sharp.dll"
+    Write-Host "LibGit2Sharp version = $([LibGit2Sharp.GlobalSettings]::Version)" -ForegroundColor "Magenta"
     If ($Env:SHOULD_PUBLISH_NUGET_ARTIFACT -eq $True)
     {
       Get-ChildItem "C:\projects\libgit2sharp\LibGit2sharp\*.nupkg" | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }


### PR DESCRIPTION
Now that #911 is merged, let's make sure to display the correct information