### PR TITLE
All unit tests fail because of Mono.Unix.UnixPath in BuildPath

### DIFF
--- a/LibGit2Sharp.Tests/BlobFixture.cs
+++ b/LibGit2Sharp.Tests/BlobFixture.cs
@@ -222,7 +222,7 @@ namespace LibGit2Sharp.Tests
 
         private static void SkipIfNotSupported(string autocrlf)
         {
-            InconclusiveIf(() => autocrlf == "true" && IsRunningOnUnix(), "Non-Windows does not support core.autocrlf = true");
+            InconclusiveIf(() => autocrlf == "true" && Constants.IsRunningOnUnix, "Non-Windows does not support core.autocrlf = true");
         }
     }
 }

--- a/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
+++ b/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
@@ -52,6 +52,9 @@
     <Compile Include="..\LibGit2Sharp\Core\Epoch.cs">
       <Link>TestHelpers\Epoch.cs</Link>
     </Compile>
+    <Compile Include="..\LibGit2Sharp\Core\Platform.cs">
+      <Link>TestHelpers\Platform.cs</Link>
+    </Compile>
     <Compile Include="BlameFixture.cs" />
     <Compile Include="ArchiveTarFixture.cs" />
     <Compile Include="CheckoutFixture.cs" />

--- a/LibGit2Sharp.Tests/ShadowCopyFixture.cs
+++ b/LibGit2Sharp.Tests/ShadowCopyFixture.cs
@@ -57,7 +57,7 @@ namespace LibGit2Sharp.Tests
             string cachedAssembliesPath = Path.Combine(setup.CachePath, setup.ApplicationName);
             Assert.True(cachedAssemblyLocation.StartsWith(cachedAssembliesPath));
 
-            if (!IsRunningOnUnix())
+            if (!Constants.IsRunningOnUnix)
             {
                 // ...that this cache doesn't contain the `NativeBinaries` folder
                 string cachedAssemblyParentPath = Path.GetDirectoryName(cachedAssemblyLocation);

--- a/LibGit2Sharp.Tests/TestHelpers/BaseFixture.cs
+++ b/LibGit2Sharp.Tests/TestHelpers/BaseFixture.cs
@@ -106,14 +106,6 @@ namespace LibGit2Sharp.Tests.TestHelpers
             return !isInsensitive;
         }
 
-        // Should match LibGit2Sharp.Core.NativeMethods.IsRunningOnUnix()
-        protected static bool IsRunningOnUnix()
-        {
-            // see http://mono-project.com/FAQ%3a_Technical#Mono_Platforms
-            var p = (int)Environment.OSVersion.Platform;
-            return (p == 4) || (p == 6) || (p == 128);
-        }
-
         protected void CreateCorruptedDeadBeefHead(string repoPath)
         {
             const string deadbeef = "deadbeef";


### PR DESCRIPTION
I just rebased my fork with latest from the `vNext` branch and hit an issue, which seems to be directly related to PR #1018 - all unit tests fail with the following exception:

```
System.TypeInitializationExceptionThe type initializer for 'LibGit2Sharp.Tests.TestHelpers.BaseFixture' threw an exception.
   at LibGit2Sharp.Tests.TestHelpers.BaseFixture..ctor()
   at LibGit2Sharp.Tests.CheckoutFixture..ctor()
System.TypeInitializationExceptionThe type initializer for 'LibGit2Sharp.Tests.TestHelpers.Constants' threw an exception.
   at LibGit2Sharp.Tests.TestHelpers.BaseFixture.IsFileSystemCaseSensitiveInternal() in BaseFixture.cs: line 94
   at LibGit2Sharp.Tests.TestHelpers.BaseFixture.SetUpTestEnvironment() in BaseFixture.cs: line 57
   at LibGit2Sharp.Tests.TestHelpers.BaseFixture..cctor() in BaseFixture.cs: line 29
System.Reflection.TargetInvocationExceptionException has been thrown by the target of an invocation.
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor)
   at System.Reflection.RuntimeMethodInfo.UnsafeInvokeInternal(Object obj, Object[] parameters, Object[] arguments)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at System.RuntimeType.InvokeMember(String name, BindingFlags bindingFlags, Binder binder, Object target, Object[] providedArgs, ParameterModifier[] modifiers, CultureInfo culture, String[] namedParams)
   at System.Type.InvokeMember(String name, BindingFlags invokeAttr, Binder binder, Object target, Object[] args)
   at LibGit2Sharp.Tests.TestHelpers.Constants.BuildPath() in Constants.cs: line 46
   at LibGit2Sharp.Tests.TestHelpers.Constants..cctor() in Constants.cs: line 9
System.BadImageFormatExceptionAn attempt was made to load a program with an incorrect format. (Exception from HRESULT: 0x8007000B)
   at Mono.Unix.Native.Syscall.readlink(String path, StringBuilder buf, UInt64 bufsiz)
   at Mono.Unix.UnixPath.ReadSymbolicLink(String path)
   at Mono.Unix.UnixPath.GetRealPath(String path)
   at Mono.Unix.UnixPath.GetCompleteRealPath(String path)
```

I'm running on Windows 8.1 and VS2013 and the `var unixPath = Type.GetType("Mono.Unix.UnixPath, Mono.Posix, Version=2.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756");` ([found here](https://github.com/libgit2/libgit2sharp/blob/vNext/LibGit2Sharp.Tests/TestHelpers/Constants.cs#L40)) type is actually not null even though I'm not running *nix. I actually don't know what added `Mono.Unix.UnixPath` to my GAC, but its obviously causing problems.

It was mentioned in #1018 that `Mono.Runtime` was used elsewhere to check if "We're running on top of .Net", and changing the type actually makes the unit tests runnable again.