### PR TITLE
Obsolete ReferenceWrapper.Name in favor of FriendlyName

### DIFF
--- a/LibGit2Sharp.Tests/BranchFixture.cs
+++ b/LibGit2Sharp.Tests/BranchFixture.cs
@@ -26,7 +26,7 @@ namespace LibGit2Sharp.Tests
 
                 Branch newBranch = repo.CreateBranch(name, committish);
                 Assert.NotNull(newBranch);
-                Assert.Equal(name, newBranch.Name);
+                Assert.Equal(name, newBranch.FriendlyName);
                 Assert.Equal("refs/heads/" + name, newBranch.CanonicalName);
                 Assert.NotNull(newBranch.Tip);
                 Assert.Equal(committish, newBranch.Tip.Sha);
@@ -36,7 +36,7 @@ namespace LibGit2Sharp.Tests
                 // when they're read back:
                 // - from InlineData: C5-00-6E-00-67-00-73-00-74-00-72-00-F6-00-6D-00
                 // - from filesystem: 41-00-0A-03-6E-00-67-00-73-00-74-00-72-00-6F-00-08-03-6D-00
-                Assert.NotNull(repo.Branches.SingleOrDefault(p => p.Name.Normalize() == name));
+                Assert.NotNull(repo.Branches.SingleOrDefault(p => p.FriendlyName.Normalize() == name));
 
                 AssertRefLogEntry(repo, newBranch.CanonicalName,
                                   "branch: Created from " + committish,
@@ -44,7 +44,7 @@ namespace LibGit2Sharp.Tests
                                   newBranch.Tip.Id,
                                   Constants.Identity, DateTimeOffset.Now);
 
-                repo.Branches.Remove(newBranch.Name);
+                repo.Branches.Remove(newBranch.FriendlyName);
                 Assert.Null(repo.Branches[name]);
             }
         }
@@ -122,12 +122,12 @@ namespace LibGit2Sharp.Tests
                 const string name = "unit_test";
                 Branch newBranch = repo.CreateBranch(name);
                 Assert.NotNull(newBranch);
-                Assert.Equal(name, newBranch.Name);
+                Assert.Equal(name, newBranch.FriendlyName);
                 Assert.Equal("refs/heads/" + name, newBranch.CanonicalName);
                 Assert.False(newBranch.IsCurrentRepositoryHead);
                 Assert.NotNull(newBranch.Tip);
                 Assert.Equal("32eab9cb1f450b5fe7ab663462b77d7f4b703344", newBranch.Tip.Sha);
-                Assert.NotNull(repo.Branches.SingleOrDefault(p => p.Name == name));
+                Assert.NotNull(repo.Branches.SingleOrDefault(p => p.FriendlyName == name));
 
                 AssertRefLogEntry(repo, newBranch.CanonicalName,
                                   "branch: Created from " + headCommitOrBranchSpec,
@@ -303,7 +303,7 @@ namespace LibGit2Sharp.Tests
             string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
-                Assert.Equal(expectedBranches, SortedBranches(repo.Branches, b => b.Name));
+                Assert.Equal(expectedBranches, SortedBranches(repo.Branches, b => b.FriendlyName));
 
                 Assert.Equal(5, repo.Branches.Count());
             }
@@ -324,7 +324,7 @@ namespace LibGit2Sharp.Tests
                                              };
 
                 Assert.Equal(expectedWdBranches,
-                             SortedBranches(repo.Branches.Where(b => !b.IsRemote), b => b.Name));
+                             SortedBranches(repo.Branches.Where(b => !b.IsRemote), b => b.FriendlyName));
             }
         }
 
@@ -341,7 +341,7 @@ namespace LibGit2Sharp.Tests
                                                  "origin/test"
                                              };
 
-                Assert.Equal(expectedWdBranches, SortedBranches(repo.Branches, b => b.Name));
+                Assert.Equal(expectedWdBranches, SortedBranches(repo.Branches, b => b.FriendlyName));
             }
         }
 
@@ -366,7 +366,7 @@ namespace LibGit2Sharp.Tests
                                                                   new { Name = "origin/test", Sha = "e90810b8df3e80c413d903f631643c716887138d", IsRemote = true },
                                                               };
                 Assert.Equal(expectedBranchesIncludingRemoteRefs,
-                             SortedBranches(repo.Branches, b => new { b.Name, b.Tip.Sha, b.IsRemote }));
+                             SortedBranches(repo.Branches, b => new { Name = b.FriendlyName, b.Tip.Sha, b.IsRemote }));
             }
         }
 
