### PR TITLE
No more check function

### DIFF
--- a/LibGit2Sharp.Tests/FilterFixture.cs
+++ b/LibGit2Sharp.Tests/FilterFixture.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using LibGit2Sharp.Tests.TestHelpers;
 using Xunit;
 
@@ -11,9 +10,7 @@ namespace LibGit2Sharp.Tests
     {
         private const int GitPassThrough = -30;
 
-        readonly Func<FilterSource, IEnumerable<string>, int> checkPassThrough = (source, attr) => GitPassThrough;
         readonly Func<Stream, Stream, int> successCallback = (reader, writer) => 0;
-        readonly Func<FilterSource, IEnumerable<string>, int> checkSuccess = (source, attr) => 0;
 
         private const string FilterName = "the-filter";
         readonly List<string> attributes = new List<string>{"test"};
@@ -56,101 +53,6 @@ namespace LibGit2Sharp.Tests
         }
 
         [Fact]
-        public void CheckCallbackNotMadeWhenFileStagedAndFilterNotRegistered()
-        {
-            bool called = false;
-            Func<FilterSource, IEnumerable<string>, int> callback = (source, attr) =>
-            {
-                called = true;
-                return GitPassThrough;
-            };
-
-            string repoPath = InitNewRepository();
-
-            new FakeFilter(FilterName + 4, attributes, callback);
-
-            using (var repo = CreateTestRepository(repoPath))
-            {
-                StageNewFile(repo);
-            }
-
-            Assert.False(called);
-        }
-
-        [Fact]
-        public void CheckCallbackMadeWhenFileStaged()
-        {
-            bool called = false;
-            Func<FilterSource, IEnumerable<string>, int> checkCallBack = (source, attr) =>
-            {
-                called = true;
-                return GitPassThrough;
-            };
-            string repoPath = InitNewRepository();
-
-            var filter = new FakeFilter(FilterName + 5, attributes, checkCallBack);
-
-            var filterRegistration = GlobalSettings.RegisterFilter(filter);
-            using (var repo = CreateTestRepository(repoPath))
-            {
-                StageNewFile(repo);
-                Assert.True(called);
-            }
-
-            GlobalSettings.DeregisterFilter(filterRegistration);
-        }
-
-        [Fact]
-        public void ApplyCallbackMadeWhenCheckCallbackReturnsZero()
-        {
-            bool called = false;
-
-            Func<Stream, Stream, int> applyCallback = (reader, writer) =>
-            {
-                called = true;
-                return 0; //successCallback
-            };
-
-            string repoPath = InitNewRepository();
-            var filter = new FakeFilter(FilterName + 6, attributes, checkSuccess, applyCallback);
-
-            var filterRegistration = GlobalSettings.RegisterFilter(filter);
-            using (var repo = CreateTestRepository(repoPath))
-            {
-                StageNewFile(repo);
-            }
-
-            GlobalSettings.DeregisterFilter(filterRegistration);
-
-            Assert.True(called);
-        }
-
-        [Fact]
-        public void ApplyCallbackNotMadeWhenCheckCallbackReturnsPassThrough()
-        {
-            bool called = false;
-
-            Func<Stream, Stream, int> applyCallback = (reader, writer) =>
-            {
-                called = true;
-                return 0;
-            };
-
-            string repoPath = InitNewRepository();
-            var filter = new FakeFilter(FilterName + 7, attributes, checkPassThrough, applyCallback);
-
-            var filterRegistration = GlobalSettings.RegisterFilter(filter);
-            using (var repo = CreateTestRepository(repoPath))
-            {
-                StageNewFile(repo);
-            }
-
-            GlobalSettings.DeregisterFilter(filterRegistration);
-
-            Assert.False(called);
-        }
-
-        [Fact]
         public void InitCallbackNotMadeWhenFilterNeverUsed()
         {
             bool called = false;
@@ -161,7 +63,6 @@ namespace LibGit2Sharp.Tests
             };
 
             var filter = new FakeFilter(FilterName + 11, attributes,
-                checkSuccess,
                 successCallback,
                 successCallback,
                 initializeCallback);
