### PR TITLE
add support for running tests inside Visual Studio

### DIFF
--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="xunit.runners" version="1.9.2" />
 </packages>

--- a/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
+++ b/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\xunit.runner.visualstudio.2.0.0-rc1-build1030\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.0.0-rc1-build1030\build\net20\xunit.runner.visualstudio.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -139,6 +140,12 @@
     <PreBuildEvent>
     </PreBuildEvent>
   </PropertyGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.0.0-rc1-build1030\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.0.0-rc1-build1030\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/LibGit2Sharp.Tests/packages.config
+++ b/LibGit2Sharp.Tests/packages.config
@@ -3,4 +3,5 @@
   <package id="Moq" version="4.2.1409.1722" targetFramework="net40" />
   <package id="xunit" version="1.9.2" targetFramework="net40" />
   <package id="xunit.extensions" version="1.9.2" targetFramework="net40" />
+  <package id="xunit.runner.visualstudio" version="2.0.0-rc1-build1030" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
For the longest time, there's been a VSIX available to run your xUnit tests in VS (2012+). 

Now they've switched over to using the NuGet-based option. You may think this requires upgrading to xUnit 2.0, but that's not necessary - it works with xUnit 1.0 tests as well.

This saved me a lot of time digging into the tests I was writing for #938, so hopefully it can help someone else out!

In VS2013 Update 4:

![screen shot 2015-01-30 at 4 56 51 pm](https://cloud.githubusercontent.com/assets/359239/5971768/139bb4a8-a8a1-11e4-9071-2a4d436afe23.png)

```
------ Run test started ------
========== Run test finished: 992 run (0:06:28.0184151) ==========
```