@@ -483,11 +483,11 @@ namespace LibGit2Sharp.Tests
             {
                 Branch branch = repo.Branches["refs/heads/br2"];
                 Assert.NotNull(branch);
-                Assert.Equal("br2", branch.Name);
+                Assert.Equal("br2", branch.FriendlyName);
 
                 Branch branch2 = repo.Branches["refs/heads/br2"];
                 Assert.NotNull(branch2);
-                Assert.Equal("br2", branch2.Name);
+                Assert.Equal("br2", branch2.FriendlyName);
 
                 Assert.Equal(branch, branch2);
                 Assert.True((branch2 == branch));
@@ -503,7 +503,7 @@ namespace LibGit2Sharp.Tests
                 Branch master = repo.Branches["master"];
                 Assert.NotNull(master);
                 Assert.False(master.IsRemote);
-                Assert.Equal("master", master.Name);
+                Assert.Equal("master", master.FriendlyName);
                 Assert.Equal("refs/heads/master", master.CanonicalName);
                 Assert.True(master.IsCurrentRepositoryHead);
                 Assert.Equal("4c062a6361ae6959e06292c1fa5e2822d9c96345", master.Tip.Sha);
@@ -551,7 +551,7 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(0, head.Commits.Count());
                 Assert.True(head.IsCurrentRepositoryHead);
                 Assert.False(head.IsRemote);
-                Assert.Equal("master", head.Name);
+                Assert.Equal("master", head.FriendlyName);
                 Assert.Null(head.Tip);
                 Assert.Null(head["huh?"]);
 
@@ -916,7 +916,7 @@ namespace LibGit2Sharp.Tests
             string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
-                Assert.Throws<LibGit2SharpException>(() => repo.Branches.Remove(repo.Head.Name));
+                Assert.Throws<LibGit2SharpException>(() => repo.Branches.Remove(repo.Head.FriendlyName));
             }
         }
 
@@ -988,7 +988,7 @@ namespace LibGit2Sharp.Tests
 
                 Branch newBranch = repo.Branches.Rename("br2", "br3");
 
-                Assert.Equal("br3", newBranch.Name);
+                Assert.Equal("br3", newBranch.FriendlyName);
 
                 Assert.Null(repo.Branches["br2"]);
                 Assert.NotNull(repo.Branches["br3"]);
@@ -1026,7 +1026,7 @@ namespace LibGit2Sharp.Tests
                 Assert.NotNull(br2);
 
                 Branch newBranch = repo.Branches.Rename("br2", "test", true);
-                Assert.Equal("test", newBranch.Name);
+                Assert.Equal("test", newBranch.FriendlyName);
 
                 Assert.Null(repo.Branches["br2"]);
 
@@ -1085,7 +1085,7 @@ namespace LibGit2Sharp.Tests
             using (var repo = new Repository(clonedRepoPath))
             {
                 Assert.Empty(Directory.GetFiles(scd2.RootedDirectoryPath));
-                Assert.Equal(repo.Head.Name, "master");
+                Assert.Equal(repo.Head.FriendlyName, "master");
 
                 Assert.Null(repo.Head.Tip);
                 Assert.NotNull(repo.Head.TrackedBranch);

--- a/LibGit2Sharp.Tests/CheckoutFixture.cs
+++ b/LibGit2Sharp.Tests/CheckoutFixture.cs
@@ -128,7 +128,7 @@ namespace LibGit2Sharp.Tests
 
                 Assert.True(detachedHead.IsCurrentRepositoryHead);
                 Assert.False(detachedHead.IsRemote);
-                Assert.Equal(detachedHead.Name, detachedHead.CanonicalName);
+                Assert.Equal(detachedHead.FriendlyName, detachedHead.CanonicalName);
 
                 Assert.Equal("(no branch)", detachedHead.CanonicalName);
 
@@ -793,7 +793,7 @@ namespace LibGit2Sharp.Tests
 
                 // Assert reflog entry is created
                 AssertRefLogEntry(repo, "HEAD",
-                    string.Format("checkout: moving from {0} to {1}", initialHead.Tip.Sha, newHead.Name),
+                    string.Format("checkout: moving from {0} to {1}", initialHead.Tip.Sha, newHead.FriendlyName),
                     initialHead.Tip.Id, newHead.Tip.Id, Constants.Identity, DateTimeOffset.Now);
             }
         }

--- a/LibGit2Sharp.Tests/CloneFixture.cs
+++ b/LibGit2Sharp.Tests/CloneFixture.cs
@@ -33,7 +33,7 @@ namespace LibGit2Sharp.Tests
                 Assert.False(repo.Info.IsBare);
 
                 Assert.True(File.Exists(Path.Combine(scd.RootedDirectoryPath, "master.txt")));
