### PR TITLE
source index using SourceLink.exe

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,6 +39,7 @@ install:
     $ShouldPublishNugetArtifact = "$($env:APPVEYOR_PULL_REQUEST_NUMBER -eq $null)"
     $Env:SHOULD_PUBLISH_NUGET_ARTIFACT = $ShouldPublishNugetArtifact
     Write-Host "Should publish Nuget artifact = $($Env:SHOULD_PUBLISH_NUGET_ARTIFACT)"
+    cinst sourcelink -y
 
 assembly_info:
   patch: true
@@ -62,7 +63,7 @@ test_script:
 
 on_success:
 - ps: |
-    & "$env:APPVEYOR_BUILD_FOLDER\nuget.package\BuildNugetPackage.ps1" "$env:APPVEYOR_REPO_COMMIT"
+    & "$env:APPVEYOR_BUILD_FOLDER\nuget.package\BuildNugetPackage.ps1" -commitSha "$env:APPVEYOR_REPO_COMMIT" -postBuild  { sourcelink index -pr LibGit2Sharp.csproj -pp Configuration Release -nf Core\UniqueIdentifier.cs -nf Properties\AssemblyInfo.cs -r .. -u 'https://raw.githubusercontent.com/libgit2/libgit2sharp/{0}/%var2%' }
     Add-Type -Path "$env:APPVEYOR_BUILD_FOLDER\LibGit2Sharp\bin\Release\LibGit2Sharp.dll"
     Write-Host "LibGit2Sharp version = $([LibGit2Sharp.GlobalSettings]::Version)" -ForegroundColor "Magenta"
     If ($Env:SHOULD_PUBLISH_NUGET_ARTIFACT -eq $True)

--- a/nuget.package/LibGit2Sharp.nuspec
+++ b/nuget.package/LibGit2Sharp.nuspec
@@ -24,5 +24,6 @@
     <file src="..\CHANGES.md" target="App_Readme\LibGit2Sharp.CHANGES.md" />
     <file src="..\nuget.package\build\*.*" target="build\net40" />
     <file src="..\Lib\NativeBinaries\libgit2.license.txt" target="App_Readme" />
+    <file src="bin\$configuration$\$id$.pdb" target="lib\net40" />
   </files>
 </package>


### PR DESCRIPTION
fixes #876, changes based on #1003

https://ci.appveyor.com/project/ctaggart/libgit2sharp/build/3/job/odbyu9n88cjfgw1i#L123
![image](https://cloud.githubusercontent.com/assets/80104/6768508/998b63da-d02c-11e4-85e6-58f3418fe07e.png)

> Is there a tool that you know of that would allow someone to check that the rewritten .pdb is valid/consistent?

I've addressed @nulltoken's concern from #465 with a `sourcelink checksums --check` command you can verify the pdb file source index works.

``` powershell
cinst sourcelink
SourceLink.exe checksums -p 'lib\net40\LibGit2Sharp.pdb' -nf -u -c
```

![image](https://cloud.githubusercontent.com/assets/80104/6768541/1475059a-d02f-11e4-989f-f941a9249268.png)