### PR TITLE
Teach clone to recurse into submodules

### DIFF
--- a/LibGit2Sharp.Tests/TestHelpers/BaseFixture.cs
+++ b/LibGit2Sharp.Tests/TestHelpers/BaseFixture.cs
@@ -40,7 +40,7 @@ namespace LibGit2Sharp.Tests.TestHelpers
         public static string SubmoduleTestRepoWorkingDirPath { get; private set; }
         private static string SubmoduleTargetTestRepoWorkingDirPath { get; set; }
         private static string AssumeUnchangedRepoWorkingDirPath { get; set; }
-        private static string SubmoduleSmallTestRepoWorkingDirPath { get; set; }
+        public static string SubmoduleSmallTestRepoWorkingDirPath { get; set; }
 
         public static DirectoryInfo ResourcesDirectory { get; private set; }
 
@@ -71,7 +71,7 @@ namespace LibGit2Sharp.Tests.TestHelpers
             SubmoduleTestRepoWorkingDirPath = Path.Combine(sourceRelativePath, "submodule_wd");
             SubmoduleTargetTestRepoWorkingDirPath = Path.Combine(sourceRelativePath, "submodule_target_wd");
             AssumeUnchangedRepoWorkingDirPath = Path.Combine(sourceRelativePath, "assume_unchanged_wd");
-            SubmoduleSmallTestRepoWorkingDirPath = Path.Combine(ResourcesDirectory.FullName, "submodule_small_wd");
+            SubmoduleSmallTestRepoWorkingDirPath = Path.Combine(sourceRelativePath, "submodule_small_wd");
         }
 
         private static bool IsFileSystemCaseSensitiveInternal()
@@ -159,8 +159,7 @@ namespace LibGit2Sharp.Tests.TestHelpers
 
         public string SandboxSubmoduleSmallTestRepo()
         {
-            var submoduleTarget = Path.Combine(ResourcesDirectory.FullName, "submodule_target_wd");
-            var path = Sandbox(SubmoduleSmallTestRepoWorkingDirPath, submoduleTarget);
+            var path = Sandbox(SubmoduleSmallTestRepoWorkingDirPath, SubmoduleTargetTestRepoWorkingDirPath);
             Directory.CreateDirectory(Path.Combine(path, "submodule_target_wd"));
 
             return path;

--- a/LibGit2Sharp/CloneOptions.cs
+++ b/LibGit2Sharp/CloneOptions.cs
@@ -34,6 +34,11 @@ namespace LibGit2Sharp
         public string BranchName { get; set; }
 
         /// <summary>
+        /// Recursively clone submodules.
+        /// </summary>
+        public bool RecurseSubmodules { get; set; }
+
+        /// <summary>
         /// Handler for checkout progress information.
         /// </summary>
         public CheckoutProgressHandler OnCheckoutProgress { get; set; }

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -1362,6 +1362,12 @@ namespace LibGit2Sharp.Core
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath name);
 
         [DllImport(libgit2)]
+        internal static extern int git_submodule_resolve_url(
+            GitBuf buf,
+            RepositorySafeHandle repo,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string url);
+
+        [DllImport(libgit2)]
         internal static extern int git_submodule_update(
             SubmoduleSafeHandle sm,
             [MarshalAs(UnmanagedType.Bool)] bool init,

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -2811,6 +2811,18 @@ namespace LibGit2Sharp.Core
             }
         }
 
