### PR TITLE
Try harder to format error messages

### DIFF
--- a/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
+++ b/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
@@ -63,6 +63,7 @@
     <Compile Include="RefSpecFixture.cs" />
     <Compile Include="EqualityFixture.cs" />
     <Compile Include="RevertFixture.cs" />
+    <Compile Include="SetErrorFixture.cs" />
     <Compile Include="SignatureFixture.cs" />
     <Compile Include="FilterBranchFixture.cs" />
     <Compile Include="RemoveFixture.cs" />

--- a/LibGit2Sharp.Tests/SetErrorFixture.cs
+++ b/LibGit2Sharp.Tests/SetErrorFixture.cs
@@ -1,0 +1,182 @@
+using System;
+using System.IO;
+using System.Text;
+using LibGit2Sharp.Tests.TestHelpers;
+using Xunit;
+
+namespace LibGit2Sharp.Tests
+{
+    public class SetErrorFixture : BaseFixture
+    {
+
+        private const string simpleExceptionMessage = "This is a simple exception message.";
+        private const string aggregateExceptionMessage = "This is aggregate exception.";
+        private const string outerExceptionMessage = "This is an outer exception.";
+        private const string innerExceptionMessage = "This is an inner exception.";
+        private const string innerExceptionMessage2 = "This is inner exception #2.";
+
+        private const string expectedInnerExceptionHeaderText = "Inner Exception:";
+        private const string expectedAggregateExceptionHeaderText = "Contained Exception:";
+        private const string expectedAggregateExceptionsHeaderText = "Contained Exceptions:";
+
+        [Fact]
+        public void FormatSimpleException()
+        {
+            Exception exceptionToThrow = new Exception(simpleExceptionMessage);
+            string expectedMessage = simpleExceptionMessage;
+
+            AssertExpectedExceptionMessage(expectedMessage, exceptionToThrow);
+        }
+
+        [Fact]
+        public void FormatExceptionWithInnerException()
+        {
+            Exception exceptionToThrow = new Exception(outerExceptionMessage, new Exception(innerExceptionMessage));
+
+            StringBuilder sb = new StringBuilder();
+            sb.AppendLine(outerExceptionMessage);
+            sb.AppendLine();
+            AppendIndentedLine(sb, expectedInnerExceptionHeaderText, 0);
+            AppendIndentedText(sb, innerExceptionMessage, 1);
+            string expectedMessage = sb.ToString();
+
+            AssertExpectedExceptionMessage(expectedMessage, exceptionToThrow);
+        }
+        
+        [Fact]
+        public void FormatAggregateException()
+        {
+            Exception exceptionToThrow = new AggregateException(aggregateExceptionMessage, new Exception(innerExceptionMessage), new Exception(innerExceptionMessage2));
+
+            StringBuilder sb = new StringBuilder();
+            sb.AppendLine(aggregateExceptionMessage);
+            sb.AppendLine();
+
+            AppendIndentedLine(sb, expectedAggregateExceptionsHeaderText, 0);
+
+            AppendIndentedLine(sb, innerExceptionMessage, 1);
+            sb.AppendLine();
+
+            AppendIndentedText(sb, innerExceptionMessage2, 1);
+
+            string expectedMessage = sb.ToString();
+
+            AssertExpectedExceptionMessage(expectedMessage, exceptionToThrow);
+        }
+
+        private void AssertExpectedExceptionMessage(string expectedMessage, Exception exceptionToThrow)
+        {
+            Exception thrownException = null;
+
+            ObjectId id = new ObjectId("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
+
+            string repoPath = InitNewRepository();
+            using (var repo = new Repository(repoPath))
+            {
+                repo.ObjectDatabase.AddBackend(new ThrowingOdbBackend(exceptionToThrow), priority: 1);
+
+                try
+                {
+                    repo.Lookup<Blob>(id);
+                }
+                catch (Exception ex)
+                {
+                    thrownException = ex;
+                }
+            }
+
+            Assert.NotNull(thrownException);
+            Assert.Equal(expectedMessage, thrownException.Message);
+        }
+
+        private void AppendIndentedText(StringBuilder sb, string text, int indentLevel)
+        {
+            sb.AppendFormat("{0}{1}", IndentString(indentLevel), text);
+        }
+
+        private void AppendIndentedLine(StringBuilder sb, string text, int indentLevel)
+        {
+            sb.AppendFormat("{0}{1}{2}", IndentString(indentLevel), text, Environment.NewLine);
+        }
+
+        private string IndentString(int level)
+        {
+            return new string(' ', level * 4);
+        }
+
+        #region ThrowingOdbBackend
+
+        private class ThrowingOdbBackend : OdbBackend
+        {
+            private Exception exceptionToThrow;
+
+            public ThrowingOdbBackend(Exception exceptionToThrow)
+            {
+                this.exceptionToThrow = exceptionToThrow;
+            }
+
+            protected override OdbBackendOperations SupportedOperations
+            {
+                get
+                {
+                    return OdbBackendOperations.Read |
+                        OdbBackendOperations.ReadPrefix |
+                        OdbBackendOperations.Write |
+                        OdbBackendOperations.WriteStream |
+                        OdbBackendOperations.Exists |
+                        OdbBackendOperations.ExistsPrefix |
+                        OdbBackendOperations.ForEach |
+                        OdbBackendOperations.ReadHeader;
+                }
+            }
+
+            public override int Read(ObjectId oid, out UnmanagedMemoryStream data, out ObjectType objectType)
+            {
+                throw this.exceptionToThrow;
+            }
+
+            public override int ReadPrefix(string shortSha, out ObjectId id, out UnmanagedMemoryStream data, out ObjectType objectType)
+            {
+                throw this.exceptionToThrow;
+            }
+
+            public override int Write(ObjectId oid, Stream dataStream, long length, ObjectType objectType)
+            {
+                throw this.exceptionToThrow;
+            }
+
+            public override int WriteStream(long length, ObjectType objectType, out OdbBackendStream stream)
+            {
+                throw this.exceptionToThrow;
+            }
+
+            public override bool Exists(ObjectId oid)
+            {
+                throw this.exceptionToThrow;
+            }
+
+            public override int ExistsPrefix(string shortSha, out ObjectId found)
+            {
+                throw this.exceptionToThrow;
+            }
+
+            public override int ReadHeader(ObjectId oid, out int length, out ObjectType objectType)
+            {
+                throw this.exceptionToThrow;
+            }
+
+            public override int ReadStream(ObjectId oid, out OdbBackendStream stream)
+            {
+                throw this.exceptionToThrow;
+            }
+
+            public override int ForEach(ForEachCallback callback)
+            {
+                throw this.exceptionToThrow;
+            }
+        }
+
+        #endregion
+
+    }
+}

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -85,7 +85,7 @@ namespace LibGit2Sharp.Core
         [DllImport(libgit2)]
         internal static extern void giterr_set_str(
             GitErrorCategory error_class,
-            string errorString);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string errorString);
 
         [DllImport(libgit2)]
         internal static extern void giterr_set_oom();


### PR DESCRIPTION
Try harder to capture relevant information when generating error message from an exception. This also marshals text as UTF8, as expected by libgit2.

TODO:
- [x] Formatting of error message
- [x] Tests covering formatting exceptions

This is currently a private method, so I can't test it as is. I could either 1) expose the method that generates error messages from exceptions as a public utility method, or 2) wire up a sub transport that just throws exceptions and verify the exception message...

/cc @ethomson 