### PR TITLE
`Index.Count` is wee

### DIFF
--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -564,7 +564,7 @@ namespace LibGit2Sharp.Core
         internal static extern int git_index_has_conflicts(IndexSafeHandle index);
 
         [DllImport(libgit2)]
-        internal static extern uint git_index_name_entrycount(IndexSafeHandle handle);
+        internal static extern UIntPtr git_index_name_entrycount(IndexSafeHandle handle);
 
         [DllImport(libgit2)]
         internal static extern IndexNameEntrySafeHandle git_index_name_get_byindex(IndexSafeHandle handle, UIntPtr n);
@@ -586,7 +586,7 @@ namespace LibGit2Sharp.Core
 
 
         [DllImport(libgit2)]
-        internal static extern uint git_index_reuc_entrycount(IndexSafeHandle handle);
+        internal static extern UIntPtr git_index_reuc_entrycount(IndexSafeHandle handle);
 
         [DllImport(libgit2)]
         internal static extern IndexReucEntrySafeHandle git_index_reuc_get_byindex(IndexSafeHandle handle, UIntPtr n);

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -3461,5 +3461,28 @@ namespace LibGit2Sharp.Core
             return result ? 0 : (int)GitErrorCode.User;
         }
     }
+
+    /// <summary>
+    /// Class to hold extension methods used by the proxy class.
+    /// </summary>
+    static class ProxyExtensions
+    {
+        /// <summary>
+        /// Convert a UIntPtr to a int value. Will throw
+        /// exception if there is an overflow.
+        /// </summary>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        public static int ConvertToInt(this UIntPtr input)
+        {
+            ulong ulongValue = (ulong)input;
+            if (ulongValue > int.MaxValue)
+            {
+                throw new LibGit2SharpException("value exceeds size of an int");
+            }
+
+            return (int)input;
+        }
+    }
 }
 // ReSharper restore InconsistentNaming

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -942,12 +942,8 @@ namespace LibGit2Sharp.Core
 
         public static int git_index_entrycount(IndexSafeHandle index)
         {
-            UIntPtr count = NativeMethods.git_index_entrycount(index);
-            if ((long)count > int.MaxValue)
-            {
-                throw new LibGit2SharpException("Index entry count exceeds size of int");
-            }
-            return (int)count;
+            return NativeMethods.git_index_entrycount(index)
+                .ConvertToInt();
         }
 
         public static StageLevel git_index_entry_stage(IndexEntrySafeHandle index)
@@ -982,12 +978,8 @@ namespace LibGit2Sharp.Core
 
         public static int git_index_name_entrycount(IndexSafeHandle index)
         {
-            uint count = NativeMethods.git_index_name_entrycount(index);
-            if ((long)count > int.MaxValue)
-            {
-                throw new LibGit2SharpException("Index name entry count exceeds size of int");
-            }
-            return (int)count;
+            return NativeMethods.git_index_name_entrycount(index)
+                .ConvertToInt();
         }
 
         public static IndexNameEntrySafeHandle git_index_name_get_byindex(IndexSafeHandle index, UIntPtr n)
@@ -1027,12 +1019,8 @@ namespace LibGit2Sharp.Core
 
         public static int git_index_reuc_entrycount(IndexSafeHandle index)
         {
-            uint count = NativeMethods.git_index_reuc_entrycount(index);
-            if ((long)count > int.MaxValue)
-            {
-                throw new LibGit2SharpException("Index REUC entry count exceeds size of int");
-            }
-            return (int)count;
+            return NativeMethods.git_index_reuc_entrycount(index)
+                .ConvertToInt();
         }
 
         public static IndexReucEntrySafeHandle git_index_reuc_get_byindex(IndexSafeHandle index, UIntPtr n)


### PR DESCRIPTION
Currently, [`Index.Count`](https://github.com/libgit2/libgit2sharp/blob/a026f5d84e35f1df94bc3f30503429ef8a216209/LibGit2Sharp/Index.cs#L59) returns an `int`.  Should this be a `long`?  (This is a `size_t` in native land.)  Exceeding a signed 32 bit's worth of index entries is a lot, but not an unfathomable or impossible number.

Similarly, [`git_index_reuc_entrycount`](https://github.com/libgit2/libgit2sharp/blob/a026f5d84e35f1df94bc3f30503429ef8a216209/LibGit2Sharp/Core/NativeMethods.cs#L613) and [`git_index_name_entrycount`](https://github.com/libgit2/libgit2sharp/blob/a026f5d84e35f1df94bc3f30503429ef8a216209/LibGit2Sharp/Core/NativeMethods.cs#L591) probably want to be `UIntPtr`s in `NativeMethods` and choked down to a `long` in the `Proxy`.
