### PR TITLE
Move Repository.Reset(paths) into Index

### DIFF
--- a/LibGit2Sharp.Tests/StageFixture.cs
+++ b/LibGit2Sharp.Tests/StageFixture.cs
@@ -195,7 +195,7 @@ namespace LibGit2Sharp.Tests
             {
                 repo.Stage(path);
                 Assert.Equal(FileStatus.Added, repo.RetrieveStatus(path));
-                repo.Reset();
+                repo.Index.Replace(repo.Head.Tip);
                 Assert.Equal(FileStatus.Untracked, repo.RetrieveStatus(path));
             }
             catch (ArgumentException)

--- a/LibGit2Sharp/IRepository.cs
+++ b/LibGit2Sharp/IRepository.cs
@@ -179,6 +179,7 @@ namespace LibGit2Sharp
         /// If set, the passed <paramref name="paths"/> will be treated as explicit paths.
         /// Use these options to determine how unmatched explicit paths should be handled.
         /// </param>
+        [Obsolete("This method will be removed in the next release. Please use Index.Replace() instead.")]
         void Reset(Commit commit, IEnumerable<string> paths, ExplicitPathsOptions explicitPathsOptions);
 
         /// <summary>

--- a/LibGit2Sharp/Index.cs
+++ b/LibGit2Sharp/Index.cs
@@ -54,7 +54,7 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
-        /// Gets the number of <see cref="IndexEntry"/> in the index.
+        /// Gets the number of <see cref="IndexEntry"/> in the <see cref="Index"/>.
         /// </summary>
         public virtual int Count
         {
@@ -62,7 +62,7 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
-        /// Determines if the index is free from conflicts.
+        /// Determines if the <see cref="Index"/> is free from conflicts.
         /// </summary>
         public virtual bool IsFullyMerged
         {
@@ -128,9 +128,9 @@ namespace LibGit2Sharp
         #endregion
 
         /// <summary>
-        /// Replaces entries in the staging area with entries from the specified tree.
+        /// Replaces entries in the <see cref="Index"/> with entries from the specified <see cref="Tree"/>.
         /// <para>
-        ///   This overwrites all existing state in the staging area.
+        ///   This overwrites all existing state in the <see cref="Index"/>.
         /// </para>
         /// </summary>
         /// <param name="source">The <see cref="Tree"/> to read the entries from.</param>
@@ -145,10 +145,10 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
-        /// Clears all entries the index. This is semantically equivalent to
-        /// creating an empty tree object and resetting the index to that tree.
+        /// Clears all entries the <see cref="Index"/>. This is semantically equivalent to
+        /// creating an empty <see cref="Tree"/> object and resetting the <see cref="Index"/> to that <see cref="Tree"/>.
         /// <para>
-        ///   This overwrites all existing state in the staging area.
+        ///   This overwrites all existing state in the <see cref="Index"/>.
         /// </para>
         /// </summary>
         public virtual void Clear()
@@ -163,7 +163,7 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
-        /// Removes a specified entry from the index.
+        /// Removes a specified entry from the <see cref="Index"/>.
         /// </summary>
         /// <param name="indexEntryPath">The path of the <see cref="Index"/> entry to be removed.</param>
         public virtual void Remove(string indexEntryPath)
@@ -179,7 +179,7 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
-        /// Adds a file from the workdir in the <see cref="Index"/>.
+        /// Adds a file from the working directory in the <see cref="Index"/>.
         /// <para>
         ///   If an entry with the same path already exists in the <see cref="Index"/>,
         ///   the newly added one will overwrite it.
@@ -295,6 +295,42 @@ namespace LibGit2Sharp
                 return string.Format(CultureInfo.InvariantCulture,
                     "Count = {0}", Count);
             }
+        }
+
+        /// <summary>
+        /// Replaces entries in the <see cref="Index"/> with entries from the specified <see cref="Commit"/>.
+        /// </summary>
+        /// <param name="commit">The target <see cref="Commit"/> object.</param>
+        public virtual void Replace(Commit commit)
+        {
+            Replace(commit, null, null);
+        }
+
+        /// <summary>
+        /// Replaces entries in the <see cref="Index"/> with entries from the specified <see cref="Commit"/>.
+        /// </summary>
+        /// <param name="commit">The target <see cref="Commit"/> object.</param>
+        /// <param name="paths">The list of paths (either files or directories) that should be considered.</param>
+        public virtual void Replace(Commit commit, IEnumerable<string> paths)
+        {
+            Replace(commit, paths, null);
+        }
+
+        /// <summary>
+        /// Replaces entries in the <see cref="Index"/> with entries from the specified <see cref="Commit"/>.
+        /// </summary>
+        /// <param name="commit">The target <see cref="Commit"/> object.</param>
+        /// <param name="paths">The list of paths (either files or directories) that should be considered.</param>
+        /// <param name="explicitPathsOptions">
+        /// If set, the passed <paramref name="paths"/> will be treated as explicit paths.
+        /// Use these options to determine how unmatched explicit paths should be handled.
+        /// </param>
+        public virtual void Replace(Commit commit, IEnumerable<string> paths, ExplicitPathsOptions explicitPathsOptions)
+        {
+            Ensure.ArgumentNotNull(commit, "commit");
+
+            var changes = repo.Diff.Compare<TreeChanges>(commit.Tree, DiffTargets.Index, paths, explicitPathsOptions, new CompareOptions { Similarity = SimilarityOptions.None });
+            Replace(changes);
         }
     }
 }

