### PR TITLE
Support push URLs

### DIFF
--- a/LibGit2Sharp.Tests/RemoteFixture.cs
+++ b/LibGit2Sharp.Tests/RemoteFixture.cs
@@ -110,6 +110,10 @@ namespace LibGit2Sharp.Tests
                 Remote remote = repo.Network.Remotes[name];
                 Assert.NotNull(remote);
 
+                // before setting push, both push and fetch urls should match
+                Assert.Equal(url, remote.Url);
+                Assert.Equal(url, remote.PushUrl);
+
                 Remote updatedremote = repo.Network.Remotes.Update(remote,
                     r => r.PushUrl = pushurl);
 

--- a/LibGit2Sharp.Tests/RemoteFixture.cs
+++ b/LibGit2Sharp.Tests/RemoteFixture.cs
@@ -95,6 +95,27 @@ namespace LibGit2Sharp.Tests
         }
 
         [Fact]
+        public void CanSetRemotePushUrl()
+        {
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
+            {
+                const string name = "upstream";
+                const string url = "https://github.com/libgit2/libgit2sharp.git";
+                const string pushurl = "https://github.com/libgit2/libgit2.git";
+
+                repo.Network.Remotes.Add(name, url);
+                Remote remote = repo.Network.Remotes[name];
+                Assert.NotNull(remote);
+
+                Remote updatedremote = repo.Network.Remotes.Update(remote,
+                    r => r.PushUrl = pushurl);
+
+                Assert.Equal(pushurl, updatedremote.PushUrl);
+            }
+        }
+
+        [Fact]
         public void CanCheckEqualityOfRemote()
         {
             string path = SandboxStandardTestRepo();

--- a/LibGit2Sharp.Tests/RemoteFixture.cs
+++ b/LibGit2Sharp.Tests/RemoteFixture.cs
@@ -91,6 +91,8 @@ namespace LibGit2Sharp.Tests
                     r => r.Url = newUrl);
 
                 Assert.Equal(newUrl, updatedremote.Url);
+                // with no push url set, PushUrl defaults to the fetch url
+                Assert.Equal(newUrl, updatedremote.PushUrl);
             }
         }
 
@@ -111,6 +113,8 @@ namespace LibGit2Sharp.Tests
                 Remote updatedremote = repo.Network.Remotes.Update(remote,
                     r => r.PushUrl = pushurl);
 
+                // url should not change, push url should be set to new value
+                Assert.Equal(url, updatedremote.Url);
                 Assert.Equal(pushurl, updatedremote.PushUrl);
             }
         }

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -1076,6 +1076,11 @@ namespace LibGit2Sharp.Core
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string url);
 
         [DllImport(libgit2)]
+        internal static extern int git_remote_set_pushurl(
+            RemoteSafeHandle remote,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string url);
+
+        [DllImport(libgit2)]
         internal static extern int git_remote_is_valid_name(
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string remote_name);
 
@@ -1103,6 +1108,10 @@ namespace LibGit2Sharp.Core
         [DllImport(libgit2)]
         [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))]
         internal static extern string git_remote_url(RemoteSafeHandle remote);
+
+        [DllImport(libgit2)]
+        [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))]
+        internal static extern string git_remote_pushurl(RemoteSafeHandle remote);
 
         [DllImport(libgit2)]
         internal static extern void git_remote_set_autotag(RemoteSafeHandle remote, TagFetchMode option);

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -2040,6 +2040,15 @@ namespace LibGit2Sharp.Core
                 Ensure.ZeroResult(res);
             }
         }
