### PR TITLE
Refactored ReferenceCollection and ReferenceCollectionExtension

### DIFF
--- a/LibGit2Sharp.Tests/BranchFixture.cs
+++ b/LibGit2Sharp.Tests/BranchFixture.cs
@@ -591,6 +591,32 @@ namespace LibGit2Sharp.Tests
             }
         }
 
+		[Fact]
+		public void CanGetTrackingInformationFromHeadSharingNoHistoryWithItsTrackedBranch()
+		{
+			string path = SandboxStandardTestRepo();
+			using (var repo = new Repository(path))
+			{
+				Branch master = repo.Branches["master"];
+				const string logMessage = "update target message";
+				repo.Refs.UpdateTarget("HEAD", "origin/test", logMessage);
+
+				Assert.True(master.IsTracking);
+				Assert.NotNull(master.TrackedBranch);
+				AssertBelongsToARepository(repo, master.TrackedBranch);
+
+				Assert.NotNull(master.TrackingDetails);
+				Assert.Equal(2, master.TrackingDetails.AheadBy);
+				Assert.Equal(2, master.TrackingDetails.BehindBy);
+				Assert.Null(repo.Head.TrackingDetails.CommonAncestor);
+
+				// Assert reflog entry is created
+				var reflogEntry = repo.Refs.Log("HEAD").First();
+				Assert.Equal(repo.Branches["origin/test"].Tip.Id, reflogEntry.To);
+				Assert.Equal(logMessage, reflogEntry.Message);
+			}
+		}
+
         [Fact]
         public void TrackingInformationIsEmptyForBranchTrackingPrunedRemoteBranch()
         {

--- a/LibGit2Sharp/ReferenceCollection.cs
+++ b/LibGit2Sharp/ReferenceCollection.cs
@@ -200,7 +200,7 @@ namespace LibGit2Sharp
             Ensure.ArgumentNotNull(directRef, "directRef");
             Ensure.ArgumentNotNull(targetId, "targetId");
 
-            if (directRef.CanonicalName == "HEAD")
+            if (directRef.CanonicalName == Head.CanonicalName)
             {
                 return UpdateHeadTarget(targetId, logMessage);
             }
@@ -240,7 +240,7 @@ namespace LibGit2Sharp
             Ensure.ArgumentNotNull(symbolicRef, "symbolicRef");
             Ensure.ArgumentNotNull(targetRef, "targetRef");
 
-            if (symbolicRef.CanonicalName == "HEAD")
+			if (symbolicRef.CanonicalName == Head.CanonicalName)
             {
                 return UpdateHeadTarget(targetRef, logMessage);
             }

--- a/LibGit2Sharp/ReferenceCollectionExtensions.cs
+++ b/LibGit2Sharp/ReferenceCollectionExtensions.cs
@@ -161,7 +161,7 @@ namespace LibGit2Sharp
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNullOrEmptyString(canonicalRefNameOrObjectish, "canonicalRefNameOrObjectish");
 
-            if (name == "HEAD")
+            if (name == refsColl.Head.CanonicalName)
             {
                 return refsColl.UpdateHeadTarget(canonicalRefNameOrObjectish, logMessage);
             }


### PR DESCRIPTION
Hello nulltoken.

Found the way to refactor #1000

I've noticed, that the collection already has reference to head, so I've chosen the CanonicalName of this reference what is equal to "HEAD"

Hope, I helped with this issue.

Regards, Alex

PS: Sorry, it is my first pull request :-) so I had little issues with creating it properly. And still might have(