--- a/LibGit2Sharp/Repository.cs
+++ b/LibGit2Sharp/Repository.cs
@@ -819,17 +819,10 @@ namespace LibGit2Sharp
         /// If set, the passed <paramref name="paths"/> will be treated as explicit paths.
         /// Use these options to determine how unmatched explicit paths should be handled.
         /// </param>
+        [Obsolete("This method will be removed in the next release. Please use Index.Replace() instead.")]
         public void Reset(Commit commit, IEnumerable<string> paths, ExplicitPathsOptions explicitPathsOptions)
         {
-            if (Info.IsBare)
-            {
-                throw new BareRepositoryException("Reset is not allowed in a bare repository");
-            }
-
-            Ensure.ArgumentNotNull(commit, "commit");
-
-            var changes = Diff.Compare<TreeChanges>(commit.Tree, DiffTargets.Index, paths, explicitPathsOptions, new CompareOptions { Similarity = SimilarityOptions.None });
-            Index.Replace(changes);
+            Index.Replace(commit, paths, explicitPathsOptions);
         }
 
         /// <summary>
@@ -1573,7 +1566,7 @@ namespace LibGit2Sharp
             }
             else
             {
-                this.Reset("HEAD", paths, explicitPathsOptions);
+                Index.Replace(Head.Tip, paths, explicitPathsOptions);
             }
         }
 

--- a/LibGit2Sharp/RepositoryExtensions.cs
+++ b/LibGit2Sharp/RepositoryExtensions.cs
@@ -183,6 +183,7 @@ namespace LibGit2Sharp
         /// If set, the passed <paramref name="paths"/> will be treated as explicit paths.
         /// Use these options to determine how unmatched explicit paths should be handled.
         /// </param>
+        [Obsolete("This method will be removed in the next release. Please use Index.Replace() instead.")]
         public static void Reset(this IRepository repository, string committish = "HEAD", IEnumerable<string> paths = null, ExplicitPathsOptions explicitPathsOptions = null)
         {
             if (repository.Info.IsBare)
@@ -194,7 +195,7 @@ namespace LibGit2Sharp
 
             Commit commit = LookUpCommit(repository, committish);
 
-            repository.Reset(commit, paths, explicitPathsOptions);
+            repository.Index.Replace(commit, paths, explicitPathsOptions);
         }
 
         private static Commit LookUpCommit(IRepository repository, string committish)
@@ -541,9 +542,10 @@ namespace LibGit2Sharp
         /// <param name="repository">The <see cref="IRepository"/> being worked with.</param>
         /// <param name="commit">The target commit object.</param>
         /// <param name="paths">The list of paths (either files or directories) that should be considered.</param>
+        [Obsolete("This method will be removed in the next release. Please use Index.Replace() instead.")]
         public static void Reset(this IRepository repository, Commit commit, IEnumerable<string> paths)
         {
-            repository.Reset(commit, paths, null);
+            repository.Index.Replace(commit, paths, null);
         }
 
         /// <summary>
@@ -551,9 +553,10 @@ namespace LibGit2Sharp
         /// </summary>
         /// <param name="repository">The <see cref="IRepository"/> being worked with.</param>
         /// <param name="commit">The target commit object.</param>
+        [Obsolete("This method will be removed in the next release. Please use Index.Replace() instead.")]
         public static void Reset(this IRepository repository, Commit commit)
         {
-            repository.Reset(commit, null, null);
+            repository.Index.Replace(commit, null, null);
         }
 
         /// <summary>


### PR DESCRIPTION
Here is what I have so far. It's just about finished, but I had some questions, so I figured I'd go ahead and open the PR for changes I made for #805.

The two things I have left to do are add messages to the `Obsolete` attributes, and update the relevant tests so they aren't getting deprecation warnings. However, I wasn't sure which methods I should be using for the messages and the tests. Should they be pointing to the new `Repository.ResetPaths()` methods or to `Index.Reset()` instead?

To add the `ResetPaths()` methods I had to update the `IRepository` interface also. While doing this, I did start to wonder about how useful these new methods actually were vs. just calling `Index.Reset()` directly. Are these really needed?

Something else that I noticed while working on this is that the version of the method that takes a `committish` string has a couple of things I wanted to comment on.

- First, it's using optional parameters, and I know #952 is talking about removing them from the public API surface. I figured that was out of scope for this PR, so I left them as is.

- Secondly, when this method was in `RepositoryExtensions` it was using a private `LookUpCommit()` method. I changed this to use the internal `Repository.LookupCommit()` instead after verifying that it appeared to do the same thing.

- Lastly, why does this version of the method have its own `IsBare` check vs. relying on the one that's already in the `Reset()` it calls? Unless looking up the commit from the `committish` is really expensive, it seems like there isn't a good reason for the duplicate check.