### PR TITLE
Move FindMergeBase() overloads to ObjectDatabase

### DIFF
--- a/LibGit2Sharp.Tests/CommitAncestorFixture.cs
+++ b/LibGit2Sharp.Tests/CommitAncestorFixture.cs
@@ -41,7 +41,7 @@ namespace LibGit2Sharp.Tests
                 var first = sha1 == "-" ? CreateOrphanedCommit(repo) : repo.Lookup<Commit>(sha1);
                 var second = sha2 == "-" ? CreateOrphanedCommit(repo) : repo.Lookup<Commit>(sha2);
 
-                Commit ancestor = repo.Commits.FindMergeBase(first, second);
+                Commit ancestor = repo.ObjectDatabase.FindMergeBase(first, second);
 
                 if (result == null)
                 {
@@ -71,7 +71,7 @@ namespace LibGit2Sharp.Tests
             {
                 var commits = shas.Select(sha => sha == "-" ? CreateOrphanedCommit(repo) : repo.Lookup<Commit>(sha)).ToArray();
 
-                Commit ancestor = repo.Commits.FindMergeBase(commits, strategy);
+                Commit ancestor = repo.ObjectDatabase.FindMergeBase(commits, strategy);
 
                 if (result == null)
                 {
@@ -96,7 +96,7 @@ namespace LibGit2Sharp.Tests
                 var first = repo.Lookup<Commit>(sha1);
                 var second = repo.Lookup<Commit>(sha2);
 
-                Assert.Throws<ArgumentNullException>(() => repo.Commits.FindMergeBase(first, second));
+                Assert.Throws<ArgumentNullException>(() => repo.ObjectDatabase.FindMergeBase(first, second));
             }
         }
 
@@ -112,7 +112,7 @@ namespace LibGit2Sharp.Tests
             {
                 var commits = shas.Select(sha => sha == "-" ? CreateOrphanedCommit(repo) : repo.Lookup<Commit>(sha)).ToArray();
 
-                Assert.Throws<ArgumentException>(() => repo.Commits.FindMergeBase(commits, strategy));
+                Assert.Throws<ArgumentException>(() => repo.ObjectDatabase.FindMergeBase(commits, strategy));
             }
         }
 

--- a/LibGit2Sharp/CommitLog.cs
+++ b/LibGit2Sharp/CommitLog.cs
@@ -87,12 +87,10 @@ namespace LibGit2Sharp
         /// <param name="first">The first <see cref="Commit"/>.</param>
         /// <param name="second">The second <see cref="Commit"/>.</param>
         /// <returns>The merge base or null if none found.</returns>
+        [Obsolete("This method will be removed in the next release. Please use ObjectDatabase.FindMergeBase() instead.")]
         public Commit FindMergeBase(Commit first, Commit second)
         {
-            Ensure.ArgumentNotNull(first, "first");
-            Ensure.ArgumentNotNull(second, "second");
-
-            return FindMergeBase(new[] { first, second }, MergeBaseFindingStrategy.Standard);
+            return repo.ObjectDatabase.FindMergeBase(first, second);
         }
 
         /// <summary>
@@ -101,42 +99,10 @@ namespace LibGit2Sharp
         /// <param name="commits">The <see cref="Commit"/>s for which to find the merge base.</param>
         /// <param name="strategy">The strategy to leverage in order to find the merge base.</param>
         /// <returns>The merge base or null if none found.</returns>
+        [Obsolete("This method will be removed in the next release. Please use ObjectDatabase.FindMergeBase() instead.")]
         public Commit FindMergeBase(IEnumerable<Commit> commits, MergeBaseFindingStrategy strategy)
         {
-            Ensure.ArgumentNotNull(commits, "commits");
-
-            ObjectId id;
-            List<GitOid> ids = new List<GitOid>(8);
-            int count = 0;
-
-            foreach (var commit in commits)
-            {
-                if (commit == null)
-                {
-                    throw new ArgumentException("Enumerable contains null at position: " + count.ToString(CultureInfo.InvariantCulture), "commits");
-                }
-                ids.Add(commit.Id.Oid);
-                count++;
-            }
-
-            if (count < 2)
-            {
-                throw new ArgumentException("The enumerable must contains at least two commits.", "commits");
-            }
-
-            switch (strategy)
-            {
-                case MergeBaseFindingStrategy.Standard:
-                    id = Proxy.git_merge_base_many(repo.Handle, ids.ToArray());
-                    break;
-                case MergeBaseFindingStrategy.Octopus:
-                    id = Proxy.git_merge_base_octopus(repo.Handle, ids.ToArray());
-                    break;
-                default:
-                    throw new ArgumentException("", "strategy");
-            }
-
-            return id == null ? null : repo.Lookup<Commit>(id);
+            return repo.ObjectDatabase.FindMergeBase(commits, strategy);
         }
 
         private class CommitEnumerator : IEnumerator<Commit>

