### PR TITLE
Make version comply to SemVer

### DIFF
--- a/LibGit2Sharp.Tests/GlobalSettingsFixture.cs
+++ b/LibGit2Sharp.Tests/GlobalSettingsFixture.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
 using LibGit2Sharp.Tests.TestHelpers;
 using Xunit;
 
@@ -20,33 +19,35 @@ namespace LibGit2Sharp.Tests
         public void CanRetrieveValidVersionString()
         {
             // Version string format is:
-            //      Major.Minor.Patch-LibGit2Sharp_abbrev_hash-libgit2_abbrev_hash (x86|amd64 - features)
+            //      Major.Minor.Patch[-preDateTime]-LibGit2Sharp_abbrev_hash-libgit2_abbrev_hash (x86|amd64 - features)
             // Example output:
-            //      "0.17.0-unknown-06d772d (x86 - Threads, Https)"
+            //      "0.17.0[-pre20170914123547]-deadcafe-06d772d (x86 - Threads, Https)"
 
             string versionInfo = GlobalSettings.Version.ToString();
 
             // The GlobalSettings.Version returned string should contain :
-            //      version: '0.17.0[.198[-pre]]' LibGit2Sharp version number.
+            //      version: '0.17.0[-pre20170914123547]' LibGit2Sharp version number.
             //      git2SharpHash:'unknown' ( when compiled from source ) else LibGit2Sharp library hash.
             //      git2hash: '06d772d' LibGit2 library hash.
             //      arch: 'x86' or 'amd64' LibGit2 target.
             //      git2Features: 'Threads, Ssh' LibGit2 features compiled with.
-            string regex = @"^(?<version>\d{1,}\.\d{1,2}\.\d{1,3}(\.\d{1,5}(-pre)?)?)-(?<git2SharpHash>\w+)-(?<git2Hash>\w+) \((?<arch>\w+) - (?<git2Features>(?:\w*(?:, )*\w+)*)\)$";
+            string regex = @"^(?<version>\d{1,}\.\d{1,2}\.\d{1,3}(-(pre|dev)\d{14})?)-(?<git2SharpHash>\w+)-(?<git2Hash>\w+) \((?<arch>\w+) - (?<git2Features>(?:\w*(?:, )*\w+)*)\)$";
 
             Assert.NotNull(versionInfo);
 
             Match regexResult = Regex.Match(versionInfo, regex);
 
             Assert.True(regexResult.Success, "The following version string format is enforced:" +
-                                             "Major.Minor.Patch[.Build['-pre']]-LibGit2Sharp_abbrev_hash-libgit2_abbrev_hash (x86|amd64 - features)");
+                                             "Major.Minor.Patch[-preDateTime]-LibGit2Sharp_abbrev_hash-libgit2_abbrev_hash (x86|amd64 - features)");
 
             GroupCollection matchGroups = regexResult.Groups;
+
+            Assert.Equal(8, matchGroups.Count);
 
             // Check that all groups are valid
             for (int i = 0; i < matchGroups.Count; i++)
             {
-                if (i == 1 || i == 2) // Build number and '-pre' are optional
+                if (i == 1 || i == 2) // '-pre' segment is optional
                 {
                     continue;
                 }

--- a/LibGit2Sharp/Properties/AssemblyInfo.cs
+++ b/LibGit2Sharp/Properties/AssemblyInfo.cs
@@ -42,6 +42,6 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("0.21.0")]
-[assembly: AssemblyFileVersion("0.21.0")]
-[assembly: AssemblyInformationalVersion("0.21.0")]
+[assembly: AssemblyVersion("0.22.0")]
+[assembly: AssemblyFileVersion("0.22.0")]
+[assembly: AssemblyInformationalVersion("0.22.0-dev00000000000000")]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: '0.21.0.{build}'
+version: '{build}'
 
 branches:
   only:
@@ -10,6 +10,7 @@ skip_tags: true
 clone_folder: C:\projects\libgit2sharp
 
 environment:
+  version : 0.22.0
   matrix:
   - xunit_runner: xunit.console.clr4.exe
     Arch: 64
@@ -22,15 +23,17 @@ matrix:
 install:
 - ps: |
     Write-Host "Commit being built = $($Env:APPVEYOR_REPO_COMMIT)"
-    Write-Host "Current build version = $($Env:APPVEYOR_BUILD_VERSION)"
+    Write-Host "Current build version = $($Env:VERSION)"
     Write-Host "Target branch = $($Env:APPVEYOR_REPO_BRANCH)"
     Write-Host "Is a Pull Request = $($Env:APPVEYOR_PULL_REQUEST_NUMBER -ne $null)"
+    $BuildDate = (Get-Date).ToUniversalTime().ToString("yyyyMMddHHmmss")
+    Write-Host "Build UTC date = $BuildDate"
     $VersionSuffix = ""
     If ($Env:APPVEYOR_REPO_BRANCH -ne "master")
     {
-      $VersionSuffix = "-pre"
+      $VersionSuffix = "-pre$BuildDate"
     }
-    $Version = "$($Env:APPVEYOR_BUILD_VERSION)$($VersionSuffix)"
+    $Version = "$($Env:VERSION)$($VersionSuffix)"
     $Env:ASSEMBLY_INFORMATIONAL_VERSION = $Version
     Write-Host "Assembly informational version = $($Env:ASSEMBLY_INFORMATIONAL_VERSION)"
     $ShouldPublishNugetArtifact = "$($env:APPVEYOR_PULL_REQUEST_NUMBER -eq $null)"
@@ -40,8 +43,8 @@ install:
 assembly_info:
   patch: true
   file: LibGit2Sharp\Properties\AssemblyInfo.cs
-  assembly_version: '{version}'
-  assembly_file_version: '{version}'
+  assembly_version: '$(VERSION)'
+  assembly_file_version: '$(VERSION)'
   assembly_informational_version: '$(ASSEMBLY_INFORMATIONAL_VERSION)'
 
 cache:


### PR DESCRIPTION
Attempt at being more semver compliant.

With this change AssemblyInformationalVersion will contain:
- **Local builds:** `0.22.0-dev000000000000`
- **Pull Request builds:** `0.22.0-preDDDDDDDDDDDD`
- **Merges in vNext:** `0.22.0-preDDDDDDDDDDDD`
- **Merges in master:** `0.22.0`

where
 - `DDDDDDDDDDDD`: UTC datetime of the build (eg. 20150231203231)