### PR TITLE
Introduce `GlobalSettings.NativeLibraryPath`

### DIFF
--- a/LibGit2Sharp.Tests/BlobFixture.cs
+++ b/LibGit2Sharp.Tests/BlobFixture.cs
@@ -222,7 +222,7 @@ namespace LibGit2Sharp.Tests
 
         private static void SkipIfNotSupported(string autocrlf)
         {
-            InconclusiveIf(() => autocrlf == "true" && IsRunningOnLinux(), "Non-Windows does not support core.autocrlf = true");
+            InconclusiveIf(() => autocrlf == "true" && IsRunningOnUnix(), "Non-Windows does not support core.autocrlf = true");
         }
     }
 }

--- a/LibGit2Sharp.Tests/GlobalSettingsFixture.cs
+++ b/LibGit2Sharp.Tests/GlobalSettingsFixture.cs
@@ -55,5 +55,14 @@ namespace LibGit2Sharp.Tests
                 Assert.True(matchGroups[i].Success);
             }
         }
+
+        [Fact]
+        public void TryingToResetNativeLibraryPathAfterLoadedThrows()
+        {
+            // Do something that loads the native library
+            Assert.NotNull(GlobalSettings.Version.Features);
+
+            Assert.Throws<LibGit2SharpException>(() => { GlobalSettings.NativeLibraryPath = "C:/Foo"; });
+        }
     }
 }

--- a/LibGit2Sharp.Tests/ShadowCopyFixture.cs
+++ b/LibGit2Sharp.Tests/ShadowCopyFixture.cs
@@ -62,7 +62,7 @@ namespace LibGit2Sharp.Tests
             string cachedAssembliesPath = Path.Combine(setup.CachePath, setup.ApplicationName);
             Assert.True(cachedAssemblyLocation.StartsWith(cachedAssembliesPath));
 
-            if (!IsRunningOnLinux())
+            if (!IsRunningOnUnix())
             {
                 // ...that this cache doesn't contain the `NativeBinaries` folder
                 string cachedAssemblyParentPath = Path.GetDirectoryName(cachedAssemblyLocation);

--- a/LibGit2Sharp.Tests/TestHelpers/BaseFixture.cs
+++ b/LibGit2Sharp.Tests/TestHelpers/BaseFixture.cs
@@ -91,8 +91,8 @@ namespace LibGit2Sharp.Tests.TestHelpers
             return !isInsensitive;
         }
 
-        // Should match LibGit2Sharp.Core.NativeMethods.IsRunningOnLinux()
-        protected static bool IsRunningOnLinux()
+        // Should match LibGit2Sharp.Core.NativeMethods.IsRunningOnUnix()
+        protected static bool IsRunningOnUnix()
         {
             // see http://mono-project.com/FAQ%3a_Technical#Mono_Platforms
             var p = (int)Environment.OSVersion.Platform;

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -64,42 +64,17 @@ namespace LibGit2Sharp.Core
 
         static NativeMethods()
         {
-            if (!IsRunningOnUnix())
+            if (Platform.OperatingSystem == OperatingSystemType.Windows)
             {
-                string originalAssemblypath = new Uri(Assembly.GetExecutingAssembly().EscapedCodeBase).LocalPath;
-
-                string currentArchSubPath = "NativeBinaries/" + ProcessorArchitecture;
-
-                string path = Path.Combine(Path.GetDirectoryName(originalAssemblypath), currentArchSubPath);
+                string path = Path.Combine(GlobalSettings.NativeLibraryPath, Platform.ProcessorArchitecture);
 
                 const string pathEnvVariable = "PATH";
                 Environment.SetEnvironmentVariable(pathEnvVariable,
-                                                   String.Format(CultureInfo.InvariantCulture, "{0}{1}{2}", path, Path.PathSeparator, Environment.GetEnvironmentVariable(pathEnvVariable)));
+                    String.Format(CultureInfo.InvariantCulture, "{0}{1}{2}", path, Path.PathSeparator, Environment.GetEnvironmentVariable(pathEnvVariable)));
             }
 
             // See LibraryLifetimeObject description.
             lifetimeObject = new LibraryLifetimeObject();
-        }
-
-        public static string ProcessorArchitecture
-        {
-            get
-            {
-                if (Environment.Is64BitProcess)
-                {
-                    return "amd64";
-                }
-
-                return "x86";
-            }
-        }
-
-        // Should match LibGit2Sharp.Tests.TestHelpers.BaseFixture.IsRunningOnUnix()
-        private static bool IsRunningOnUnix()
-        {
-            // see http://mono-project.com/FAQ%3a_Technical#Mono_Platforms
-            var p = (int)Environment.OSVersion.Platform;
-            return (p == 4) || (p == 6) || (p == 128);
         }
 
         [DllImport(libgit2)]

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -64,7 +64,7 @@ namespace LibGit2Sharp.Core
 
         static NativeMethods()
         {
-            if (!IsRunningOnLinux())
+            if (!IsRunningOnUnix())
             {
                 string originalAssemblypath = new Uri(Assembly.GetExecutingAssembly().EscapedCodeBase).LocalPath;
 
@@ -94,8 +94,8 @@ namespace LibGit2Sharp.Core
             }
         }
 
