### PR TITLE
Add Tag.PeeledTarget property

### DIFF
--- a/LibGit2Sharp.Tests/TagFixture.cs
+++ b/LibGit2Sharp.Tests/TagFixture.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using LibGit2Sharp.Core;
 using LibGit2Sharp.Tests.TestHelpers;
 using Xunit;
+using Xunit.Extensions;
 
 namespace LibGit2Sharp.Tests
 {
@@ -737,6 +738,35 @@ namespace LibGit2Sharp.Tests
             using (var repo = new Repository(path))
             {
                 Assert.Throws<ArgumentNullException>(() => { Tag t = repo.Tags[null]; });
+            }
+        }
+
+        [Fact]
+        public void CanRetrieveThePeeledTargetOfATagPointingToATag()
+        {
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
+            {
+                Tag tag = repo.Tags["test"];
+
+                Assert.True(tag.Target is TagAnnotation);
+                Assert.True(tag.PeeledTarget is Commit);
+            }
+        }
+
+        [Theory]
+        [InlineData("e90810b")]
+        [InlineData("lw")]
+        [InlineData("point_to_blob")]
+        [InlineData("tag_without_tagger")]
+        public void PeeledTargetAndTargetAreEqualWhenTagIsNotChained(string tagName)
+        {
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
+            {
+                Tag tag = repo.Tags[tagName];
+
+                Assert.Equal<GitObject>(tag.Target, tag.PeeledTarget);
             }
         }
 

--- a/LibGit2Sharp/Tag.cs
+++ b/LibGit2Sharp/Tag.cs
@@ -41,6 +41,27 @@
         }
 
         /// <summary>
+        /// Gets the peeled <see cref="GitObject"/> that this tag points to.
+        /// </summary>
+        public virtual GitObject PeeledTarget
+        {
+            get
+            {
+                GitObject target = TargetObject;
+
+                var annotation = target as TagAnnotation;
+
+                while (annotation != null)
+                {
+                    target = annotation.Target;
+                    annotation = target as TagAnnotation;
+                }
+
+                return target;
+            }
+        }
+
+        /// <summary>
         /// Indicates whether the tag holds any metadata.
         /// </summary>
         public virtual bool IsAnnotated


### PR DESCRIPTION
Per issue #551, a `PeeledTarget` property has been added to `Tag`.

I added the test that was in the issue, and I added one other test to verify that `Target` and `PeeledTarget` return the same result when the tag isn't chained.

Does this look ok as is, or do you think there need to be more tests?