+        
+        public static void git_remote_set_pushurl(RemoteSafeHandle remote, string url)
+        {
+            using (ThreadAffinity())
+            {
+                int res = NativeMethods.git_remote_set_pushurl(remote, url);
+                Ensure.ZeroResult(res);
+            }
+        }
 
         public static void git_remote_fetch(RemoteSafeHandle remote, Signature signature, string logMessage)
         {
@@ -2221,6 +2230,11 @@ namespace LibGit2Sharp.Core
         public static string git_remote_url(RemoteSafeHandle remote)
         {
             return NativeMethods.git_remote_url(remote);
+        }
+
+        public static string git_remote_pushurl(RemoteSafeHandle remote)
+        {
+            return NativeMethods.git_remote_pushurl(remote);
         }
 
         #endregion

--- a/LibGit2Sharp/Remote.cs
+++ b/LibGit2Sharp/Remote.cs
@@ -15,7 +15,7 @@ namespace LibGit2Sharp
     public class Remote : IEquatable<Remote>, IBelongToARepository
     {
         private static readonly LambdaEqualityHelper<Remote> equalityHelper =
-            new LambdaEqualityHelper<Remote>(x => x.Name, x => x.Url);
+            new LambdaEqualityHelper<Remote>(x => x.Name, x => x.Url, x => x.PushUrl);
 
         internal readonly Repository repository;
 
@@ -32,6 +32,7 @@ namespace LibGit2Sharp
             this.repository = repository;
             Name = Proxy.git_remote_name(handle);
             Url = Proxy.git_remote_url(handle);
+            PushUrl = Proxy.git_remote_pushurl(handle);
             TagFetchMode = Proxy.git_remote_autotag(handle);
             refSpecs = new RefSpecCollection(handle);
         }
@@ -52,6 +53,12 @@ namespace LibGit2Sharp
         /// Gets the url to use to communicate with this remote repository.
         /// </summary>
         public virtual string Url { get; private set; }
+
+        /// <summary>
+        /// Gets the distinct push url for this remote repository, if set.
+        /// If no separate push url is specified, PushUrl is null.
+        /// </summary>
+        public virtual string PushUrl { get; private set; }
 
         /// <summary>
         /// Gets the Tag Fetch Mode of the remote - indicating how tags are fetched.

--- a/LibGit2Sharp/Remote.cs
+++ b/LibGit2Sharp/Remote.cs
@@ -20,6 +20,7 @@ namespace LibGit2Sharp
         internal readonly Repository repository;
 
         private readonly RefSpecCollection refSpecs;
+        private string pushUrl;
 
         /// <summary>
         /// Needed for mocking purposes.
@@ -56,9 +57,18 @@ namespace LibGit2Sharp
 
         /// <summary>
         /// Gets the distinct push url for this remote repository, if set.
-        /// If no separate push url is specified, PushUrl is null.
+        /// Defaults to the fetch url (<see cref="Url"/>) if not set.
         /// </summary>
-        public virtual string PushUrl { get; private set; }
+        public virtual string PushUrl {
+            get
+            {
+                return pushUrl ?? Url;
+            }
+            private set
+            {
+                pushUrl = value;
+            }
+        }
 
         /// <summary>
         /// Gets the Tag Fetch Mode of the remote - indicating how tags are fetched.

--- a/LibGit2Sharp/RemoteUpdater.cs
+++ b/LibGit2Sharp/RemoteUpdater.cs
@@ -76,6 +76,18 @@ namespace LibGit2Sharp
                 Proxy.git_remote_save(remoteHandle);
             }
         }
+        
+        /// <summary>
+        /// Sets the push url defined for this <see cref="Remote"/>
+        /// </summary>
+        public virtual string PushUrl
+        {
+            set
+            {
+                Proxy.git_remote_set_pushurl(remoteHandle, value);
+                Proxy.git_remote_save(remoteHandle);
+            }
+        }
 
         /// <summary>
         /// Sets the list of <see cref="RefSpec"/>s defined for this <see cref="Remote"/> that are intended to


### PR DESCRIPTION
This brings libgit2's support of remote push URLs to the C# layer.
The new `Remote.PushURL` property is backed by `git_remote_pushurl` and `git_remote_set_pushurl`.
`Remote.PushURL` defaults to the fetch URL (`Remote.Url`) if no push url is specified.