### PR TITLE
Make NuGet package copy native binaries on windows only

### DIFF
--- a/nuget.package/build/LibGit2Sharp.props
+++ b/nuget.package/build/LibGit2Sharp.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<ItemGroup>
+	<ItemGroup Condition=" '$(OS)' == 'Windows_NT' ">
 		<None Include="$(MSBuildThisFileDirectory)\..\..\lib\net40\NativeBinaries\amd64\git2-e0902fb.dll">
 			<Link>NativeBinaries\amd64\git2-e0902fb.dll</Link>
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
The props file added to the NuGet package in #821 makes sure the Windows native binaries are copied to the correct location. However, as pointed out in #835, this now happens even when the package is installed on a non-Windows platform.

This can be prevented by adding a condition to the imported ItemGroup that makes it be ignored when running on a non-Windows platform.

I've tested this change in Visual Studio and Xamarin Studio on OS X.