-        // Should match LibGit2Sharp.Tests.TestHelpers.BaseFixture.IsRunningOnLinux()
-        private static bool IsRunningOnLinux()
+        // Should match LibGit2Sharp.Tests.TestHelpers.BaseFixture.IsRunningOnUnix()
+        private static bool IsRunningOnUnix()
         {
             // see http://mono-project.com/FAQ%3a_Technical#Mono_Platforms
             var p = (int)Environment.OSVersion.Platform;

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -66,7 +66,9 @@ namespace LibGit2Sharp.Core
         {
             if (Platform.OperatingSystem == OperatingSystemType.Windows)
             {
-                string path = Path.Combine(GlobalSettings.NativeLibraryPath, Platform.ProcessorArchitecture);
+                string nativeLibraryPath = GlobalSettings.GetAndLockNativeLibraryPath();
+
+                string path = Path.Combine(nativeLibraryPath, Platform.ProcessorArchitecture);
 
                 const string pathEnvVariable = "PATH";
                 Environment.SetEnvironmentVariable(pathEnvVariable,

--- a/LibGit2Sharp/Core/Platform.cs
+++ b/LibGit2Sharp/Core/Platform.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace LibGit2Sharp.Core
+{
+    internal enum OperatingSystemType
+    {
+        Windows,
+        Unix,
+        MacOSX
+    }
+
+    internal class Platform
+    {
+        public static string ProcessorArchitecture
+        {
+            get
+            {
+                if (Environment.Is64BitProcess)
+                {
+                    return "amd64";
+                }
+
+                return "x86";
+            }
+        }
+
+        public static OperatingSystemType OperatingSystem
+        {
+            get
+            {
+                // See http://www.mono-project.com/docs/faq/technical/#how-to-detect-the-execution-platform
+                var platformId = (int)Environment.OSVersion.Platform;
+
+                switch ((int)Environment.OSVersion.Platform)
+                {
+                    case 4:
+                    case 128:
+                        return OperatingSystemType.Unix;
+                    case 6:
+                        return OperatingSystemType.MacOSX;
+                    default:
+                        return OperatingSystemType.Windows;
+                }
+            }
+        }
+    }
+}

--- a/LibGit2Sharp/GlobalSettings.cs
+++ b/LibGit2Sharp/GlobalSettings.cs
@@ -15,6 +15,7 @@ namespace LibGit2Sharp
         private static LogConfiguration logConfiguration = LogConfiguration.None;
 
         private static string nativeLibraryPath;
+        private static bool nativeLibraryPathLocked;
 
         static GlobalSettings()
         {
@@ -154,8 +155,19 @@ namespace LibGit2Sharp
                     throw new LibGit2SharpException("Setting the native hint path is only supported on Windows platforms");
                 }
 
+                if (nativeLibraryPathLocked)
+                {
+                    throw new LibGit2SharpException("You cannot set the native library path after it has been loaded");
+                }
+
                 nativeLibraryPath = value;
             }
+        }
+
+        internal static string GetAndLockNativeLibraryPath()
+        {
+            nativeLibraryPathLocked = true;
+            return nativeLibraryPath;
         }
     }
 }

