### PR TITLE
Introduce `Repository.MergeCommits`

### DIFF
--- a/LibGit2Sharp/CherryPickOptions.cs
+++ b/LibGit2Sharp/CherryPickOptions.cs
@@ -6,7 +6,7 @@ namespace LibGit2Sharp
     /// <summary>
     /// Options controlling CherryPick behavior.
     /// </summary>
-    public sealed class CherryPickOptions : IConvertableToGitCheckoutOpts
+    public sealed class CherryPickOptions : MergeAndCheckoutOptionsBase
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CherryPickOptions"/> class.
@@ -14,100 +14,18 @@ namespace LibGit2Sharp
         /// </summary>
         public CherryPickOptions()
         {
-            CommitOnSuccess = true;
-
-            FindRenames = true;
-
-            // TODO: libgit2 should provide reasonable defaults for these
-            //       values, but it currently does not.
-            RenameThreshold = 50;
-            TargetLimit = 200;
         }
-
-        /// <summary>
-        /// The Flags specifying what conditions are
-        /// reported through the OnCheckoutNotify delegate.
-        /// </summary>
-        public CheckoutNotifyFlags CheckoutNotifyFlags { get; set; }
-
-        /// <summary>
-        /// Delegate that checkout progress will be reported through.
-        /// </summary>
-        public CheckoutProgressHandler OnCheckoutProgress { get; set; }
-
-        /// <summary>
-        /// Delegate that checkout will notify callers of
-        /// certain conditions. The conditions that are reported is
-        /// controlled with the CheckoutNotifyFlags property.
-        /// </summary>
-        public CheckoutNotifyHandler OnCheckoutNotify { get; set; }
-
-        /// <summary>
-        /// Commit the cherry pick if the cherry pick is successful.
-        /// </summary>
-        public bool CommitOnSuccess { get; set; }
 
         /// <summary>
         /// When cherry picking a merge commit, the parent number to consider as
         /// mainline, starting from offset 1.
         /// <para>
         ///  As a merge commit has multiple parents, cherry picking a merge commit
-        ///  will reverse all the changes brought in by the merge except for
-        ///  one parent's line of commits. The parent to preserve is called the
-        ///  mainline, and must be specified by its number (i.e. offset).
+        ///  will take only the changes relative to the given parent.  The parent
+        ///  to consider changes based on is called the mainline, and must be
+        ///  specified by its number (i.e. offset).
         /// </para>
         /// </summary>
         public int Mainline { get; set; }
-
-        /// <summary>
-        /// How to handle conflicts encountered during a merge.
-        /// </summary>
-        public MergeFileFavor MergeFileFavor { get; set; }
-
-        /// <summary>
-        /// How Checkout should handle writing out conflicting index entries.
-        /// </summary>
-        public CheckoutFileConflictStrategy FileConflictStrategy { get; set; }
-
-        /// <summary>
-        /// Find renames. Default is true.
-        /// </summary>
-        public bool FindRenames { get; set; }
-
-        /// <summary>
-        /// Similarity to consider a file renamed (default 50). If
-        /// `FindRenames` is enabled, added files will be compared
-        /// with deleted files to determine their similarity. Files that are
-        /// more similar than the rename threshold (percentage-wise) will be
-        /// treated as a rename.
-        /// </summary>
-        public int RenameThreshold;
-
-        /// <summary>
-        /// Maximum similarity sources to examine for renames (default 200).
-        /// If the number of rename candidates (add / delete pairs) is greater
-        /// than this value, inexact rename detection is aborted.
-        ///
-        /// This setting overrides the `merge.renameLimit` configuration value.
-        /// </summary>
-        public int TargetLimit;
-
-        #region IConvertableToGitCheckoutOpts
-
-        CheckoutCallbacks IConvertableToGitCheckoutOpts.GenerateCallbacks()
-        {
-            return CheckoutCallbacks.From(OnCheckoutProgress, OnCheckoutNotify);
-        }
-
-        CheckoutStrategy IConvertableToGitCheckoutOpts.CheckoutStrategy
-        {
-            get
-            {
-                return CheckoutStrategy.GIT_CHECKOUT_SAFE |
-                       GitCheckoutOptsWrapper.CheckoutStrategyFromFileConflictStrategy(FileConflictStrategy);
-            }
-        }
-
-        #endregion IConvertableToGitCheckoutOpts
     }
 }

