### PR TITLE
Check if git_merge_trees returned a null indexHandle

### DIFF
--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -1081,10 +1081,7 @@ namespace LibGit2Sharp.Core
                 IndexSafeHandle index;
                 GitMergeOpts opts = new GitMergeOpts { Version = 1 };
                 int res = NativeMethods.git_merge_trees(out index, repo, ancestorTree, ourTree, theirTree, ref opts);
-                if (res != (int) GitErrorCode.Ok || index == null)
-                {
-                    return null;
-                }
+                Ensure.ZeroResult(res);
 
                 return index;
             }


### PR DESCRIPTION
We should check if `git_merge_trees` returned a null `indexHandle` before passing it to `git_index_has_conflicts`.