### PR TITLE
Enable custom unit test location with standard location fallback

### DIFF
--- a/LibGit2Sharp.Tests/TestHelpers/Constants.cs
+++ b/LibGit2Sharp.Tests/TestHelpers/Constants.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 
 namespace LibGit2Sharp.Tests.TestHelpers
@@ -34,7 +35,7 @@ namespace LibGit2Sharp.Tests.TestHelpers
 
         public static string BuildPath()
         {
-            string tempPath;
+            string tempPath = null;
 
             var unixPath = Type.GetType("Mono.Unix.UnixPath, Mono.Posix, Version=2.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756");
 
@@ -48,11 +49,24 @@ namespace LibGit2Sharp.Tests.TestHelpers
             }
             else
             {
+                const string LibGit2TestPath = "LibGit2TestPath";
                 // We're running on .Net/Windows
-                tempPath = Path.GetTempPath();
+                if (Environment.GetEnvironmentVariables().Contains(LibGit2TestPath))
+                {
+                    Trace.TraceInformation("{0} environment variable detected", LibGit2TestPath);
+                    tempPath = Environment.GetEnvironmentVariables()[LibGit2TestPath] as String;
+                }
+
+                if (String.IsNullOrWhiteSpace(tempPath) || !Directory.Exists(tempPath))
+                {
+                    Trace.TraceInformation("Using default test path value");
+                    tempPath = Path.GetTempPath();
+                }
             }
 
-            return Path.Combine(tempPath, "LibGit2Sharp-TestRepos");
+            string testWorkingDirectory = Path.Combine(tempPath, "LibGit2Sharp-TestRepos");
+            Trace.TraceInformation("Test working directory set to '{0}'", testWorkingDirectory);
+            return testWorkingDirectory;
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -57,6 +57,17 @@ More thorough information available in the [wiki][wiki].
 
  [wiki]: https://github.com/libgit2/libgit2sharp/wiki
 
+## Optimizing unit testing
+LibGit2Sharp strives to have comprehensive and robust unit test suite to insure the quality of the software and to assist new contributors and users who can use the tests as sample to jump start development. There are over one-thousand unit-tests for LibGit2Sharp, this number will only grow as functionality is added.
+
+You can do a few things to optimize running unit-tests on Windows:
+
+1. Set the `LibGit2TestPath` environment variable to a path in your development environment.
+  * If the unit-test framework cannot find the specified folder at runtime, it will fall back to the default location.
+2. Configure your anti-virus software to ignore the `LibGit2TestPath` path.
+3. Install a RAM disk like [IMDisk](http://www.ltr-data.se/opencode.html/#ImDisk) and set `LibGit2TestPath` to use it.
+  * Use `imdisk.exe -a -s 256M -m X: -p "/fs:fat /q /v:ramdisk /y"` to create a RAM disk. This command requires elevated privileges and can be placed into a scheduled task or run manually before you begin unit-testing.
+
 ## Authors
 
  - **Code:** The LibGit2Sharp [contributors][committers]


### PR DESCRIPTION
Enables developers of Libgit2Sharp to use a custom path for the temporary repositories used during unit testing. For example, I've setup a RAM disk on my development machine. While the RAM disk isn't suitable for all of operating system's `%TEMP%` needs, it's ideal for unit testing Libgit2Sharp.

On my Surface Pro 3 (Core i5 version) unit tests are reduced from roughly 17 minute to around 2 minutes. Basically an order of magnitude improvement.

Of course, we should fallback to the traditional `%TEMP%` folder if the developer hasn't provided a viable alternative.

This PR has no impact on non-Windows development environments.