### PR TITLE
Trying to fetch all tags fails

### DIFF
--- a/LibGit2Sharp.Tests/FetchFixture.cs
+++ b/LibGit2Sharp.Tests/FetchFixture.cs
@@ -16,7 +16,9 @@ namespace LibGit2Sharp.Tests
         [InlineData("git://github.com/libgit2/TestGitRepository.git")]
         public void CanFetchIntoAnEmptyRepository(string url)
         {
-            using (var repo = InitIsolatedRepository())
+            string path = InitNewRepository();
+
+            using (var repo = new Repository(path))
             {
                 Remote remote = repo.Network.Remotes.Add(remoteName, url);
 
@@ -53,7 +55,9 @@ namespace LibGit2Sharp.Tests
             InconclusiveIf(() => string.IsNullOrEmpty(Constants.PrivateRepoUrl),
                 "Populate Constants.PrivateRepo* to run this test");
 
-            using (var repo = InitIsolatedRepository())
+            string path = InitNewRepository();
+
+            using (var repo = new Repository(path))
             {
                 Remote remote = repo.Network.Remotes.Add(remoteName, Constants.PrivateRepoUrl);
 
@@ -71,7 +75,9 @@ namespace LibGit2Sharp.Tests
         [InlineData("git://github.com/libgit2/TestGitRepository.git")]
         public void CanFetchAllTagsIntoAnEmptyRepository(string url)
         {
-            using (var repo = InitIsolatedRepository())
+            string path = InitNewRepository();
+
+            using (var repo = new Repository(path))
             {
                 Remote remote = repo.Network.Remotes.Add(remoteName, url);
 
@@ -112,7 +118,9 @@ namespace LibGit2Sharp.Tests
         [InlineData("git://github.com/libgit2/TestGitRepository.git", "master", "first-merge")]
         public void CanFetchCustomRefSpecsIntoAnEmptyRepository(string url, string localBranchName, string remoteBranchName)
         {
-            using (var repo = InitIsolatedRepository())
+            string path = InitNewRepository();
+
+            using (var repo = new Repository(path))
             {
                 Remote remote = repo.Network.Remotes.Add(remoteName, url);
 
@@ -147,7 +155,9 @@ namespace LibGit2Sharp.Tests
         {
             string url = "http://github.com/libgit2/TestGitRepository";
 
-            using (var repo = InitIsolatedRepository())
+            string path = InitNewRepository();
+
+            using (var repo = new Repository(path))
             {
                 Remote remote = repo.Network.Remotes.Add(remoteName, url);
                 Assert.NotNull(remote);

--- a/LibGit2Sharp.Tests/FetchFixture.cs
+++ b/LibGit2Sharp.Tests/FetchFixture.cs
@@ -173,5 +173,20 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(expectedTagCount, repo.Tags.Count());
             }
         }
+
+        [Fact]
+        public void CanFetchAllTagsAfterAnInitialClone()
+        {
+            var scd = BuildSelfCleaningDirectory();
+
+            const string url = "https://github.com/libgit2/TestGitRepository";
+
+            string clonedRepoPath = Repository.Clone(url, scd.DirectoryPath);
+
+            using (var repo = new Repository(clonedRepoPath))
+            {
+                repo.Fetch("origin", new FetchOptions { TagFetchMode = TagFetchMode.All });
+            }
+        }
     }
 }

--- a/LibGit2Sharp.Tests/FetchFixture.cs
+++ b/LibGit2Sharp.Tests/FetchFixture.cs
@@ -147,10 +147,10 @@ namespace LibGit2Sharp.Tests
             }
         }
 
-        [Theory(Skip = "Skipping due to recent github handling modification of --include-tag.")]
+        [Theory]
         [InlineData(TagFetchMode.All, 4)]
         [InlineData(TagFetchMode.None, 0)]
-        [InlineData(TagFetchMode.Auto, 3)]
+        //[InlineData(TagFetchMode.Auto, 3)] // TODO: Skipping due to github modification of --include-tag handling."
         public void FetchRespectsConfiguredAutoTagSetting(TagFetchMode tagFetchMode, int expectedTagCount)
         {
             string url = "http://github.com/libgit2/TestGitRepository";


### PR DESCRIPTION
Related to this: http://stackoverflow.com/questions/28091482/how-to-pull-all-new-tags-using-libgit2sharp

Essentially I would like to use libgit2sharp to achieve 'git pull --tags'
I am using libgit2sharp 0.20.2

Here is a sample which fails for me:

    static void Main(string[] args)
    {
        const string haskellMode = "https://github.com/haskell/haskell-mode.git";

        var guid = Guid.NewGuid().ToString();
        var wdir = string.Format("%TEMP%/git-fetch-tags-{0}", guid);
        wdir = Environment.ExpandEnvironmentVariables(wdir);

        var sig = new Signature("hendrik", "hendrik@somemail.ee", new DateTimeOffset());
            
        var repoWithTags = Repository.Clone(haskellMode, wdir);
        Console.WriteLine(repoWithTags);

        using (var repo = new Repository(repoWithTags))
        {
            // this one works, but if there are any new tags in the remote it does not get them
            repo.Network.Pull(sig, new PullOptions());

            // this one throws
            repo.Network.Pull(sig, new PullOptions { FetchOptions = new FetchOptions { TagFetchMode = TagFetchMode.All } });

            // this one also throws but I think it manages to get the tags
            repo.Fetch("origin", new FetchOptions { TagFetchMode = TagFetchMode.All });

            Console.WriteLine("Done for {0}", haskellMode);
        }
            
        Console.ReadLine();
    }