@@ -184,7 +85,6 @@ namespace LibGit2Sharp.Tests
             };
 
             var filter = new FakeFilter(FilterName + 12, attributes,
-                checkSuccess,
                 successCallback,
                 successCallback,
                 initializeCallback);
@@ -203,68 +103,6 @@ namespace LibGit2Sharp.Tests
         }
 
         [Fact]
-        public void WhenStagingFileCheckIsCalledWithCleanForCorrectPath()
-        {
-            string repoPath = InitNewRepository();
-
-            var calledWithMode = FilterMode.Smudge;
-            string actualPath = string.Empty;
-            IEnumerable<string> actualAttributes = Enumerable.Empty<string>();
-            Func<FilterSource, IEnumerable<string>, int> callback = (source, attr) =>
-            {
-                calledWithMode = source.SourceMode;
-                actualPath = source.Path;
-                actualAttributes = attr;
-                return GitPassThrough;
-            };
-
-            var filter = new FakeFilter(FilterName + 13, attributes, callback);
-
-            var filterRegistration = GlobalSettings.RegisterFilter(filter);
-
-            using (var repo = CreateTestRepository(repoPath))
-            {
-                FileInfo expectedFile = StageNewFile(repo);
-
-                Assert.Equal(FilterMode.Clean, calledWithMode);
-                Assert.Equal(expectedFile.Name, actualPath);
-                Assert.Equal(attributes, actualAttributes);
-            }
-
-            GlobalSettings.DeregisterFilter(filterRegistration);
-        }
-
-
-        [Fact]
-        public void WhenCheckingOutAFileFileCheckIsCalledWithSmudgeForCorrectPath()
-        {
-            const string branchName = "branch";
-            string repoPath = InitNewRepository();
-
-            var calledWithMode = FilterMode.Clean;
-            string actualPath = string.Empty;
-            IEnumerable<string> actualAttributes = Enumerable.Empty<string>();
-            Func<FilterSource, IEnumerable<string>, int> callback = (source, attr) =>
-            {
-                calledWithMode = source.SourceMode;
-                actualPath = source.Path;
-                actualAttributes = attr;
-                return GitPassThrough;
-            };
-
-            var filter = new FakeFilter(FilterName + 14, attributes, callback);
-
-            var filterRegistration = GlobalSettings.RegisterFilter(filter);
-
-            FileInfo expectedFile = CheckoutFileForSmudge(repoPath, branchName, "hello");
-            Assert.Equal(FilterMode.Smudge, calledWithMode);
-            Assert.Equal(expectedFile.FullName, actualPath);
-            Assert.Equal(attributes, actualAttributes);
-
-            GlobalSettings.DeregisterFilter(filterRegistration);
-        }
-
-        [Fact]
         public void WhenStagingFileApplyIsCalledWithCleanForCorrectPath()
         {
             string repoPath = InitNewRepository();
@@ -275,7 +113,7 @@ namespace LibGit2Sharp.Tests
                 called = true;
                 return GitPassThrough;
             };
-            var filter = new FakeFilter(FilterName + 15, attributes, checkSuccess, clean);
+            var filter = new FakeFilter(FilterName + 15, attributes, clean);
 
             var filterRegistration = GlobalSettings.RegisterFilter(filter);
 
@@ -298,7 +136,7 @@ namespace LibGit2Sharp.Tests
 
             Func<Stream, Stream, int> cleanCallback = SubstitutionCipherFilter.RotateByThirteenPlaces;
 
-            var filter = new FakeFilter(FilterName + 16, attributes, checkSuccess, cleanCallback);
+            var filter = new FakeFilter(FilterName + 16, attributes, cleanCallback);
 
             var filterRegistration = GlobalSettings.RegisterFilter(filter);
 
