### PR TITLE
Wire and fire the OnPushStatusError when an update was rejected by the remote server.

### DIFF
--- a/LibGit2Sharp/Core/GitRemoteCallbacks.cs
+++ b/LibGit2Sharp/Core/GitRemoteCallbacks.cs
@@ -27,7 +27,7 @@ namespace LibGit2Sharp.Core
 
         internal NativeMethods.git_push_transfer_progress push_transfer_progress;
 
-        internal IntPtr push_update_reference;
+        internal NativeMethods.push_update_reference_callback push_update_reference;
 
         internal IntPtr payload;
     }

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -1108,6 +1108,12 @@ namespace LibGit2Sharp.Core
             ref GitOid newId,
             IntPtr data);
 
+        internal delegate int push_update_reference_callback(
+            IntPtr refName,
+            IntPtr status,
+            IntPtr data
+            );
+
         [DllImport(libgit2)]
         internal static extern int git_repository_discover(
             GitBuf buf,

--- a/LibGit2Sharp/RemoteCallbacks.cs
+++ b/LibGit2Sharp/RemoteCallbacks.cs
@@ -27,6 +27,7 @@ namespace LibGit2Sharp
             PushTransferProgress = pushOptions.OnPushTransferProgress;
             PackBuilderProgress = pushOptions.OnPackBuilderProgress;
             CredentialsProvider = pushOptions.CredentialsProvider;
+            PushStatusError = pushOptions.OnPushStatusError;
         }
 
         internal RemoteCallbacks(FetchOptionsBase fetchOptions)
@@ -53,6 +54,12 @@ namespace LibGit2Sharp
         /// UpdateTips callback. Corresponds to libgit2 update_tips callback.
         /// </summary>
         private readonly UpdateTipsHandler UpdateTips;
+
+        /// <summary>
+        /// PushStatusError callback. It will be called when the libgit2 push_update_reference returns a non null status message, 
+        /// which means that the update was rejected by the remote server.
+        /// </summary>
+        private readonly PushStatusErrorHandler PushStatusError;
 
         /// <summary>
         /// Managed delegate to be called in response to a git_transfer_progress_callback callback from libgit2.
@@ -89,6 +96,11 @@ namespace LibGit2Sharp
             if (UpdateTips != null)
             {
                 callbacks.update_tips = GitUpdateTipsHandler;
+            }
+
+            if (PushStatusError != null)
+            {
+                callbacks.push_update_reference = GitPushUpdateReference;
             }
 
             if (CredentialsProvider != null)
@@ -162,6 +174,30 @@ namespace LibGit2Sharp
             }
 
             return Proxy.ConvertResultToCancelFlag(shouldContinue);
+        }
+
+        /// <summary>
+        /// The delegate with the signature that matches the native push_update_reference function's signature
+        /// </summary>
+        /// <param name="str">IntPtr to string, the name of the reference</param>
+        /// <param name="status">IntPtr to string, the update status message</param>
+        /// <param name="data">IntPtr to optional payload passed back to the callback.</param>
+        /// <returns>0 on success; a negative value to abort the process.</returns>
+        private int GitPushUpdateReference(IntPtr str, IntPtr status, IntPtr data)
+        {
+            PushStatusErrorHandler onPushError = PushStatusError;            
+
+            if (onPushError != null)
+            {
+                string reference = LaxUtf8Marshaler.FromNative(str);
+                string message = LaxUtf8Marshaler.FromNative(status);
+                if (message != null)
+                {
+                    onPushError(new PushStatusError(reference, message));
+                }
+            }
+
+            return Proxy.ConvertResultToCancelFlag(true);
         }
 
         /// <summary>


### PR DESCRIPTION
What is the problem:
---

Currently the `PushOptions.OnPushStatusError` is not wired so it is never fired. Therefore subscribers are not notified if the remote server rejects the update (for example with a pre-receive hook). 

How is the solution implemented:
---

There is already a callback defined on the libgit2 ``git_remote_callbacks`` called ``push_update_reference`` which is called on each updated reference during the push and contains information about whether the update is succeeded or not.

I have extended the ``GitRemoteCallbacks`` with the required ``push_update_reference_callback`` delegate and wired up and fire the ``pushOptions.OnPushStatusError`` when inside the ``GitPushUpdateReference`` we receive a null message.

Some context:
---

We are working on a client application which has to communicate with the GitLab server. There is new feature in GitLab which allows to create [protected branches](https://about.gitlab.com/2014/11/26/keeping-your-code-protected/). These branches are protected through a pre-receive hook, so if the user does not have permission the hook rejects the commit. However we have noticed that the ``OnPushStatusError`` is not called and the ``Network.Push`` also does not throw any exception. 

After some investigation we realized that it is by design in libgit2 that the ``git_remote_push`` does not return an error code if a hook rejects a commit, see details here: https://github.com/libgit2/libgit2/issues/2628. So the clients has to explicitly call ``git_push_status_foreach`` to check that the update was really successful, luckily there is already a callback defined ``push_update_reference`` which is calling ``git_push_status_foreach`` we just need to supply a callback. 

Looking on the signature of the ``PushStatusError`` it seems it was its intended propose to wrap the result of the ``push_update_reference``.

Why there are no test:
---
I don't really know how to create an error which results of a non NULL status message without creating a git hook. However as far as I know libgit2 itself does not executes any of the git hooks see https://github.com/libgit2/libgit2/issues/964: so even if I would create a repository with a hook libgit2 wouldn't execute it so this can be only tested with a "proper" git server. 

If there are other ways to simulate a server error I'm happy to try to write the tests.