### PR TITLE
add support for testing merge conflicts

### DIFF
--- a/LibGit2Sharp.Tests/ObjectDatabaseFixture.cs
+++ b/LibGit2Sharp.Tests/ObjectDatabaseFixture.cs
@@ -654,6 +654,50 @@ namespace LibGit2Sharp.Tests
             }
         }
 
+        [Fact]
+        public void TestMergeIntoSelfHasNoConflicts()
+        {
+            string path = SandboxMergeTestRepo();
+            using (var repo = new Repository(path))
+            {
+                var master = repo.Lookup<Commit>("master");
+
+                var result = repo.ObjectDatabase.CanMergeWithoutConflict(master, master);
+
+                Assert.True(result);
+            }
+        }
+
+        [Fact]
+        public void TestMergeIntoOtherBranchHasNoConflicts()
+        {
+            string path = SandboxMergeTestRepo();
+            using (var repo = new Repository(path))
+            {
+                var master = repo.Lookup<Commit>("master");
+                var branch = repo.Lookup<Commit>("fast_forward");
+
+                var result = repo.ObjectDatabase.CanMergeWithoutConflict(master, branch);
+
+                Assert.True(result);
+            }
+        }
+
+        [Fact]
+        public void TestMergeIntoWrongBranchHasConflicts()
+        {
+            string path = SandboxMergeTestRepo();
+            using (var repo = new Repository(path))
+            {
+                var master = repo.Lookup<Commit>("master");
+                var branch = repo.Lookup<Commit>("conflicts");
+
+                var result = repo.ObjectDatabase.CanMergeWithoutConflict(master, branch);
+
+                Assert.False(result);
+            }
+        }
+
         private static Blob CreateBlob(Repository repo, string content)
         {
             using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(content)))

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -679,6 +679,15 @@ namespace LibGit2Sharp.Core
             ref GitCheckoutOpts checkout_opts);
 
         [DllImport(libgit2)]
+        internal static extern int git_merge_trees(
+            out IndexSafeHandle index,
+            RepositorySafeHandle repo,
+            GitObjectSafeHandle ancestor_tree,
+            GitObjectSafeHandle our_tree,
+            GitObjectSafeHandle their_tree,
+            ref GitMergeOpts merge_opts);
+
+        [DllImport(libgit2)]
         internal static extern int git_merge_analysis(
             out GitMergeAnalysis status_out,
             out GitMergePreference preference_out,

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -1074,6 +1074,22 @@ namespace LibGit2Sharp.Core
 
         #region git_merge_
 
+        public static IndexSafeHandle git_merge_trees(RepositorySafeHandle repo, GitObjectSafeHandle ancestorTree, GitObjectSafeHandle ourTree, GitObjectSafeHandle theirTree)
+        {
+            using (ThreadAffinity())
+            {
+                IndexSafeHandle index;
+                GitMergeOpts opts = new GitMergeOpts { Version = 1 };
+                int res = NativeMethods.git_merge_trees(out index, repo, ancestorTree, ourTree, theirTree, ref opts);
+                if (res != (int) GitErrorCode.Ok || index == null)
+                {
+                    return null;
+                }
+
+                return index;
+            }
+        }
+
         public static ObjectId git_merge_base_many(RepositorySafeHandle repo, GitOid[] commitIds)
         {
             using (ThreadAffinity())


### PR DESCRIPTION
Fixes #628

- ~~[ ] helper functions to simplify discovering trees?~~ just use `Commit`
- [x] other scenarios to test?
- [x] correct rebase to drop `Repository.Version`
- [x] clean up history

A couple of questions for reviewers:

 - ~~we kept the API as low-level as possible - should we add overloads to lookup by a `commitish` string?~~ switched over to use `Commit` instead of `Tree`
 - ~~the `bool` returned from the API, is that enough detail?~~ perhaps a more detailed API in the future
 - i tested the basic scenarios of "self merge", "clean merge" and "merge with conflicts" - can you think of any others we should include here?