### PR TITLE
Unskip include-tag related fetch tests

### DIFF
--- a/LibGit2Sharp.Tests/FetchFixture.cs
+++ b/LibGit2Sharp.Tests/FetchFixture.cs
@@ -12,7 +12,7 @@ namespace LibGit2Sharp.Tests
     {
         private const string remoteName = "testRemote";
 
-        [Theory(Skip = "Skipping due to recent github handling modification of --include-tag.")]
+        [Theory]
         [InlineData("http://github.com/libgit2/TestGitRepository")]
         [InlineData("https://github.com/libgit2/TestGitRepository")]
         [InlineData("git://github.com/libgit2/TestGitRepository.git")]
@@ -152,7 +152,7 @@ namespace LibGit2Sharp.Tests
         [Theory]
         [InlineData(TagFetchMode.All, 4)]
         [InlineData(TagFetchMode.None, 0)]
-        //[InlineData(TagFetchMode.Auto, 3)] // TODO: Skipping due to github modification of --include-tag handling."
+        [InlineData(TagFetchMode.Auto, 3)]
         public void FetchRespectsConfiguredAutoTagSetting(TagFetchMode tagFetchMode, int expectedTagCount)
         {
             string url = "http://github.com/libgit2/TestGitRepository";

--- a/LibGit2Sharp.Tests/RepositoryFixture.cs
+++ b/LibGit2Sharp.Tests/RepositoryFixture.cs
@@ -150,7 +150,7 @@ namespace LibGit2Sharp.Tests
             Assert.Equal(FileAttributes.Hidden, (attribs & FileAttributes.Hidden));
         }
 
-        [Fact(Skip = "Skipping due to recent github handling modification of --include-tag.")]
+        [Fact]
         public void CanFetchFromRemoteByName()
         {
             string remoteName = "testRemote";

--- a/LibGit2Sharp.Tests/SmartSubtransportFixture.cs
+++ b/LibGit2Sharp.Tests/SmartSubtransportFixture.cs
@@ -55,7 +55,7 @@ namespace LibGit2Sharp.Tests
                     }
 
                     // Add the expected tags
-                    string[] expectedTagNames = { "blob", "commit_tree" };
+                    string[] expectedTagNames = { "blob", "commit_tree", "annotated_tag" };
                     foreach (string tagName in expectedTagNames)
                     {
                         TestRemoteInfo.ExpectedTagInfo expectedTagInfo = expectedResults.Tags[tagName];


### PR DESCRIPTION
Due to a recent GitHub policy change, those tests now pass