-                Assert.Equal(repo.Head.Name, "master");
+                Assert.Equal(repo.Head.FriendlyName, "master");
                 Assert.Equal(repo.Head.Tip.Id.ToString(), "49322bb17d3acc9146f98c97d078513228bbf3c0");
             }
         }
@@ -52,7 +52,7 @@ namespace LibGit2Sharp.Tests
             {
                 var head = repo.Head;
 
-                Assert.Equal(branchName, head.Name);
+                Assert.Equal(branchName, head.FriendlyName);
                 Assert.True(head.IsTracking);
                 Assert.Equal(headTipId, head.Tip.Sha);
             }

--- a/LibGit2Sharp.Tests/ResetHeadFixture.cs
+++ b/LibGit2Sharp.Tests/ResetHeadFixture.cs
@@ -80,7 +80,7 @@ namespace LibGit2Sharp.Tests
         public void SoftResetSetsTheHeadToTheSpecifiedCommit()
         {
             /* Make the Head point to a branch through its name */
-            AssertSoftReset(b => b.Name, false, b => b.Name);
+            AssertSoftReset(b => b.FriendlyName, false, b => b.FriendlyName);
         }
 
         [Fact]
@@ -107,12 +107,12 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(shouldHeadBeDetached, repo.Info.IsHeadDetached);
 
                 string expectedHeadName = expectedHeadNameRetriever(branch);
-                Assert.Equal(expectedHeadName, repo.Head.Name);
+                Assert.Equal(expectedHeadName, repo.Head.FriendlyName);
                 Assert.Equal(branch.Tip.Sha, repo.Head.Tip.Sha);
 
                 /* Reset --soft the Head to a tag through its canonical name */
                 repo.Reset(ResetMode.Soft, tag.CanonicalName);
-                Assert.Equal(expectedHeadName, repo.Head.Name);
+                Assert.Equal(expectedHeadName, repo.Head.FriendlyName);
                 Assert.Equal(tag.Target.Id, repo.Head.Tip.Id);
 
                 Assert.Equal(FileStatus.Staged, repo.RetrieveStatus("a.txt"));
@@ -134,7 +134,7 @@ namespace LibGit2Sharp.Tests
 
                 /* Reset --soft the Head to a commit through its sha */
                 repo.Reset(ResetMode.Soft, branch.Tip.Sha);
-                Assert.Equal(expectedHeadName, repo.Head.Name);
+                Assert.Equal(expectedHeadName, repo.Head.FriendlyName);
                 Assert.Equal(branch.Tip.Sha, repo.Head.Tip.Sha);
 
                 Assert.Equal(FileStatus.Unaltered, repo.RetrieveStatus("a.txt"));

--- a/LibGit2Sharp.Tests/TagFixture.cs
+++ b/LibGit2Sharp.Tests/TagFixture.cs
@@ -106,7 +106,7 @@ namespace LibGit2Sharp.Tests
                 Assert.NotNull(lwTag);
                 Assert.False(lwTag.IsAnnotated);
                 Assert.Equal(commitE90810BSha, lwTag.Target.Sha);
-                Assert.Equal(lwTagName, lwTag.Name);
+                Assert.Equal(lwTagName, lwTag.FriendlyName);
 
                 const string anTagName = lwTagName + "_as_well";
                 Tag anTag = repo.Tags.Add(anTagName, commitE90810BSha, signatureNtk, "a nice message");
@@ -114,7 +114,7 @@ namespace LibGit2Sharp.Tests
                 Assert.True(anTag.IsAnnotated);
                 Assert.Equal(commitE90810BSha, anTag.Target.Sha);
                 Assert.Equal(anTag.Target, anTag.Annotation.Target);
-                Assert.Equal(anTagName, anTag.Name);
+                Assert.Equal(anTagName, anTag.FriendlyName);
             }
         }
 
@@ -371,7 +371,7 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(tree.Id, tag.Target.Id);
 
                 Assert.Equal(tree, repo.Lookup(tag.Target.Id));
-                Assert.Equal(tag, repo.Tags[tag.Name]);
+                Assert.Equal(tag, repo.Tags[tag.FriendlyName]);
             }
         }
 
@@ -409,7 +409,7 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(blob.Id, tag.Target.Id);
 
                 Assert.Equal(blob, repo.Lookup(tag.Target.Id));
-                Assert.Equal(tag, repo.Tags[tag.Name]);
+                Assert.Equal(tag, repo.Tags[tag.FriendlyName]);
             }
         }
 