--- a/LibGit2Sharp/ConflictCollection.cs
+++ b/LibGit2Sharp/ConflictCollection.cs
@@ -13,7 +13,7 @@ namespace LibGit2Sharp
     /// </summary>
     public class ConflictCollection : IEnumerable<Conflict>
     {
-        private readonly Repository repo;
+        private readonly Index index;
 
         /// <summary>
         /// Needed for mocking purposes.
@@ -21,9 +21,9 @@ namespace LibGit2Sharp
         protected ConflictCollection()
         { }
 
-        internal ConflictCollection(Repository repo)
+        internal ConflictCollection(Index index)
         {
-            this.repo = repo;
+            this.index = index;
         }
 
         /// <summary>
@@ -36,7 +36,7 @@ namespace LibGit2Sharp
         {
             get
             {
-                return Proxy.git_index_conflict_get(repo.Index.Handle, repo, path);
+                return Proxy.git_index_conflict_get(index.Handle, path);
             }
         }
 
@@ -48,7 +48,7 @@ namespace LibGit2Sharp
         {
             get
             {
-                return new IndexReucEntryCollection(repo);
+                return new IndexReucEntryCollection(index);
             }
         }
 
@@ -60,7 +60,7 @@ namespace LibGit2Sharp
         {
             get
             {
-                return new IndexNameEntryCollection(repo);
+                return new IndexNameEntryCollection(index);
             }
         }
 
@@ -72,7 +72,7 @@ namespace LibGit2Sharp
             IndexEntry ancestor = null, ours = null, theirs = null;
             string currentPath = null;
 
-            foreach (IndexEntry entry in repo.Index)
+            foreach (IndexEntry entry in index)
             {
                 if (entry.StageLevel == StageLevel.Staged)
                 {

--- a/LibGit2Sharp/Core/Handles/ConflictIteratorSafeHandle.cs
+++ b/LibGit2Sharp/Core/Handles/ConflictIteratorSafeHandle.cs
@@ -1,0 +1,11 @@
+﻿namespace LibGit2Sharp.Core.Handles
+{
+    internal class ConflictIteratorSafeHandle : SafeHandleBase
+    {
+        protected override bool ReleaseHandleImpl()
+        {
+            Proxy.git_index_conflict_iterator_free(handle);
+            return true;
+        }
+    }
+}

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -543,6 +543,22 @@ namespace LibGit2Sharp.Core
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath path);
 
         [DllImport(libgit2)]
+        internal static extern int git_index_conflict_iterator_new(
+            out ConflictIteratorSafeHandle iterator,
+            IndexSafeHandle index);
+
+        [DllImport(libgit2)]
+        internal static extern int git_index_conflict_next(
+            out IndexEntrySafeHandle ancestor,
+            out IndexEntrySafeHandle ours,
+            out IndexEntrySafeHandle theirs,
+            ConflictIteratorSafeHandle iterator);
+
+        [DllImport(libgit2)]
+        internal static extern void git_index_conflict_iterator_free(
+            IntPtr iterator);
+
+        [DllImport(libgit2)]
         internal static extern UIntPtr git_index_entrycount(IndexSafeHandle index);
 
         [DllImport(libgit2)]
@@ -603,6 +619,9 @@ namespace LibGit2Sharp.Core
         internal static extern int git_index_write_tree(out GitOid treeOid, IndexSafeHandle index);
 
         [DllImport(libgit2)]
+        internal static extern int git_index_write_tree_to(out GitOid treeOid, IndexSafeHandle index, RepositorySafeHandle repo);
+
+        [DllImport(libgit2)]
         internal static extern int git_index_read_tree(IndexSafeHandle index, GitObjectSafeHandle tree);
 
         [DllImport(libgit2)]
@@ -661,12 +680,11 @@ namespace LibGit2Sharp.Core
             ref GitCheckoutOpts checkout_opts);
 
         [DllImport(libgit2)]
-        internal static extern int git_merge_trees(
+        internal static extern int git_merge_commits(
             out IndexSafeHandle index,
             RepositorySafeHandle repo,
-            GitObjectSafeHandle ancestor_tree,
-            GitObjectSafeHandle our_tree,
-            GitObjectSafeHandle their_tree,
+            GitObjectSafeHandle our_commit,
+            GitObjectSafeHandle their_commit,
             ref GitMergeOpts merge_opts);
 
         [DllImport(libgit2)]

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -919,7 +919,6 @@ namespace LibGit2Sharp.Core
 
         public static Conflict git_index_conflict_get(
             IndexSafeHandle index,
-            Repository repo,
             FilePath path)
         {
             IndexEntrySafeHandle ancestor, ours, theirs;

--- a/LibGit2Sharp/Index.cs
+++ b/LibGit2Sharp/Index.cs
@@ -30,7 +30,7 @@ namespace LibGit2Sharp
             this.repo = repo;
 
             handle = Proxy.git_repository_index(repo.Handle);
-            conflicts = new ConflictCollection(repo);
+            conflicts = new ConflictCollection(this);
 
             repo.RegisterForCleanup(handle);
         }
@@ -41,7 +41,7 @@ namespace LibGit2Sharp
 
             handle = Proxy.git_index_open(indexPath);
             Proxy.git_repository_set_index(repo.Handle, handle);
-            conflicts = new ConflictCollection(repo);
+            conflicts = new ConflictCollection(this);
 
             repo.RegisterForCleanup(handle);
         }

--- a/LibGit2Sharp/IndexNameEntryCollection.cs
+++ b/LibGit2Sharp/IndexNameEntryCollection.cs
@@ -13,7 +13,7 @@ namespace LibGit2Sharp
     /// </summary>
     public class IndexNameEntryCollection : IEnumerable<IndexNameEntry>
     {
-        private readonly Repository repo;
+        private readonly Index index;
 
         /// <summary>
         /// Needed for mocking purposes.
@@ -21,16 +21,16 @@ namespace LibGit2Sharp
         protected IndexNameEntryCollection()
         { }
 
-        internal IndexNameEntryCollection(Repository repo)
+        internal IndexNameEntryCollection(Index index)
         {
-            this.repo = repo;
+            this.index = index;
         }
 
-        private IndexNameEntry this[int index]
+        private IndexNameEntry this[int idx]
         {
             get
             {
-                IndexNameEntrySafeHandle entryHandle = Proxy.git_index_name_get_byindex(repo.Index.Handle, (UIntPtr)index);
+                IndexNameEntrySafeHandle entryHandle = Proxy.git_index_name_get_byindex(index.Handle, (UIntPtr)idx);
                 return IndexNameEntry.BuildFromPtr(entryHandle);
             }
         }
@@ -41,7 +41,7 @@ namespace LibGit2Sharp
         {
             var list = new List<IndexNameEntry>();
 
-            int count = Proxy.git_index_name_entrycount(repo.Index.Handle);
+            int count = Proxy.git_index_name_entrycount(index.Handle);
 
             for (int i = 0; i < count; i++)
             {

--- a/LibGit2Sharp/IndexReucEntryCollection.cs
+++ b/LibGit2Sharp/IndexReucEntryCollection.cs
@@ -13,7 +13,7 @@ namespace LibGit2Sharp
     /// </summary>
     public class IndexReucEntryCollection : IEnumerable<IndexReucEntry>
     {
-        private readonly Repository repo;
+        private readonly Index index;
 
         /// <summary>
         /// Needed for mocking purposes.
@@ -21,9 +21,9 @@ namespace LibGit2Sharp
         protected IndexReucEntryCollection()
         { }
 
-        internal IndexReucEntryCollection(Repository repo)
+        internal IndexReucEntryCollection(Index index)
         {
-            this.repo = repo;
+            this.index = index;
         }
 
         /// <summary>
@@ -35,16 +35,16 @@ namespace LibGit2Sharp
             {
                 Ensure.ArgumentNotNullOrEmptyString(path, "path");
 
-                IndexReucEntrySafeHandle entryHandle = Proxy.git_index_reuc_get_bypath(repo.Index.Handle, path);
+                IndexReucEntrySafeHandle entryHandle = Proxy.git_index_reuc_get_bypath(index.Handle, path);
                 return IndexReucEntry.BuildFromPtr(entryHandle);
             }
         }
 
-        private IndexReucEntry this[int index]
+        private IndexReucEntry this[int idx]
         {
             get
             {
-                IndexReucEntrySafeHandle entryHandle = Proxy.git_index_reuc_get_byindex(repo.Index.Handle, (UIntPtr)index);
+                IndexReucEntrySafeHandle entryHandle = Proxy.git_index_reuc_get_byindex(index.Handle, (UIntPtr)idx);
                 return IndexReucEntry.BuildFromPtr(entryHandle);
             }
         }
@@ -55,7 +55,7 @@ namespace LibGit2Sharp
         {
             var list = new List<IndexReucEntry>();
 
-            int count = Proxy.git_index_reuc_entrycount(repo.Index.Handle);
+            int count = Proxy.git_index_reuc_entrycount(index.Handle);
 
             for (int i = 0; i < count; i++)
             {

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -69,6 +69,7 @@
     <Compile Include="CommitSortStrategies.cs" />
     <Compile Include="CompareOptions.cs" />
     <Compile Include="Core\Platform.cs" />
+    <Compile Include="Core\Handles\ConflictIteratorSafeHandle.cs" />
     <Compile Include="DescribeOptions.cs" />
     <Compile Include="DescribeStrategy.cs" />
     <Compile Include="Core\GitDescribeFormatOptions.cs" />
@@ -101,6 +102,8 @@
     <Compile Include="IndexNameEntry.cs" />
     <Compile Include="MergeOptions.cs" />
     <Compile Include="MergeResult.cs" />
+    <Compile Include="MergeTreeOptions.cs" />
+    <Compile Include="MergeTreeResult.cs" />
     <Compile Include="NotFoundException.cs" />
     <Compile Include="GitObjectMetadata.cs" />
     <Compile Include="PatchEntryChanges.cs" />

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -100,7 +100,9 @@
     <Compile Include="IndexReucEntry.cs" />
     <Compile Include="IndexReucEntryCollection.cs" />
     <Compile Include="IndexNameEntry.cs" />
+    <Compile Include="MergeAndCheckoutOptionsBase.cs" />
     <Compile Include="MergeOptions.cs" />
+    <Compile Include="MergeOptionsBase.cs" />
     <Compile Include="MergeResult.cs" />
     <Compile Include="MergeTreeOptions.cs" />
     <Compile Include="MergeTreeResult.cs" />

--- a/LibGit2Sharp/MergeAndCheckoutOptionsBase.cs
+++ b/LibGit2Sharp/MergeAndCheckoutOptionsBase.cs
@@ -1,0 +1,75 @@
+﻿using LibGit2Sharp.Core;
+using LibGit2Sharp.Handlers;
+using System;
+
+namespace LibGit2Sharp
+{
+    /// <summary>
+    /// Options controlling the behavior of things that do a merge and then
+    /// check out the merge results (eg: merge, revert, cherry-pick).
+    /// </summary>
+    public abstract class MergeAndCheckoutOptionsBase : MergeOptionsBase, IConvertableToGitCheckoutOpts
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MergeOptions"/> class.
+        /// <para>
+        ///   Default behavior:
+        ///     A fast-forward merge will be performed if possible, unless the merge.ff configuration option is set.
+        ///     A merge commit will be committed, if one was created.
+        ///     Merge will attempt to find renames.
+        /// </para>
+        /// </summary>
+        public MergeAndCheckoutOptionsBase()
+        {
+            CommitOnSuccess = true;
+        }
+
+        /// <summary>
+        /// The Flags specifying what conditions are
+        /// reported through the OnCheckoutNotify delegate.
+        /// </summary>
+        public CheckoutNotifyFlags CheckoutNotifyFlags { get; set; }
+
+        /// <summary>
+        /// Commit the merge if the merge is successful and this is a non-fast-forward merge.
+        /// If this is a fast-forward merge, then there is no merge commit and this option
+        /// will not affect the merge.
+        /// </summary>
+        public bool CommitOnSuccess { get; set; }
+
+        /// <summary>
+        /// How conflicting index entries should be written out during checkout.
+        /// </summary>
+        public CheckoutFileConflictStrategy FileConflictStrategy { get; set; }
+
+        /// <summary>
+        /// Delegate that the checkout will report progress through.
+        /// </summary>
+        public CheckoutProgressHandler OnCheckoutProgress { get; set; }
+
+        /// <summary>
+        /// Delegate that checkout will notify callers of
+        /// certain conditions. The conditions that are reported is
+        /// controlled with the CheckoutNotifyFlags property.
+        /// </summary>
+        public CheckoutNotifyHandler OnCheckoutNotify { get; set; }
+
+        #region IConvertableToGitCheckoutOpts
+
+        CheckoutCallbacks IConvertableToGitCheckoutOpts.GenerateCallbacks()
+        {
+            return CheckoutCallbacks.From(OnCheckoutProgress, OnCheckoutNotify);
+        }
+
+        CheckoutStrategy IConvertableToGitCheckoutOpts.CheckoutStrategy
+        {
+            get
+            {
+                return CheckoutStrategy.GIT_CHECKOUT_SAFE |
+                       GitCheckoutOptsWrapper.CheckoutStrategyFromFileConflictStrategy(FileConflictStrategy);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/LibGit2Sharp/MergeOptions.cs
+++ b/LibGit2Sharp/MergeOptions.cs
@@ -132,41 +132,4 @@ namespace LibGit2Sharp
         /// </summary>
         FastForwardOnly = 2, /* GIT_MERGE_FASTFORWARD_ONLY */
     }
-
-    /// <summary>
-    /// Enum specifying how merge should deal with conflicting regions
-    /// of the files.
-    /// </summary>
-    public enum MergeFileFavor
-    {
-        /// <summary>
-        /// When a region of a file is changed in both branches, a conflict
-        /// will be recorded in the index so that the checkout operation can produce
-        /// a merge file with conflict markers in the working directory.
-        /// This is the default.
-        /// </summary>
-        Normal = 0,
-
-        /// <summary>
-        /// When a region of a file is changed in both branches, the file
-        /// created in the index will contain the "ours" side of any conflicting
-        /// region. The index will not record a conflict.
-        /// </summary>
-        Ours = 1,
-
-        /// <summary>
-        /// When a region of a file is changed in both branches, the file
-        /// created in the index will contain the "theirs" side of any conflicting
-        /// region. The index will not record a conflict.
-        /// </summary>
-        Theirs = 2,
-
-        /// <summary>
-        /// When a region of a file is changed in both branches, the file
-        /// created in the index will contain each unique line from each side,
-        /// which has the result of combining both files. The index will not
-        /// record a conflict.
-        /// </summary>
-        Union = 3,
-    }
 }

--- a/LibGit2Sharp/MergeOptions.cs
+++ b/LibGit2Sharp/MergeOptions.cs
@@ -7,7 +7,7 @@ namespace LibGit2Sharp
     /// <summary>
     /// Options controlling Merge behavior.
     /// </summary>
-    public sealed class MergeOptions : IConvertableToGitCheckoutOpts
+    public sealed class MergeOptions : MergeAndCheckoutOptionsBase
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MergeOptions"/> class.
@@ -20,88 +20,12 @@ namespace LibGit2Sharp
         /// </summary>
         public MergeOptions()
         {
-            CommitOnSuccess = true;
-
-            FindRenames = true;
-            // TODO: libgit2 should provide reasonable defaults for these
-            //       values, but it currently does not.
-            RenameThreshold = 50;
-            TargetLimit = 200;
         }
-
-        /// <summary>
-        /// The Flags specifying what conditions are
-        /// reported through the OnCheckoutNotify delegate.
-        /// </summary>
-        public CheckoutNotifyFlags CheckoutNotifyFlags { get; set; }
-
-        /// <summary>
-        /// Commit the merge if the merge is successful and this is a non-fast-forward merge.
-        /// If this is a fast-forward merge, then there is no merge commit and this option
-        /// will not affect the merge.
-        /// </summary>
-        public bool CommitOnSuccess { get; set; }
 
         /// <summary>
         /// The type of merge to perform.
         /// </summary>
         public FastForwardStrategy FastForwardStrategy { get; set; }
-
-        /// <summary>
-        /// How conflicting index entries should be written out during checkout.
-        /// </summary>
-        public CheckoutFileConflictStrategy FileConflictStrategy { get; set; }
-
-        /// <summary>
-        /// Find renames. Default is true.
-        /// </summary>
-        public bool FindRenames { get; set; }
-
-        /// <summary>
-        /// Similarity to consider a file renamed.
-        /// </summary>
-        public int RenameThreshold;
-
-        /// <summary>
-        /// Maximum similarity sources to examine (overrides
-        /// 'merge.renameLimit' config (default 200)
-        /// </summary>
-        public int TargetLimit;
-
-        /// <summary>
-        /// How to handle conflicts encountered during a merge.
-        /// </summary>
-        public MergeFileFavor MergeFileFavor { get; set; }
-
-        /// <summary>
-        /// Delegate that the checkout will report progress through.
-        /// </summary>
-        public CheckoutProgressHandler OnCheckoutProgress { get; set; }
-
-        /// <summary>
-        /// Delegate that checkout will notify callers of
-        /// certain conditions. The conditions that are reported is
-        /// controlled with the CheckoutNotifyFlags property.
-        /// </summary>
-        public CheckoutNotifyHandler OnCheckoutNotify { get; set; }
-
-        #region IConvertableToGitCheckoutOpts
-
-        CheckoutCallbacks IConvertableToGitCheckoutOpts.GenerateCallbacks()
-        {
-            return CheckoutCallbacks.From(OnCheckoutProgress, OnCheckoutNotify);
-        }
-
-        CheckoutStrategy IConvertableToGitCheckoutOpts.CheckoutStrategy
-        {
-            get
-            {
-                return CheckoutStrategy.GIT_CHECKOUT_SAFE |
-                       GitCheckoutOptsWrapper.CheckoutStrategyFromFileConflictStrategy(FileConflictStrategy);
-            }
-        }
-
-        #endregion
     }
 
     /// <summary>

--- a/LibGit2Sharp/MergeOptionsBase.cs
+++ b/LibGit2Sharp/MergeOptionsBase.cs
@@ -1,0 +1,82 @@
+﻿using LibGit2Sharp.Core;
+using LibGit2Sharp.Handlers;
+using System;
+
+namespace LibGit2Sharp
+{
+    /// <summary>
+    /// Options controlling the behavior of actions that use merge (merge
+    /// proper, cherry-pick, revert)
+    /// </summary>
+    public abstract class MergeOptionsBase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MergeOptionsBase"/> class.
+        /// The default behavior is to attempt to find renames.
+        /// </summary>
+        public MergeOptionsBase()
+        {
+            FindRenames = true;
+            RenameThreshold = 50;
+            TargetLimit = 200;
+        }
+
+        /// <summary>
+        /// Find renames. Default is true.
+        /// </summary>
+        public bool FindRenames { get; set; }
+
+        /// <summary>
+        /// Similarity to consider a file renamed.
+        /// </summary>
+        public int RenameThreshold;
+
+        /// <summary>
+        /// Maximum similarity sources to examine (overrides
+        /// 'merge.renameLimit' config (default 200)
+        /// </summary>
+        public int TargetLimit;
+
+        /// <summary>
+        /// How to handle conflicts encountered during a merge.
+        /// </summary>
+        public MergeFileFavor MergeFileFavor { get; set; }
+    }
+
+    /// <summary>
+    /// Enum specifying how merge should deal with conflicting regions
+    /// of the files.
+    /// </summary>
+    public enum MergeFileFavor
+    {
+        /// <summary>
+        /// When a region of a file is changed in both branches, a conflict
+        /// will be recorded in the index so that the checkout operation can produce
+        /// a merge file with conflict markers in the working directory.
+        /// This is the default.
+        /// </summary>
+        Normal = 0,
+
+        /// <summary>
+        /// When a region of a file is changed in both branches, the file
+        /// created in the index will contain the "ours" side of any conflicting
+        /// region. The index will not record a conflict.
+        /// </summary>
+        Ours = 1,
+
+        /// <summary>
+        /// When a region of a file is changed in both branches, the file
+        /// created in the index will contain the "theirs" side of any conflicting
+        /// region. The index will not record a conflict.
+        /// </summary>
+        Theirs = 2,
+
+        /// <summary>
+        /// When a region of a file is changed in both branches, the file
+        /// created in the index will contain each unique line from each side,
+        /// which has the result of combining both files. The index will not
+        /// record a conflict.
+        /// </summary>
+        Union = 3,
+    }
+}

--- a/LibGit2Sharp/MergeTreeOptions.cs
+++ b/LibGit2Sharp/MergeTreeOptions.cs
@@ -1,0 +1,84 @@
+﻿using LibGit2Sharp.Core;
+using LibGit2Sharp.Handlers;
+using System;
+
+namespace LibGit2Sharp
+{
+    /// <summary>
+    /// Options controlling the behavior of two trees being merged.
+    /// </summary>
+    public sealed class MergeTreeOptions
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MergeTreeOptions"/> class.
+        /// <para>
+        ///   Default behavior:
+        ///     Merge will attempt to find renames.
+        /// </para>
+        /// </summary>
+        public MergeTreeOptions()
+        {
+            FindRenames = true;
+            RenameThreshold = 50;
+            TargetLimit = 200;
+        }
+
+        /// <summary>
+        /// Find renames. Default is true.
+        /// </summary>
+        public bool FindRenames { get; set; }
+
+        /// <summary>
+        /// Similarity to consider a file renamed.
+        /// </summary>
+        public int RenameThreshold;
+
+        /// <summary>
+        /// Maximum similarity sources to examine (overrides
+        /// 'merge.renameLimit' config (default 200)
+        /// </summary>
+        public int TargetLimit;
+
+        /// <summary>
+        /// How to handle conflicts encountered during a merge.
+        /// </summary>
+        public MergeFileFavor MergeFileFavor { get; set; }
+    }
+
+    /// <summary>
+    /// Enum specifying how merge should deal with conflicting regions
+    /// of the files.
+    /// </summary>
+    public enum MergeFileFavor
+    {
+        /// <summary>
+        /// When a region of a file is changed in both branches, a conflict
+        /// will be recorded in the index so that the checkout operation can produce
+        /// a merge file with conflict markers in the working directory.
+        /// This is the default.
+        /// </summary>
+        Normal = 0,
+
+        /// <summary>
+        /// When a region of a file is changed in both branches, the file
+        /// created in the index will contain the "ours" side of any conflicting
+        /// region. The index will not record a conflict.
+        /// </summary>
+        Ours = 1,
+
+        /// <summary>
+        /// When a region of a file is changed in both branches, the file
+        /// created in the index will contain the "theirs" side of any conflicting
+        /// region. The index will not record a conflict.
+        /// </summary>
+        Theirs = 2,
+
+        /// <summary>
+        /// When a region of a file is changed in both branches, the file
+        /// created in the index will contain each unique line from each side,
+        /// which has the result of combining both files. The index will not
+        /// record a conflict.
+        /// </summary>
+        Union = 3,
+    }
+}

--- a/LibGit2Sharp/MergeTreeOptions.cs
+++ b/LibGit2Sharp/MergeTreeOptions.cs
@@ -7,7 +7,7 @@ namespace LibGit2Sharp
     /// <summary>
     /// Options controlling the behavior of two trees being merged.
     /// </summary>
-    public sealed class MergeTreeOptions
+    public sealed class MergeTreeOptions : MergeOptionsBase
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MergeTreeOptions"/> class.
@@ -18,67 +18,6 @@ namespace LibGit2Sharp
         /// </summary>
         public MergeTreeOptions()
         {
-            FindRenames = true;
-            RenameThreshold = 50;
-            TargetLimit = 200;
         }
-
-        /// <summary>
-        /// Find renames. Default is true.
-        /// </summary>
-        public bool FindRenames { get; set; }
-
-        /// <summary>
-        /// Similarity to consider a file renamed.
-        /// </summary>
-        public int RenameThreshold;
-
-        /// <summary>
-        /// Maximum similarity sources to examine (overrides
-        /// 'merge.renameLimit' config (default 200)
-        /// </summary>
-        public int TargetLimit;
-
-        /// <summary>
-        /// How to handle conflicts encountered during a merge.
-        /// </summary>
-        public MergeFileFavor MergeFileFavor { get; set; }
-    }
-
-    /// <summary>
-    /// Enum specifying how merge should deal with conflicting regions
-    /// of the files.
-    /// </summary>
-    public enum MergeFileFavor
-    {
-        /// <summary>
-        /// When a region of a file is changed in both branches, a conflict
-        /// will be recorded in the index so that the checkout operation can produce
-        /// a merge file with conflict markers in the working directory.
-        /// This is the default.
-        /// </summary>
-        Normal = 0,
-
-        /// <summary>
-        /// When a region of a file is changed in both branches, the file
-        /// created in the index will contain the "ours" side of any conflicting
-        /// region. The index will not record a conflict.
-        /// </summary>
-        Ours = 1,
-
-        /// <summary>
-        /// When a region of a file is changed in both branches, the file
-        /// created in the index will contain the "theirs" side of any conflicting
-        /// region. The index will not record a conflict.
-        /// </summary>
-        Theirs = 2,
-
-        /// <summary>
-        /// When a region of a file is changed in both branches, the file
-        /// created in the index will contain each unique line from each side,
-        /// which has the result of combining both files. The index will not
-        /// record a conflict.
-        /// </summary>
-        Union = 3,
     }
 }

--- a/LibGit2Sharp/MergeTreeResult.cs
+++ b/LibGit2Sharp/MergeTreeResult.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using LibGit2Sharp.Core;
+
+namespace LibGit2Sharp
+{
+    /// <summary>
+    /// The results of a merge of two trees.
+    /// </summary>
+    public class MergeTreeResult
+    {
+        /// <summary>
+        /// Needed for mocking purposes.
+        /// </summary>
+        protected MergeTreeResult()
+        { }
+
+        internal MergeTreeResult(IEnumerable<Conflict> conflicts)
+        {
+            this.Status = MergeTreeStatus.Conflicts;
+            this.Conflicts = conflicts;
+        }
+
+        internal MergeTreeResult(Tree tree)
+        {
+            this.Status = MergeTreeStatus.Succeeded;
+            this.Tree = tree;
+            this.Conflicts = new List<Conflict>();
+        }
+
+        /// <summary>
+        /// The status of the merge.
+        /// </summary>
+        public virtual MergeTreeStatus Status
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// The resulting tree of the merge.
+        /// <para>This will return <code>null</code> if the merge has been unsuccessful due to conflicts.</para>
+        /// </summary>
+        public virtual Tree Tree
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// The resulting conflicts from the merge.
+        /// <para>This will return <code>null</code> if the merge was successful and there were no conflicts.</para>
+        /// </summary>
+        public virtual IEnumerable<Conflict> Conflicts
+        {
+            get;
+            private set;
+        }
+    }
+
+    /// <summary>
+    /// The status of what happened as a result of a merge.
+    /// </summary>
+    public enum MergeTreeStatus
+    {
+        /// <summary>
+        /// Merge succeeded.
+        /// </summary>
+        Succeeded,
+
+        /// <summary>
+        /// Merge resulted in conflicts.
+        /// </summary>
+        Conflicts,
+    }
+}

--- a/LibGit2Sharp/Repository.cs
+++ b/LibGit2Sharp/Repository.cs
@@ -970,7 +970,7 @@ namespace LibGit2Sharp
                 throw new UnbornBranchException("Can not amend anything. The Head doesn't point at any commit.");
             }
 
-            var treeId = Proxy.git_tree_create_fromindex(Index);
+            var treeId = Proxy.git_index_write_tree(Index.Handle);
             var tree = this.Lookup<Tree>(treeId);
 
             var parents = RetrieveParentsOfTheCommitBeingCreated(options.AmendPreviousCommit).ToList();

--- a/LibGit2Sharp/RevertOptions.cs
+++ b/LibGit2Sharp/RevertOptions.cs
@@ -6,7 +6,7 @@ namespace LibGit2Sharp
     /// <summary>
     /// Options controlling Revert behavior.
     /// </summary>
-    public sealed class RevertOptions : IConvertableToGitCheckoutOpts
+    public sealed class RevertOptions : MergeAndCheckoutOptionsBase
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RevertOptions"/> class.
@@ -14,48 +14,7 @@ namespace LibGit2Sharp
         /// </summary>
         public RevertOptions()
         {
-            CommitOnSuccess = true;
-
-            FindRenames = true;
-
-            // TODO: libgit2 should provide reasonable defaults for these
-            //       values, but it currently does not.
-            RenameThreshold = 50;
-            TargetLimit = 200;
         }
-
-        /// <summary>
-        /// The Flags specifying what conditions are
-        /// reported through the OnCheckoutNotify delegate.
-        /// </summary>
-        public CheckoutNotifyFlags CheckoutNotifyFlags { get; set; }
-
-        /// <summary>
-        /// Delegate that checkout progress will be reported through.
-        /// </summary>
-        public CheckoutProgressHandler OnCheckoutProgress { get; set; }
-
-        /// <summary>
-        /// Delegate that checkout will notify callers of
-        /// certain conditions. The conditions that are reported is
-        /// controlled with the CheckoutNotifyFlags property.
-        /// </summary>
-        public CheckoutNotifyHandler OnCheckoutNotify { get; set; }
-
-        /// <summary>
-        /// Commit changes if there are no conflicts and the revert results
-        /// in changes.
-        /// <para>
-        ///  Following command line behavior, if the revert results in no
-        ///  changes, then Revert will cleanup the repository state if
-        ///  <see cref="CommitOnSuccess"/> is true (i.e. the repository
-        ///  will not be left in a "revert in progress" state).
-        ///  If <see cref="CommitOnSuccess"/> is false and there are no
-        ///  changes to revert, then the repository will be left in
-        ///  the "revert in progress" state.
-        /// </para>
-        /// </summary>
-        public bool CommitOnSuccess { get; set; }
 
         /// <summary>
         /// When reverting a merge commit, the parent number to consider as
@@ -68,57 +27,5 @@ namespace LibGit2Sharp
         /// </para>
         /// </summary>
         public int Mainline { get; set; }
-
-        /// <summary>
-        /// How to handle conflicts encountered during a merge.
-        /// </summary>
-        public MergeFileFavor MergeFileFavor { get; set; }
-
-        /// <summary>
-        /// How Checkout should handle writing out conflicting index entries.
-        /// </summary>
-        public CheckoutFileConflictStrategy FileConflictStrategy { get; set; }
-
-        /// <summary>
-        /// Find renames. Default is true.
-        /// </summary>
-        public bool FindRenames { get; set; }
-
-        /// <summary>
-        /// Similarity to consider a file renamed (default 50). If
-        /// `FindRenames` is enabled, added files will be compared
-        /// with deleted files to determine their similarity. Files that are
-        /// more similar than the rename threshold (percentage-wise) will be
-        /// treated as a rename.
-        /// </summary>
-        public int RenameThreshold;
-
-        /// <summary>
-        /// Maximum similarity sources to examine for renames (default 200).
-        /// If the number of rename candidates (add / delete pairs) is greater
-        /// than this value, inexact rename detection is aborted.
-        ///
-        /// This setting overrides the `merge.renameLimit` configuration value.
-        /// </summary>
-        public int TargetLimit;
-
-        #region IConvertableToGitCheckoutOpts
-
-        CheckoutCallbacks IConvertableToGitCheckoutOpts.GenerateCallbacks()
-        {
-            return CheckoutCallbacks.From(OnCheckoutProgress, OnCheckoutNotify);
-        }
-
-        CheckoutStrategy IConvertableToGitCheckoutOpts.CheckoutStrategy
-        {
-            get
-            {
-                return CheckoutStrategy.GIT_CHECKOUT_SAFE |
-                       GitCheckoutOptsWrapper.CheckoutStrategyFromFileConflictStrategy(FileConflictStrategy);
-            }
-        }
-
-        #endregion IConvertableToGitCheckoutOpts
-
     }
 }


### PR DESCRIPTION
This introduces `Repository.MergeCommits` which wraps `git_merge_commits` and is suitable for taking two commits and getting the merge results as an `Index`.  There's a handful of interesting details here:

* The conflict data previously had a pointer to the `Repository`.  This meant that they always went to the repository's `Index`.  I broke this and pass in the `Index` that they're supposed to pay attention to.  This is probably the least contentious change.

* Since the resultant `index` needs to be freed with `git_index_free`, I made `Index` implement `IDisposable` so that consumers of `Repository.MergeCommits` can just wrap that in a `using`.  To prevent anybody from trying to `Dispose` the `Repository.Index`, I only wired up `Dispose` for things that came from a merge.  

* I refactored `MergeOptions`, `CherryPickOptions` and `RevertOptions` to share a common base class.  They were getting a little copy-pastey.  I also pulled out the `git_merge_options`-like things into their own base class so that `MergeTreeOptions` could also take advantage.

I suspect there's going to be something in here for everybody to hate!  :)  Other suggestions for how to implement these things  are welcome.