### PR TITLE
Kill Encoding.UTF8 whenever that makes sense

### DIFF
--- a/LibGit2Sharp/BlobExtensions.cs
+++ b/LibGit2Sharp/BlobExtensions.cs
@@ -22,10 +22,7 @@ namespace LibGit2Sharp
         {
             Ensure.ArgumentNotNull(blob, "blob");
 
-            using (var reader = new StreamReader(blob.GetContentStream(), encoding ?? Encoding.UTF8, encoding == null))
-            {
-                return reader.ReadToEnd();
-            }
+            return ReadToEnd(blob.GetContentStream, encoding);
         }
 
         /// <summary>
@@ -43,7 +40,12 @@ namespace LibGit2Sharp
             Ensure.ArgumentNotNull(blob, "blob");
             Ensure.ArgumentNotNull(filteringOptions, "filteringOptions");
 
-            using (var reader = new StreamReader(blob.GetContentStream(filteringOptions), encoding ?? Encoding.UTF8, encoding == null))
+            return ReadToEnd(() => blob.GetContentStream(filteringOptions), encoding);
+        }
+
+        private static string ReadToEnd(Func<Stream> streamProvider, Encoding encoding)
+        {
+            using (var reader = new StreamReader(streamProvider(), encoding ?? Encoding.UTF8, encoding == null))
             {
                 return reader.ReadToEnd();
             }

--- a/LibGit2Sharp/BlobExtensions.cs
+++ b/LibGit2Sharp/BlobExtensions.cs
@@ -22,7 +22,7 @@ namespace LibGit2Sharp
         {
             Ensure.ArgumentNotNull(blob, "blob");
 
-            return ReadToEnd(blob.GetContentStream, encoding);
+            return ReadToEnd(blob.GetContentStream(), encoding);
         }
 
         /// <summary>
@@ -40,12 +40,12 @@ namespace LibGit2Sharp
             Ensure.ArgumentNotNull(blob, "blob");
             Ensure.ArgumentNotNull(filteringOptions, "filteringOptions");
 
-            return ReadToEnd(() => blob.GetContentStream(filteringOptions), encoding);
+            return ReadToEnd(blob.GetContentStream(filteringOptions), encoding);
         }
 
-        private static string ReadToEnd(Func<Stream> streamProvider, Encoding encoding)
+        private static string ReadToEnd(Stream stream, Encoding encoding)
         {
-            using (var reader = new StreamReader(streamProvider(), encoding ?? Encoding.UTF8, encoding == null))
+            using (var reader = new StreamReader(stream, encoding ?? LaxUtf8Marshaler.Encoding, encoding == null))
             {
                 return reader.ReadToEnd();
             }

--- a/LibGit2Sharp/Core/Utf8Marshaler.cs
+++ b/LibGit2Sharp/Core/Utf8Marshaler.cs
@@ -91,9 +91,9 @@ namespace LibGit2Sharp.Core
     {
         private static readonly LaxUtf8Marshaler staticInstance = new LaxUtf8Marshaler();
 
-        private static readonly Encoding encoding = new UTF8Encoding(false, false);
+        public static readonly Encoding Encoding = new UTF8Encoding(false, false);
 
-        public LaxUtf8Marshaler() : base(encoding)
+        public LaxUtf8Marshaler() : base(Encoding)
         { }
 
         public static ICustomMarshaler GetInstance(String cookie)
@@ -113,22 +113,22 @@ namespace LibGit2Sharp.Core
 
         public static string FromNative(IntPtr pNativeData)
         {
-            return FromNative(encoding, pNativeData);
+            return FromNative(Encoding, pNativeData);
         }
 
         public static string FromNative(IntPtr pNativeData, int length)
         {
-            return FromNative(encoding, pNativeData, length);
+            return FromNative(Encoding, pNativeData, length);
         }
 
         public static string FromBuffer(byte[] buffer)
         {
-            return FromBuffer(encoding, buffer);
+            return FromBuffer(Encoding, buffer);
         }
 
         public static string FromBuffer(byte[] buffer, int length)
         {
-            return FromBuffer(encoding, buffer, length);
+            return FromBuffer(Encoding, buffer, length);
         }
     }
 }


### PR DESCRIPTION
In the LibGit2Sharp code, we shouldn't rely on `Encoding.UTF8` and rather prefer `LaxUtf8Marshaler.Encoding` when the data comes from the git repository or `StrictUtf8Marshaler.Encoding` when the data comes from the user.