@@ -429,7 +429,7 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(annotation, tag.Annotation);
 
                 Assert.Equal(annotation, repo.Lookup(tag.Annotation.Id));
-                Assert.Equal(tag, repo.Tags[tag.Name]);
+                Assert.Equal(tag, repo.Tags[tag.FriendlyName]);
             }
         }
 
@@ -448,7 +448,7 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(annotation.Id, tag.Annotation.Target.Id);
                 Assert.NotEqual(annotation, tag.Annotation);
 
-                Assert.Equal(tag, repo.Tags[tag.Name]);
+                Assert.Equal(tag, repo.Tags[tag.FriendlyName]);
             }
         }
 
@@ -605,12 +605,12 @@ namespace LibGit2Sharp.Tests
             {
                 const string tagName = "e90810b";
 
-                List<string> tags = repo.Tags.Select(r => r.Name).ToList();
+                List<string> tags = repo.Tags.Select(r => r.FriendlyName).ToList();
                 Assert.True(tags.Contains(tagName));
 
                 repo.Tags.Remove(tagName);
 
-                List<string> tags2 = repo.Tags.Select(r => r.Name).ToList();
+                List<string> tags2 = repo.Tags.Select(r => r.FriendlyName).ToList();
                 Assert.False(tags2.Contains(tagName));
 
                 Assert.Equal(tags.Count - 1, tags2.Count);
@@ -646,7 +646,7 @@ namespace LibGit2Sharp.Tests
             string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
-                Assert.Equal(expectedTags, SortedTags(repo.Tags, t => t.Name));
+                Assert.Equal(expectedTags, SortedTags(repo.Tags, t => t.FriendlyName));
 
                 Assert.Equal(5, repo.Tags.Count());
             }
