### PR TITLE
Fix typo

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@
  - @libgit2sharp: <http://twitter.com/libgit2sharp>
  - CI servers:
   - Windows (x86/amd64): <https://ci.appveyor.com/project/libgit2/libgit2sharp>
-  - Linux/MacOsX: <https://travis-ci.org/libgit2/libgit2sharp>
+  - Linux/Mac OS X: <https://travis-ci.org/libgit2/libgit2sharp>
 
 ## v0.21 - ([diff](https://github.com/libgit2/libgit2sharp/compare/v0.20.2...v0.21))
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Prerequisites
 
  - **Windows:** .Net 4.0+
- - **Linux/MacOsX:** Mono 3.6+
+ - **Linux/Mac OS X:** Mono 3.6+
 
 ## Online resources
 
@@ -30,7 +30,7 @@
 ## Current project build status
 The CI builds are generously hosted and run on the [Travis][travis] and [AppVeyor][appveyor] infrastructures.
 
-|  | Windows (x86/amd64) | Linux/MacOsX |
+|  | Windows (x86/amd64) | Linux/Mac OS X |
 | :------ | :------: | :------: |
 | **master** | [![master win][master-win-badge]][master-win] | [![master nix][master-nix-badge]][master-nix] |
 | **vNext** | [![vNext win][vNext-win-badge]][vNext-win] | [![vNext nix][vNext-nix-badge]][vNext-nix] |


### PR DESCRIPTION
rename `MacOsX` as `Mac OS X`