### PR TITLE
Adds a FileConflictStrategy property to CheckoutOptions

### DIFF
--- a/LibGit2Sharp/CheckoutOptions.cs
+++ b/LibGit2Sharp/CheckoutOptions.cs
@@ -20,6 +20,11 @@ namespace LibGit2Sharp
         public CheckoutNotifyFlags CheckoutNotifyFlags { get; set; }
 
         /// <summary>
+        /// How conflicting index entries should be written out during checkout.
+        /// </summary>
+        public CheckoutFileConflictStrategy FileConflictStrategy { get; set; }
+
+        /// <summary>
         /// Delegate to be called during checkout for files that match
         /// desired filter specified with the NotifyFlags property.
         /// </summary>
@@ -34,8 +39,16 @@ namespace LibGit2Sharp
         {
             get
             {
-                return CheckoutModifiers.HasFlag(CheckoutModifiers.Force) ?
-                    CheckoutStrategy.GIT_CHECKOUT_FORCE : CheckoutStrategy.GIT_CHECKOUT_SAFE;
+                var strategy = GitCheckoutOptsWrapper.CheckoutStrategyFromFileConflictStrategy(FileConflictStrategy);
+                if (strategy != default(CheckoutStrategy))
+                    return CheckoutModifiers.HasFlag(CheckoutModifiers.Force)
+                        ? CheckoutStrategy.GIT_CHECKOUT_FORCE | strategy
+                        : strategy;
+
+                if (CheckoutModifiers.HasFlag(CheckoutModifiers.Force))
+                    return CheckoutStrategy.GIT_CHECKOUT_FORCE;
+
+                return CheckoutStrategy.GIT_CHECKOUT_SAFE;
             }
         }
 


### PR DESCRIPTION
PR for #868 

This is my initial implementation of using a FileConflictStrategy to select Ours/Theirs for Paths upon Checkout. But I'm wondering if it would make _(more)_ sense to make an overload for `CheckoutPaths` that accepts an Ours/Theirs (enum) instead of `CheckoutOptions` with a `FileConflictStrategy` property.
One thing that bugs me about `CheckoutPaths` is that you can pass it a "committishOrBranchSpec" that doesn't correspond to the `FileConflictStrategy` property and you'd thus get an unexpected result (ie. pass the branch spec for the currently checked out branch and `FileConflictStrategy.Theirs`).

Wouldn't it be easier if it was possible to pass a list of `Conflict` objects along with an Ours/Theirs enum to `CheckoutPaths` - or a list of `IndexEntry` objects and an Ours/Theirs enum  - if it is in fact possible to get the correct `Tree` from the `IndexEntry.Id`(?).

@nulltoken whats your thoughts on this?