@@ -673,7 +673,7 @@ namespace LibGit2Sharp.Tests
             {
                 Tag tag = repo.Tags["lw"];
                 Assert.NotNull(tag);
-                Assert.Equal("lw", tag.Name);
+                Assert.Equal("lw", tag.FriendlyName);
                 Assert.Equal(commitE90810BSha, tag.Target.Sha);
 
                 Assert.False(tag.IsAnnotated);
@@ -689,11 +689,11 @@ namespace LibGit2Sharp.Tests
             {
                 Tag tag = repo.Tags["refs/tags/lw"];
                 Assert.NotNull(tag);
-                Assert.Equal("lw", tag.Name);
+                Assert.Equal("lw", tag.FriendlyName);
 
                 Tag tag2 = repo.Tags["refs/tags/lw"];
                 Assert.NotNull(tag2);
-                Assert.Equal("lw", tag2.Name);
+                Assert.Equal("lw", tag2.FriendlyName);
 
                 Assert.Equal(tag, tag2);
                 Assert.True((tag2 == tag));
@@ -708,7 +708,7 @@ namespace LibGit2Sharp.Tests
             {
                 Tag tag = repo.Tags["e90810b"];
                 Assert.NotNull(tag);
-                Assert.Equal("e90810b", tag.Name);
+                Assert.Equal("e90810b", tag.FriendlyName);
                 Assert.Equal(commitE90810BSha, tag.Target.Sha);
 
                 Assert.True(tag.IsAnnotated);

--- a/LibGit2Sharp/Branch.cs
+++ b/LibGit2Sharp/Branch.cs
@@ -182,7 +182,7 @@ namespace LibGit2Sharp
 
         private string UpstreamBranchCanonicalNameFromLocalBranch()
         {
-            ConfigurationEntry<string> mergeRefEntry = repo.Config.Get<string>("branch", Name, "merge");
+            ConfigurationEntry<string> mergeRefEntry = repo.Config.Get<string>("branch", FriendlyName, "merge");
 
             if (mergeRefEntry == null)
             {
@@ -194,7 +194,7 @@ namespace LibGit2Sharp
 
         private string RemoteNameFromLocalBranch()
         {
-            ConfigurationEntry<string> remoteEntry = repo.Config.Get<string>("branch", Name, "remote");
+            ConfigurationEntry<string> remoteEntry = repo.Config.Get<string>("branch", FriendlyName, "remote");
 
             if (remoteEntry == null)
             {

--- a/LibGit2Sharp/BranchCollection.cs
+++ b/LibGit2Sharp/BranchCollection.cs
@@ -154,10 +154,10 @@ namespace LibGit2Sharp
             {
                 throw new LibGit2SharpException(
                     string.Format(CultureInfo.InvariantCulture,
-                        "Cannot rename branch '{0}'. It's a remote tracking branch.", branch.Name));
+                        "Cannot rename branch '{0}'. It's a remote tracking branch.", branch.FriendlyName));
             }
 
-            using (ReferenceSafeHandle referencePtr = repo.Refs.RetrieveReferencePtr(Reference.LocalBranchPrefix + branch.Name))
+            using (ReferenceSafeHandle referencePtr = repo.Refs.RetrieveReferencePtr(Reference.LocalBranchPrefix + branch.FriendlyName))
             {
                 using (Proxy.git_branch_move(referencePtr, newName, allowOverwrite))
                 {
@@ -183,7 +183,7 @@ namespace LibGit2Sharp
                 action(updater);
             }
 
-            return this[branch.Name];
+            return this[branch.FriendlyName];
         }
 
         private static bool LooksLikeABranchName(string referenceName)

--- a/LibGit2Sharp/BranchUpdater.cs
+++ b/LibGit2Sharp/BranchUpdater.cs
@@ -125,7 +125,7 @@ namespace LibGit2Sharp
         /// <param name="mergeBranchName">The merge branch in the upstream remote's namespace.</param>
         private void SetUpstreamBranch(string mergeBranchName)
         {
-            string configKey = string.Format(CultureInfo.InvariantCulture, "branch.{0}.merge", branch.Name);
+            string configKey = string.Format(CultureInfo.InvariantCulture, "branch.{0}.merge", branch.FriendlyName);
 
             if (string.IsNullOrEmpty(mergeBranchName))
             {
@@ -143,7 +143,7 @@ namespace LibGit2Sharp
         /// <param name="remoteName">The name of the remote to set as the upstream branch.</param>
         private void SetUpstreamRemote(string remoteName)
         {
-            string configKey = string.Format(CultureInfo.InvariantCulture, "branch.{0}.remote", branch.Name);
+            string configKey = string.Format(CultureInfo.InvariantCulture, "branch.{0}.remote", branch.FriendlyName);
 
             if (string.IsNullOrEmpty(remoteName))
             {

--- a/LibGit2Sharp/NetworkExtensions.cs
+++ b/LibGit2Sharp/NetworkExtensions.cs
@@ -46,7 +46,7 @@ namespace LibGit2Sharp
                         string.Format(
                             CultureInfo.InvariantCulture,
                             "The branch '{0}' (\"{1}\") that you are trying to push does not track an upstream branch.",
-                            branch.Name, branch.CanonicalName));
+                            branch.FriendlyName, branch.CanonicalName));
                 }
             }
 

--- a/LibGit2Sharp/ReferenceWrapper.cs
+++ b/LibGit2Sharp/ReferenceWrapper.cs
@@ -52,11 +52,20 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
-        /// Gets the name of this reference.
+        /// Gets the human-friendly name of this reference.
         /// </summary>
-        public virtual string Name
+        public virtual string FriendlyName
         {
             get { return Shorten(); }
+        }
+
+        /// <summary>
+        /// Gets the name of this reference.
+        /// </summary>
+        [Obsolete("This property will be removed in the next release. Please use FriendlyName instead.")]
+        public virtual string Name
+        {
+            get { return FriendlyName; }
         }
 
         /// <summary>

--- a/LibGit2Sharp/Repository.cs
+++ b/LibGit2Sharp/Repository.cs
@@ -806,7 +806,7 @@ namespace LibGit2Sharp
             {
                 throw new UnbornBranchException(
                     string.Format(CultureInfo.InvariantCulture,
-                    "The tip of branch '{0}' is null. There's nothing to checkout.", branch.Name));
+                    "The tip of branch '{0}' is null. There's nothing to checkout.", branch.FriendlyName));
             }
 
             if (!branch.IsRemote && !(branch is DetachedHead) &&

--- a/LibGit2Sharp/RepositoryExtensions.cs
+++ b/LibGit2Sharp/RepositoryExtensions.cs
@@ -124,7 +124,7 @@ namespace LibGit2Sharp
         public static Branch CreateBranch(this IRepository repository, string branchName)
         {
             var head = repository.Head;
-            var reflogName = head is DetachedHead ? head.Tip.Sha : head.Name;
+            var reflogName = head is DetachedHead ? head.Tip.Sha : head.FriendlyName;
 
             return CreateBranch(repository, branchName, reflogName);
         }


### PR DESCRIPTION
@jamill rightfully pointed at the fact that `Name` was maybe not explicit enough for a `Branch` or a `Tag`.

This PR is proposal to work around this by explicitly stating that this is a shortened version of the complete canonical name.

Thoughts?