+        public static string git_submodule_resolve_url(RepositorySafeHandle repo, string url)
+        {
+            using (ThreadAffinity())
+            using (var buf = new GitBuf())
+            {
+                int res = NativeMethods.git_submodule_resolve_url(buf, repo, url);
+
+                Ensure.ZeroResult(res);
+                return LaxUtf8Marshaler.FromNative(buf.ptr);
+            }
+        }
+
         public static ICollection<TResult> git_submodule_foreach<TResult>(RepositorySafeHandle repo, Func<IntPtr, IntPtr, TResult> resultSelector)
         {
             return git_foreach(resultSelector, c => NativeMethods.git_submodule_foreach(repo, (x, y, p) => c(x, y, p), IntPtr.Zero));

--- a/LibGit2Sharp/FetchOptionsBase.cs
+++ b/LibGit2Sharp/FetchOptionsBase.cs
@@ -33,5 +33,15 @@ namespace LibGit2Sharp
         /// Handler to generate <see cref="LibGit2Sharp.Credentials"/> for authentication.
         /// </summary>
         public CredentialsHandler CredentialsProvider { get; set; }
+
+        /// <summary>
+        /// Starting to operate on a new repository.
+        /// </summary>
+        public RepositoryOperationStarting RepositoryOperationStarting { get; set; }
+
+        /// <summary>
+        /// Completed operating on the current repository.
+        /// </summary>
+        public RepositoryOperationCompleted RepositoryOperationCompleted { get; set; }
     }
 }