@@ -328,7 +166,7 @@ namespace LibGit2Sharp.Tests
 
             Func<Stream, Stream, int> smudgeCallback = SubstitutionCipherFilter.RotateByThirteenPlaces;
 
-            var filter = new FakeFilter(FilterName + 17, attributes, checkSuccess, null, smudgeCallback);
+            var filter = new FakeFilter(FilterName + 17, attributes, null, smudgeCallback);
             var filterRegistration = GlobalSettings.RegisterFilter(filter);
 
             FileInfo expectedFile = CheckoutFileForSmudge(repoPath, branchName, encodedInput);
@@ -361,7 +199,7 @@ namespace LibGit2Sharp.Tests
                 return GitPassThrough;
             };
 
-            var filter = new FakeFilter(FilterName + 18, attributes, checkSuccess, assertor, assertor);
+            var filter = new FakeFilter(FilterName + 18, attributes, assertor, assertor);
 
             var filterRegistration = GlobalSettings.RegisterFilter(filter);
 
@@ -440,27 +278,19 @@ namespace LibGit2Sharp.Tests
 
         class FakeFilter : Filter
         {
-            private readonly Func<FilterSource, IEnumerable<string>, int> checkCallBack;
             private readonly Func<Stream, Stream, int> cleanCallback;
             private readonly Func<Stream, Stream, int> smudgeCallback;
             private readonly Func<int> initCallback;
 
             public FakeFilter(string name, IEnumerable<string> attributes,
-                Func<FilterSource, IEnumerable<string>, int> checkCallBack = null,
                 Func<Stream, Stream, int> cleanCallback = null,
                 Func<Stream, Stream, int> smudgeCallback = null,
                 Func<int> initCallback = null)
                 : base(name, attributes)
             {
-                this.checkCallBack = checkCallBack;
                 this.cleanCallback = cleanCallback;
                 this.smudgeCallback = smudgeCallback;
                 this.initCallback = initCallback;
-            }
-
-            protected override int Check(IEnumerable<string> attributes, FilterSource filterSource)
-            {
-                return checkCallBack != null ? checkCallBack(filterSource, attributes) : base.Check(attributes, filterSource);
             }
 
             protected override int Clean(string path, Stream input, Stream output)

--- a/LibGit2Sharp.Tests/FilterFixture.cs
+++ b/LibGit2Sharp.Tests/FilterFixture.cs
@@ -13,7 +13,7 @@ namespace LibGit2Sharp.Tests
         readonly Func<Stream, Stream, int> successCallback = (reader, writer) => 0;
 
         private const string FilterName = "the-filter";
-        readonly List<string> attributes = new List<string>{"test"};
+        readonly List<FilterAttribute> attributes = new List<FilterAttribute> { new FilterAttribute("test") };
 
         [Fact]
         public void CanRegisterFilterWithSingleAttribute()
@@ -271,7 +271,7 @@ namespace LibGit2Sharp.Tests
 
         class EmptyFilter : Filter
         {
-            public EmptyFilter(string name, IEnumerable<string> attributes)
+            public EmptyFilter(string name, IEnumerable<FilterAttribute> attributes)
                 : base(name, attributes)
             { }
         }
@@ -282,7 +282,7 @@ namespace LibGit2Sharp.Tests
             private readonly Func<Stream, Stream, int> smudgeCallback;
             private readonly Func<int> initCallback;
 
-            public FakeFilter(string name, IEnumerable<string> attributes,
+            public FakeFilter(string name, IEnumerable<FilterAttribute> attributes,
                 Func<Stream, Stream, int> cleanCallback = null,
                 Func<Stream, Stream, int> smudgeCallback = null,
                 Func<int> initCallback = null)

--- a/LibGit2Sharp.Tests/FilterSubstitutionCipherFixture.cs
+++ b/LibGit2Sharp.Tests/FilterSubstitutionCipherFixture.cs
@@ -15,7 +15,7 @@ namespace LibGit2Sharp.Tests
             const string decodedInput = "This is a substitution cipher";
             const string encodedInput = "Guvf vf n fhofgvghgvba pvcure";
 
-            var attributes = new List<string> { "filter=rot13" };
+            var attributes = new List<FilterAttribute> { new FilterAttribute("filter=rot13") };
             var filter = new SubstitutionCipherFilter("cipher-filter", attributes);
             var filterRegistration = GlobalSettings.RegisterFilter(filter);
 
@@ -55,7 +55,7 @@ namespace LibGit2Sharp.Tests
             const string decodedInput = "This is a substitution cipher";
             const string encodedInput = "Guvf vf n fhofgvghgvba pvcure";
 
-            var attributes = new List<string> { "filter=rot13" };
+            var attributes = new List<FilterAttribute> { new FilterAttribute("filter=rot13") };
             var filter = new SubstitutionCipherFilter("cipher-filter", attributes);
             var filterRegistration = GlobalSettings.RegisterFilter(filter);
 
@@ -98,7 +98,7 @@ namespace LibGit2Sharp.Tests
             const string decodedInput = "This is a substitution cipher";
             string attributeFileEntry = string.Format("{0} {1}", pathSpec, filterName);
 
-            var filterForAttributes = new List<string> { filterName };
+            var filterForAttributes = new List<FilterAttribute> { new FilterAttribute(filterName) };
             var filter = new SubstitutionCipherFilter("cipher-filter", filterForAttributes);
 
             var filterRegistration = GlobalSettings.RegisterFilter(filter);
@@ -125,13 +125,17 @@ namespace LibGit2Sharp.Tests
         [InlineData("filter=rot13", "*.txt filter=rot13", 1)]
         [InlineData("filter=rot13", "*.txt filter=fake", 0)]
         [InlineData("filter=rot13", "*.bat filter=rot13", 0)]
-        [InlineData("rot13", "*.bat filter=rot13", 1)]
-        [InlineData("rot13", "*.bat filter=fake", 0)]
+        [InlineData("rot13", "*.txt filter=rot13", 1)]
+        [InlineData("rot13", "*.txt filter=fake", 0)]
+        [InlineData("fake", "*.txt filter=fake", 1)]
+        [InlineData("filter=fake", "*.txt filter=fake", 1)]
+        [InlineData("filter=fake", "*.bat filter=fake", 0)]
+        [InlineData("filter=rot13", "*.txt filter=rot13 -crlf", 1)]
         public void CleanIsCalledIfAttributeEntryMatches(string filterAttribute, string attributeEntry, int cleanCount)
         {
             const string decodedInput = "This is a substitution cipher";
 
-            var filterForAttributes = new List<string> { filterAttribute };
+            var filterForAttributes = new List<FilterAttribute> { new FilterAttribute(filterAttribute) };
             var filter = new SubstitutionCipherFilter("cipher-filter", filterForAttributes);
 
             var filterRegistration = GlobalSettings.RegisterFilter(filter);
@@ -157,13 +161,14 @@ namespace LibGit2Sharp.Tests
         [InlineData("filter=rot13", "*.txt filter=rot13", 1)]
         [InlineData("filter=rot13", "*.txt filter=fake", 0)]
         [InlineData("filter=rot13", "*.bat filter=rot13", 0)]
-        [InlineData("rot13", "*.bat filter=rot13", 1)]
-        [InlineData("rot13", "*.bat filter=fake", 0)]
+        [InlineData("rot13", "*.txt filter=rot13", 1)]
+        [InlineData("rot13", "*.txt filter=fake", 0)]
+        [InlineData("filter=rot13", "*.txt filter=rot13 -crlf", 1)]
         public void SmudgeIsCalledIfAttributeEntryMatches(string filterAttribute, string attributeEntry, int smudgeCount)
         {
             const string decodedInput = "This is a substitution cipher";
 
-            var filterForAttributes = new List<string> { filterAttribute };
+            var filterForAttributes = new List<FilterAttribute> { new FilterAttribute(filterAttribute) };
             var filter = new SubstitutionCipherFilter("cipher-filter", filterForAttributes);
 
             var filterRegistration = GlobalSettings.RegisterFilter(filter);
@@ -190,6 +195,7 @@ namespace LibGit2Sharp.Tests
             }
 
             GlobalSettings.DeregisterFilter(filterRegistration);
+
         }
 
         private static string ReadTextFromFile(Repository repo, string fileName)

--- a/LibGit2Sharp.Tests/TestHelpers/SubstitutionCipherFilter.cs
+++ b/LibGit2Sharp.Tests/TestHelpers/SubstitutionCipherFilter.cs
@@ -5,19 +5,12 @@ namespace LibGit2Sharp.Tests.TestHelpers
 {
     public class SubstitutionCipherFilter : Filter
     {
-        public int CheckCalledCount = 0;
         public int CleanCalledCount = 0;
         public int SmudgeCalledCount = 0;
 
         public SubstitutionCipherFilter(string name, IEnumerable<string> attributes)
             : base(name, attributes)
         {
-        }
-
-        protected override int Check(IEnumerable<string> attributes, FilterSource filterSource)
-        {
-            CheckCalledCount++;
-            return base.Check(attributes, filterSource);
         }
 
         protected override int Clean(string path, Stream input, Stream output)

--- a/LibGit2Sharp.Tests/TestHelpers/SubstitutionCipherFilter.cs
+++ b/LibGit2Sharp.Tests/TestHelpers/SubstitutionCipherFilter.cs
@@ -8,7 +8,7 @@ namespace LibGit2Sharp.Tests.TestHelpers
         public int CleanCalledCount = 0;
         public int SmudgeCalledCount = 0;
 
-        public SubstitutionCipherFilter(string name, IEnumerable<string> attributes)
+        public SubstitutionCipherFilter(string name, IEnumerable<FilterAttribute> attributes)
             : base(name, attributes)
         {
         }

--- a/LibGit2Sharp/Filter.cs
+++ b/LibGit2Sharp/Filter.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
 using LibGit2Sharp.Core;
 
@@ -49,8 +48,7 @@ namespace LibGit2Sharp
             {
                 attributes = EncodingMarshaler.FromManaged(Encoding.UTF8, attributes),
                 init = InitializeCallback,
-                apply = ApplyCallback,
-                check = CheckCallback
+                apply = ApplyCallback
             };
         }
 
@@ -92,20 +90,6 @@ namespace LibGit2Sharp
         protected virtual int Initialize()
         {
             return 0;
-        }
-
-        /// <summary>
-        /// Decides if a given source needs to be filtered by checking if the filter
-        /// matches the current file extension.
-        /// </summary>
-        /// <param name="filterForAttributes">The filterForAttributes that this filter was created for.</param>
-        /// <param name="filterSource">The source of the filter</param>
-        /// <returns>0 if successful and <see cref="GitErrorCode.PassThrough"/> to skip and pass through</returns>
-        protected virtual int Check(IEnumerable<string> filterForAttributes, FilterSource filterSource)
-        {
-            var fileInfo = new FileInfo(filterSource.Path);
-            var matches = filterForAttributes.Any(currentExtension => string.Equals(fileInfo.Extension, currentExtension, StringComparison.Ordinal));
-            return matches ? 0 : (int)GitErrorCode.PassThrough;
         }
 
         /// <summary>
@@ -197,29 +181,6 @@ namespace LibGit2Sharp
         {
             return Initialize();
         }
-
-        /// <summary>
-        /// Callback to decide if a given source needs this filter
-        /// Specified as `filter.check`, this is an optional callback that checks if filtering is needed for a given source.
-        ///
-        /// It should return 0 if the filter should be applied (i.e. success), GIT_PASSTHROUGH if the filter should
-        /// not be applied, or an error code to fail out of the filter processing pipeline and return to the caller.
-        ///
-        /// The `attr_values` will be set to the values of any filterForAttributes given in the filter definition.  See `git_filter` below for more detail.
-        ///
-        /// The `payload` will be a pointer to a reference payload for the filter. This will start as NULL, but `check` can assign to this
-        /// pointer for later use by the `apply` callback.  Note that the value should be heap allocated (not stack), so that it doesn't go
-        /// away before the `apply` callback can use it.  If a filter allocates and assigns a value to the `payload`, it will need a `cleanup`
-        /// callback to free the payload.
-        /// </summary>
-        /// <returns></returns>
-        int CheckCallback(GitFilter filter, IntPtr payload, IntPtr filterSourcePtr, IntPtr attributeValues)
-        {
-            string filterForAttributes = EncodingMarshaler.FromNative(Encoding.UTF8, filter.attributes);
-            var filterSource = FilterSource.FromNativePtr(filterSourcePtr);
-            return Check(filterForAttributes.Split(','), filterSource);
-        }
-
 
         /// <summary>
         /// Callback to actually perform the data filtering

--- a/LibGit2Sharp/FilterAttribute.cs
+++ b/LibGit2Sharp/FilterAttribute.cs
@@ -1,0 +1,42 @@
+using LibGit2Sharp.Core;
+
+namespace LibGit2Sharp
+{
+    /// <summary>
+    /// The definition for a given filter found in the .gitattributes file.
+    /// The filter definition will result as 'filter=filterName'
+    /// 
+    /// In the .gitattributes file a filter will be matched to a pathspec like so
+    /// '*.txt filter=filterName'
+    /// </summary>
+    public class FilterAttribute
+    {
+        private const string AttributeFilterDefinition = "filter=";
+
+        private readonly string filterDefinition;
+
+        /// <summary>
+        /// The name of the filter found in a .gitattributes file
+        /// </summary>
+        /// <param name="filterName">The name of the filter</param>
+        public FilterAttribute(string filterName)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(filterName, "filterName");
+
+            if (!filterName.Contains(AttributeFilterDefinition))
+            {
+                filterName = string.Format("{0}{1}", AttributeFilterDefinition, filterName);
+            }
+
+            this.filterDefinition = filterName;
+        }
+
+        /// <summary>
+        /// The filter name in the form of 'filter=filterName'
+        /// </summary>
+        public string FilterDefinition
+        {
+            get { return filterDefinition; }
+        }
+    }
+}

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -81,6 +81,7 @@
     <Compile Include="Core\Handles\IndexReucEntrySafeHandle.cs" />
     <Compile Include="EntryExistsException.cs" />
     <Compile Include="FetchOptionsBase.cs" />
+    <Compile Include="FilterAttribute.cs" />
     <Compile Include="FilterMode.cs" />
     <Compile Include="FilterRegistration.cs" />
     <Compile Include="FilterSource.cs" />


### PR DESCRIPTION
This PR removes the need to supply the check callback when registering a Filter with the library.

For example if you want to install a filter with libgit2 with the name ``foo`` you would register that filter with libgit2sharp and it would be applied to any file that matched the path spec found in the gitattributes file. For example `` *.txt filter=foo``

I naively thought that we needed to implement custom check logic for filters (the piece that actually matches the entry in the attributes file to the file being filtered) but it turns out this is already implemented in libgit2 https://github.com/libgit2/libgit2/blob/master/src/filter.c#L403 and if we simply do not provide the optional check callback, everything just works :tm:


I've added an object ``FilterAttribute`` which allows you to define and register a filter in the correct format ``filter=name``
