### PR TITLE
Remote tracking branches pruning

### DIFF
--- a/LibGit2Sharp.Tests/RemoteFixture.cs
+++ b/LibGit2Sharp.Tests/RemoteFixture.cs
@@ -334,5 +334,43 @@ namespace LibGit2Sharp.Tests
                 Assert.Throws<NameConflictException>(() => repo.Network.Remotes.Rename("origin", "upstream"));
             }
         }
+
+        [Theory]
+        [InlineData(null, null, false)]
+        [InlineData(null, false, false)]
+        [InlineData(null, true, true)]
+        [InlineData(false, null, false)]
+        [InlineData(false, false, false)]
+        [InlineData(false, true, true)]
+        [InlineData(true, null, true)]
+        [InlineData(true, false, false)]
+        [InlineData(true, true, true)]
+        public void ShoudlPruneOnFetchReflectsTheConfiguredSetting(bool? fetchPrune, bool? remotePrune, bool expectedFetchPrune)
+        {
+            var path = SandboxStandardTestRepo();
+            var scd = BuildSelfCleaningDirectory();
+
+            using (var repo = new Repository(path, BuildFakeConfigs(scd)))
+            {
+                Assert.Null(repo.Config.Get<bool>("fetch.prune"));
+                Assert.Null(repo.Config.Get<bool>("remote.origin.prune"));
+
+                SetIfNotNull(repo, "fetch.prune", fetchPrune);
+                SetIfNotNull(repo, "remote.origin.prune", remotePrune);
+
+                var remote = repo.Network.Remotes["origin"];
+                Assert.Equal(expectedFetchPrune, remote.AutomaticallyPruneOnFetch);
+            }
+        }
+
+        private void SetIfNotNull(IRepository repo, string configName, bool? value)
+        {
+            if (!value.HasValue)
+            {
+                return;
+            }
+
+            repo.Config.Set(configName, value.Value);
+        }
     }
 }

--- a/LibGit2Sharp/Remote.cs
+++ b/LibGit2Sharp/Remote.cs
@@ -106,6 +106,31 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
+        /// Gets the configured behavior regarding the deletion
+        /// of stale remote tracking branches.
+        /// <para>
+        ///   If defined, will return the value of the <code>remote.&lt;name&gt;.prune</code> entry.
+        ///   Otherwise return the value of <code>fetch.prune</code>.
+        /// </para>
+        /// </summary>
+        public virtual bool AutomaticallyPruneOnFetch
+        {
+            get
+            {
+                var remotePrune = repository.Config.Get<bool>("remote", Name, "prune");
+
+                if (remotePrune != null)
+                {
+                    return remotePrune.Value;
+                }
+
+                var fetchPrune = repository.Config.Get<bool>("fetch.prune");
+
+                return fetchPrune != null && fetchPrune.Value;
+            }
+        }
+
+        /// <summary>
         /// Determines whether the specified <see cref="Object"/> is equal to the current <see cref="Remote"/>.
         /// </summary>
         /// <param name="obj">The <see cref="Object"/> to compare with the current <see cref="Remote"/>.</param>


### PR DESCRIPTION
https://github.com/libgit2/libgit2/pull/2761 has been merged and brings a lot of niceties!

We may now expose the following

 - `remote.ShouldPruneOnFetch { get; }`
 - `remoteUpdater.ShouldPruneOnFetch { get; set; }`

Along with some basic test coverage to ensure everything works as expected