--- a/LibGit2Sharp/HistoryDivergence.cs
+++ b/LibGit2Sharp/HistoryDivergence.cs
@@ -19,7 +19,7 @@ namespace LibGit2Sharp
 
         internal HistoryDivergence(Repository repo, Commit one, Commit another)
         {
-            commonAncestor = new Lazy<Commit>(() => repo.Commits.FindMergeBase(one, another));
+            commonAncestor = new Lazy<Commit>(() => repo.ObjectDatabase.FindMergeBase(one, another));
             Tuple<int?, int?> div = Proxy.git_graph_ahead_behind(repo.Handle, one, another);
 
             One = one;

--- a/LibGit2Sharp/IQueryableCommitLog.cs
+++ b/LibGit2Sharp/IQueryableCommitLog.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace LibGit2Sharp
 {
@@ -20,6 +21,7 @@ namespace LibGit2Sharp
         /// <param name="first">The first <see cref="Commit"/>.</param>
         /// <param name="second">The second <see cref="Commit"/>.</param>
         /// <returns>The merge base or null if none found.</returns>
+        [Obsolete("This method will be removed in the next release. Please use ObjectDatabase.FindMergeBase() instead.")]
         Commit FindMergeBase(Commit first, Commit second);
 
         /// <summary>
@@ -28,6 +30,7 @@ namespace LibGit2Sharp
         /// <param name="commits">The <see cref="Commit"/>s for which to find the merge base.</param>
         /// <param name="strategy">The strategy to leverage in order to find the merge base.</param>
         /// <returns>The merge base or null if none found.</returns>
+        [Obsolete("This method will be removed in the next release. Please use ObjectDatabase.FindMergeBase() instead.")]
         Commit FindMergeBase(IEnumerable<Commit> commits, MergeBaseFindingStrategy strategy);
     }
 }

--- a/LibGit2Sharp/ObjectDatabase.cs
+++ b/LibGit2Sharp/ObjectDatabase.cs
@@ -422,7 +422,7 @@ namespace LibGit2Sharp
             using (var ourHandle = Proxy.git_object_peel(repo.Handle, one.Id, GitObjectType.Tree, true))
             using (var theirHandle = Proxy.git_object_peel(repo.Handle, another.Id, GitObjectType.Tree, true))
             {
-                var ancestorCommit = repo.Commits.FindMergeBase(one, another);
+                var ancestorCommit = FindMergeBase(one, another);
 
                 var ancestorHandle = ancestorCommit != null
                     ? Proxy.git_object_peel(repo.Handle, ancestorCommit.Id, GitObjectType.Tree, false)
@@ -434,6 +434,64 @@ namespace LibGit2Sharp
                     return !Proxy.git_index_has_conflicts(indexHandle);
                 }
             }
+        }
+
+        /// <summary>
+        /// Find the best possible merge base given two <see cref="Commit"/>s.
+        /// </summary>
+        /// <param name="first">The first <see cref="Commit"/>.</param>
+        /// <param name="second">The second <see cref="Commit"/>.</param>
+        /// <returns>The merge base or null if none found.</returns>
+        public virtual Commit FindMergeBase(Commit first, Commit second)
+        {
+            Ensure.ArgumentNotNull(first, "first");
+            Ensure.ArgumentNotNull(second, "second");
+
+            return FindMergeBase(new[] { first, second }, MergeBaseFindingStrategy.Standard);
+        }
+
+        /// <summary>
+        /// Find the best possible merge base given two or more <see cref="Commit"/> according to the <see cref="MergeBaseFindingStrategy"/>.
+        /// </summary>
+        /// <param name="commits">The <see cref="Commit"/>s for which to find the merge base.</param>
+        /// <param name="strategy">The strategy to leverage in order to find the merge base.</param>
+        /// <returns>The merge base or null if none found.</returns>
+        public virtual Commit FindMergeBase(IEnumerable<Commit> commits, MergeBaseFindingStrategy strategy)
+        {
+            Ensure.ArgumentNotNull(commits, "commits");
+
+            ObjectId id;
+            List<GitOid> ids = new List<GitOid>(8);
+            int count = 0;
+
+            foreach (var commit in commits)
+            {
+                if (commit == null)
+                {
+                    throw new ArgumentException("Enumerable contains null at position: " + count.ToString(CultureInfo.InvariantCulture), "commits");
+                }
+                ids.Add(commit.Id.Oid);
+                count++;
+            }
+
+            if (count < 2)
+            {
+                throw new ArgumentException("The enumerable must contains at least two commits.", "commits");
+            }
+
+            switch (strategy)
+            {
+                case MergeBaseFindingStrategy.Standard:
+                    id = Proxy.git_merge_base_many(repo.Handle, ids.ToArray());
+                    break;
+                case MergeBaseFindingStrategy.Octopus:
+                    id = Proxy.git_merge_base_octopus(repo.Handle, ids.ToArray());
+                    break;
+                default:
+                    throw new ArgumentException("", "strategy");
+            }
+
+            return id == null ? null : repo.Lookup<Commit>(id);
         }
     }
 }


### PR DESCRIPTION
Per isssues #864 and #951, the overloads of FindMergeBase() have been moved
from CommitLog to ObjectDatabase.

The methods on ICommitLog and CommitLog have been deprecated, and calls to
the CommitLog methods have been changed to call the ObjectDatabase versions
instead.

The relevant tests have been updated as well.