--- a/LibGit2Sharp/GlobalSettings.cs
+++ b/LibGit2Sharp/GlobalSettings.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.IO;
+using System.Reflection;
 using LibGit2Sharp.Core;
 
 namespace LibGit2Sharp
@@ -11,6 +13,17 @@ namespace LibGit2Sharp
         private static readonly Lazy<Version> version = new Lazy<Version>(Version.Build);
 
         private static LogConfiguration logConfiguration = LogConfiguration.None;
+
+        private static string nativeLibraryPath;
+
+        static GlobalSettings()
+        {
+            if (Platform.OperatingSystem == OperatingSystemType.Windows)
+            {
+                string managedPath = new Uri(Assembly.GetExecutingAssembly().EscapedCodeBase).LocalPath;
+                nativeLibraryPath = Path.Combine(Path.GetDirectoryName(managedPath), "NativeBinaries");
+            }
+        }
 
         /// <summary>
         /// Returns information related to the current LibGit2Sharp
@@ -106,6 +119,42 @@ namespace LibGit2Sharp
             get
             {
                 return logConfiguration;
+            }
+        }
+
+        /// <summary>
+        /// Sets a hint path for searching for native binaries: when
+        /// specified, native binaries will first be searched in a
+        /// subdirectory of the given path corresponding to the architecture
+        /// (eg, "x86" or "amd64") before falling back to the default
+        /// path ("NativeBinaries\x86" or "NativeBinaries\amd64" next
+        /// to the application).
+        /// <para>
+        /// This must be set before any other calls to the library,
+        /// and is not available on Unix platforms: see your dynamic
+        /// library loader's documentation for details.
+        /// </para>
+        /// </summary>
+        public static string NativeLibraryPath
+        {
+            get
+            {
+                if (Platform.OperatingSystem != OperatingSystemType.Windows)
+                {
+                    throw new LibGit2SharpException("Querying the native hint path is only supported on Windows platforms");
+                }
+
+                return nativeLibraryPath;
+            }
+
+            set
+            {
+                if (Platform.OperatingSystem != OperatingSystemType.Windows)
+                {
+                    throw new LibGit2SharpException("Setting the native hint path is only supported on Windows platforms");
+                }
+
+                nativeLibraryPath = value;
             }
         }
     }

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -68,6 +68,7 @@
     <Compile Include="CommitOptions.cs" />
     <Compile Include="CommitSortStrategies.cs" />
     <Compile Include="CompareOptions.cs" />
+    <Compile Include="Core\Platform.cs" />
     <Compile Include="DescribeOptions.cs" />
     <Compile Include="DescribeStrategy.cs" />
     <Compile Include="Core\GitDescribeFormatOptions.cs" />

--- a/LibGit2Sharp/Version.cs
+++ b/LibGit2Sharp/Version.cs
@@ -98,7 +98,7 @@ namespace LibGit2Sharp
                 InformationalVersion,
                 LibGit2SharpCommitSha,
                 LibGit2CommitSha,
-                NativeMethods.ProcessorArchitecture,
+                Platform.ProcessorArchitecture,
                 features);
         }
 


### PR DESCRIPTION
Introduce `GlobalSettings.NativeLibraryPath` on Windows, that allows consumers to configure the location where native libraries will get loaded.

This is advantageous in some environments where you have control over the location of your native libraries, but do not have any control over the location of the executing assembly.  An example of such a crazy setup would be an MSBuild task - custom tasks are built (and executed from) `%LOCALAPPDATA%\Temp\<random>`.