--- a/LibGit2Sharp/Handlers.cs
+++ b/LibGit2Sharp/Handlers.cs
@@ -1,4 +1,5 @@
-﻿namespace LibGit2Sharp.Handlers
+﻿using System;
+namespace LibGit2Sharp.Handlers
 {
     /// <summary>
     /// Delegate definition to handle Progress callback.
@@ -36,6 +37,21 @@
     /// <param name="progress">The <see cref="TransferProgress"/> object containing progress information.</param>
     /// <returns>True to continue, false to cancel.</returns>
     public delegate bool TransferProgressHandler(TransferProgress progress);
+
+    /// <summary>
+    /// Delegate definition to indicate that a repository is about to be operated on.
+    /// (In the context of a recursive operation).
+    /// </summary>
+    /// <param name="context">Context on the repository that is being operated on.</param>
+    /// <returns>true to continue, false to cancel.</returns>
+    public delegate bool RepositoryOperationStarting(RepositoryOperationContext context);
+
+    /// <summary>
+    /// Delegate definition to indicate that an operation is done in a repository.
+    /// (In the context of a recursive operation).
+    /// </summary>
+    /// <param name="context">Context on the repository that is being operated on.</param>
+    public delegate void RepositoryOperationCompleted(RepositoryOperationContext context);
 
     /// <summary>
     /// Delegate definition for callback reporting push network progress.

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -107,6 +107,7 @@
     <Compile Include="PatchStats.cs" />
     <Compile Include="PeelException.cs" />
     <Compile Include="PullOptions.cs" />
+    <Compile Include="RecurseSubmodulesException.cs" />
     <Compile Include="RefSpec.cs" />
     <Compile Include="RefSpecCollection.cs" />
     <Compile Include="Core\EncodingMarshaler.cs" />
@@ -123,6 +124,7 @@
     <Compile Include="Core\GitBuf.cs" />
     <Compile Include="FilteringOptions.cs" />
     <Compile Include="MergeFetchHeadNotFoundException.cs" />
+    <Compile Include="RepositoryOperationContext.cs" />
     <Compile Include="ResetMode.cs" />
     <Compile Include="NoteCollectionExtensions.cs" />
     <Compile Include="RefSpecDirection.cs" />

--- a/LibGit2Sharp/RecurseSubmodulesException.cs
+++ b/LibGit2Sharp/RecurseSubmodulesException.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace LibGit2Sharp
+{
+    /// <summary>
+    /// The exception that is thrown when an error is encountered while recursing
+    /// through submodules. The inner exception contains the exception that was
+    /// initially thrown while operating on the submodule.
+    /// </summary>
+    [Serializable]
+    public class RecurseSubmodulesException : LibGit2SharpException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RecurseSubmodulesException"/> class.
+        /// </summary>
+        public RecurseSubmodulesException()
+        {
+        }
+
+        /// <summary>
+        /// The path to the initial repository the operation was run on.
+        /// </summary>
+        public virtual string InitialRepositoryPath { get; private set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RecurseSubmodulesException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception. If the <paramref name="innerException"/> parameter is not a null reference, the current exception is raised in a catch block that handles the inner exception.</param>
+        /// <param name="initialRepositoryPath">The path to the initial repository the operation was performed on.</param>
+        public RecurseSubmodulesException(string message, Exception innerException, string initialRepositoryPath)
+            : base(message, innerException)
+        {
+            InitialRepositoryPath = initialRepositoryPath;
+        }
+    }
+}

--- a/LibGit2Sharp/RepositoryOperationContext.cs
+++ b/LibGit2Sharp/RepositoryOperationContext.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace LibGit2Sharp
+{
+    /// <summary>
+    /// Class to convey information about the repository that is being operated on
+    /// for operations that can recurse into submodules.
+    /// </summary>
+    public class RepositoryOperationContext
+    {
+        /// <summary>
+        /// Needed for mocking.
+        /// </summary>
+        protected RepositoryOperationContext()
+        { }
+
+        /// <summary>
+        /// Constructor suitable for use on the repository the main
+        /// operation is being run on (i.e. the super project, not a submodule).
+        /// </summary>
+        /// <param name="repositoryPath">The path of the repository being operated on.</param>
+        /// <param name="remoteUrl">The URL that this operation will download from.</param>
+        internal RepositoryOperationContext(string repositoryPath, string remoteUrl)
+            : this(repositoryPath, remoteUrl, string.Empty, string.Empty, 0)
+        {
+        }
+
+        /// <summary>
+        /// Constructor suitable for use on the sub repositories.
+        /// </summary>
+        /// <param name="repositoryPath">The path of the repository being operated on.</param>
+        /// <param name="remoteUrl">The URL that this operation will download from.</param>
+        /// <param name="parentRepositoryPath">The path to the super repository.</param>
+        /// <param name="submoduleName">The logical name of this submodule.</param>
+        /// <param name="recursionDepth">The depth of this sub repository from the original super repository.</param>
+        internal RepositoryOperationContext(string repositoryPath,
+                                            string remoteUrl,
+                                            string parentRepositoryPath,
+                                            string submoduleName, int recursionDepth)
+        {
+            RepositoryPath = repositoryPath;
+            RemoteUrl = remoteUrl;
+            ParentRepositoryPath = parentRepositoryPath;
+            SubmoduleName = submoduleName;
+            RecursionDepth = recursionDepth;
+        }
+
+        /// <summary>
+        /// If this is a submodule repository, the full path to the parent
+        /// repository. If this is not a submodule repository, then
+        /// this is empty.
+        /// </summary>
+        public virtual string ParentRepositoryPath { get; private set; }
+
+        /// <summary>
+        /// The recursion depth for the current repository being operated on
+        /// with respect to the repository the original operation was run
+        /// against. The initial repository has a recursion depth of 0,
+        /// the 1st level of subrepositories has a recursion depth of 1.
+        /// </summary>
+        public virtual int RecursionDepth { get; private set; }
+
+        /// <summary>
+        /// The remote URL this operation will work against, if any.
+        /// </summary>
+        public virtual string RemoteUrl { get; private set; }
+
+        /// <summary>
+        /// Full path of the repository.
+        /// </summary>
+        public virtual string RepositoryPath { get; private set; }
+
+        /// <summary>
+        /// The submodule's logical name in the parent repository, if this is a
+        /// submodule repository. If this is not a submodule repository, then
+        /// this is empty.
+        /// </summary>
+        public virtual string SubmoduleName { get; private set; }
+    }
+}


### PR DESCRIPTION
This is the basic outline to enable cloning with the option to recursively clone submodules. I wanted to put this up to get feedback on how the progress is reported through callbacks.

**Notes:**
This adds callbacks that are called before and after cloning a repository. The user has an opportunity to cancel the clone before starting a clone operation in a repository.