### PR TITLE
Restrict potential reference targets of HistoryRewriter

### DIFF
--- a/LibGit2Sharp/Core/HistoryRewriter.cs
+++ b/LibGit2Sharp/Core/HistoryRewriter.cs
@@ -59,7 +59,11 @@ namespace LibGit2Sharp.Core
                 // before A.
                 foreach (var reference in refsToRewrite.OrderBy(ReferenceDepth))
                 {
-                    // TODO: Check how rewriting of notes actually behaves
+                    // TODO: Rewrite refs/notes/* properly
+                    if (reference.CanonicalName.StartsWith("refs/notes/"))
+                    {
+                        continue;
+                    }
 
                     RewriteReference(reference);
                 }


### PR DESCRIPTION
Currently, the `HistoryRewriter` will blindy rewrite any reference that's being passed to it.

However, this may make no sense to rewrite the remote tracking branches.
Moreover, the way git notes are structured isn't actually handled by the rewriting process.

Proposal:
 - Would a reference which canonical name starts with `ref/notes/` be passed, throw a NotSupportedException with a meaningful message.
 - Silently not consider references which canonical name starts with `ref/remotes/`

Thoughts?