### PR TITLE
Upgrade to libgit2 ff8d635

### DIFF
--- a/LibGit2Sharp.Tests/FetchFixture.cs
+++ b/LibGit2Sharp.Tests/FetchFixture.cs
@@ -134,6 +134,18 @@ namespace LibGit2Sharp.Tests
                 var expectedFetchState = new ExpectedFetchState(remoteName);
                 expectedFetchState.AddExpectedBranch(localBranchName, ObjectId.Zero, remoteInfo.BranchTips[remoteBranchName]);
 
+                // Let's account for opportunistic updates during the Fetch() call
+                if (!string.Equals("master", localBranchName, StringComparison.OrdinalIgnoreCase))
+                {
+                    expectedFetchState.AddExpectedBranch("master", ObjectId.Zero, remoteInfo.BranchTips["master"]);
+                }
+
+                if (string.Equals("master", localBranchName, StringComparison.OrdinalIgnoreCase)
+                    && !string.Equals("master", remoteBranchName, StringComparison.OrdinalIgnoreCase))
+                {
+                    expectedFetchState.AddExpectedBranch(remoteBranchName, ObjectId.Zero, remoteInfo.BranchTips[remoteBranchName]);
+                }
+
                 // Perform the actual fetch
                 repo.Network.Fetch(remote, new string[] { refSpec }, new FetchOptions {
                     TagFetchMode = TagFetchMode.None,

--- a/LibGit2Sharp.Tests/RefSpecFixture.cs
+++ b/LibGit2Sharp.Tests/RefSpecFixture.cs
@@ -183,7 +183,7 @@ namespace LibGit2Sharp.Tests
                 var remote = repo.Network.Remotes["origin"];
                 var oldRefSpecs = remote.RefSpecs.Select(r => r.Specification).ToList();
 
-                Assert.Throws<LibGit2SharpException>(() =>
+                Assert.Throws<InvalidSpecificationException>(() =>
                     repo.Network.Remotes.Update(remote, r => r.FetchRefSpecs.Add(refSpec)));
 
                 var newRemote = repo.Network.Remotes["origin"];

--- a/LibGit2Sharp/Configuration.cs
+++ b/LibGit2Sharp/Configuration.cs
@@ -151,6 +151,16 @@ namespace LibGit2Sharp
             }
         }
 
+        internal void UnsetMultivar(string key, ConfigurationLevel level)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(key, "key");
+
+            using (ConfigurationSafeHandle h = RetrieveConfigurationHandle(level, true, configHandle))
+            {
+                Proxy.git_config_delete_multivar(h, key);
+            }
+        }
+
         /// <summary>
         /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
         /// </summary>

--- a/LibGit2Sharp/Core/FetchPruneStrategy.cs
+++ b/LibGit2Sharp/Core/FetchPruneStrategy.cs
@@ -1,0 +1,25 @@
+namespace LibGit2Sharp.Core
+{
+    /// <summary>
+    /// Specify how the remote tracking branches should be locally dealt with
+    /// when their upstream countepart doesn't exist anymore.
+    /// </summary>
+    internal enum FetchPruneStrategy
+    {
+        /// <summary>
+        /// Use the setting from the configuration
+        /// or, when there isn't any, fallback to default behavior.
+        /// </summary>
+        FromConfigurationOrDefault = 0,
+
+        /// <summary>
+        /// Force pruning on
+        /// </summary>
+        Prune,
+
+        /// <summary>
+        /// Force pruning off
+        /// </summary>
+        NoPrune,
+    }
+}

--- a/LibGit2Sharp/Core/GitCheckoutOpts.cs
+++ b/LibGit2Sharp/Core/GitCheckoutOpts.cs
@@ -158,6 +158,7 @@ namespace LibGit2Sharp.Core
         public GitStrArray paths;
 
         public IntPtr baseline;
+        public IntPtr baseline_index;
         public IntPtr target_directory;
 
         public IntPtr ancestor_label;

--- a/LibGit2Sharp/Core/GitCloneOptions.cs
+++ b/LibGit2Sharp/Core/GitCloneOptions.cs
@@ -17,7 +17,7 @@ namespace LibGit2Sharp.Core
         public uint Version;
 
         public GitCheckoutOpts CheckoutOpts;
-        public GitRemoteCallbacks RemoteCallbacks;
+        public GitFetchOptions FetchOpts;
 
         public int Bare;
         public GitCloneLocal Local;

--- a/LibGit2Sharp/Core/GitDiff.cs
+++ b/LibGit2Sharp/Core/GitDiff.cs
@@ -80,6 +80,13 @@ namespace LibGit2Sharp.Core
         /// </summary>
         GIT_DIFF_IGNORE_CASE = (1 << 10),
 
+
+        /// <summary>
+        /// May be combined with `GIT_DIFF_IGNORE_CASE` to specify that a file
+        /// that has changed case will be returned as an add/delete pair.
+        /// </summary>
+        GIT_DIFF_INCLUDE_CASECHANGE = (1 << 11),
+
         /// <summary>
         /// If the pathspec is set in the diff options, this flags means to
         /// apply it as an exact match instead of as an fnmatch pattern.

--- a/LibGit2Sharp/Core/GitFetchOptions.cs
+++ b/LibGit2Sharp/Core/GitFetchOptions.cs
@@ -1,0 +1,14 @@
+using System.Runtime.InteropServices;
+
+namespace LibGit2Sharp.Core
+{
+    [StructLayout(LayoutKind.Sequential)]
+    internal class GitFetchOptions
+    {
+        public int Version = 1;
+        public GitRemoteCallbacks RemoteCallbacks;
+        public FetchPruneStrategy Prune;
+        public bool UpdateFetchHead = true;
+        public TagFetchMode download_tags;
+    }
+}

--- a/LibGit2Sharp/Core/GitIndexEntry.cs
+++ b/LibGit2Sharp/Core/GitIndexEntry.cs
@@ -15,7 +15,7 @@ namespace LibGit2Sharp.Core
         public uint Mode;
         public uint Uid;
         public uint Gid;
-        public Int64 file_size;
+        public uint file_size;
         public GitOid Id;
         public ushort Flags;
         public ushort ExtendedFlags;

--- a/LibGit2Sharp/Core/GitIndexTime.cs
+++ b/LibGit2Sharp/Core/GitIndexTime.cs
@@ -5,7 +5,7 @@ namespace LibGit2Sharp.Core
     [StructLayout(LayoutKind.Sequential)]
     internal class GitIndexTime
     {
-        public long seconds;
+        public int seconds;
         public uint nanoseconds;
     }
 }

--- a/LibGit2Sharp/Core/GitMergeOpts.cs
+++ b/LibGit2Sharp/Core/GitMergeOpts.cs
@@ -31,6 +31,11 @@ namespace LibGit2Sharp.Core
         /// Flags for automerging content.
         /// </summary>
         public MergeFileFavor MergeFileFavorFlags;
+
+        /// <summary>
+        /// File merging flags.
+        /// </summary>
+        public GitMergeFileFlags FileFlags;
     }
 
     /// <summary>
@@ -63,11 +68,11 @@ namespace LibGit2Sharp.Core
         /// </summary>
         GIT_MERGE_ANALYSIS_FASTFORWARD = (1 << 2),
 
-        /**
-         * The HEAD of the current repository is "unborn" and does not point to
-         * a valid commit.  No merge can be performed, but the caller may wish
-         * to simply set HEAD to the target commit(s).
-         */
+        /// <summary>
+        /// The HEAD of the current repository is "unborn" and does not point to
+        /// a valid commit.  No merge can be performed, but the caller may wish
+        /// to simply set HEAD to the target commit(s).
+        /// </summary>
         GIT_MERGE_ANALYSIS_UNBORN = (1 << 3),
     }
 
@@ -104,5 +109,54 @@ namespace LibGit2Sharp.Core
         /// GIT_MERGE_TREE_FIND_RENAMES in libgit2
         /// </summary>
         GIT_MERGE_TREE_FIND_RENAMES = (1 << 0),
+    }
+
+    [Flags]
+    internal enum GitMergeFileFlags
+    {
+        /// <summary>
+        /// Defaults
+        /// </summary>
+        GIT_MERGE_FILE_DEFAULT = 0,
+
+        /// <summary>
+        /// Create standard conflicted merge files
+        /// </summary>
+        GIT_MERGE_FILE_STYLE_MERGE = (1 << 0),
+
+        /// <summary>
+        /// Create diff3-style files
+        /// </summary>
+        GIT_MERGE_FILE_STYLE_DIFF3 = (1 << 1),
+
+        /// <summary>
+        /// Condense non-alphanumeric regions for simplified diff file
+        /// </summary>
+        GIT_MERGE_FILE_SIMPLIFY_ALNUM = (1 << 2),
+
+        /// <summary>
+        /// Ignore all whitespace
+        /// </summary>
+        GIT_MERGE_FILE_IGNORE_WHITESPACE = (1 << 3),
+
+        /// <summary>
+        /// Ignore changes in amount of whitespace
+        /// </summary>
+        GIT_MERGE_FILE_IGNORE_WHITESPACE_CHANGE = (1 << 4),
+
+        /// <summary>
+        /// Ignore whitespace at end of line
+        /// </summary>
+        GIT_MERGE_FILE_IGNORE_WHITESPACE_EOL = (1 << 5),
+
+        /// <summary>
+        /// Use the "patience diff" algorithm
+        /// </summary>
+        GIT_MERGE_FILE_DIFF_PATIENCE = (1 << 6),
+
+        /// <summary>
+        /// Take extra time to find minimal diff
+        /// </summary>
+        GIT_MERGE_FILE_DIFF_MINIMAL = (1 << 7),
     }
 }

--- a/LibGit2Sharp/Core/GitOdbBackend.cs
+++ b/LibGit2Sharp/Core/GitOdbBackend.cs
@@ -130,7 +130,7 @@ namespace LibGit2Sharp.Core
         public delegate int writestream_callback(
             out IntPtr stream_out,
             IntPtr backend,
-            UIntPtr length,
+            Int64 length,
             GitObjectType type);
 
         /// <summary>

--- a/LibGit2Sharp/Core/GitOdbBackendStream.cs
+++ b/LibGit2Sharp/Core/GitOdbBackendStream.cs
@@ -22,8 +22,8 @@ namespace LibGit2Sharp.Core
         public GitOdbBackendStreamMode Mode;
         public IntPtr HashCtx;
 
-        public UIntPtr DeclaredSize;
-        public UIntPtr ReceivedBytes;
+        public Int64 DeclaredSize;
+        public Int64 ReceivedBytes;
 
         public read_callback Read;
         public write_callback Write;

--- a/LibGit2Sharp/Core/GitPushOptions.cs
+++ b/LibGit2Sharp/Core/GitPushOptions.cs
@@ -7,5 +7,6 @@ namespace LibGit2Sharp.Core
     {
         public int Version = 1;
         public int PackbuilderDegreeOfParallelism;
+        public GitRemoteCallbacks RemoteCallbacks;
     }
 }

--- a/LibGit2Sharp/Core/GitPushUpdate.cs
+++ b/LibGit2Sharp/Core/GitPushUpdate.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace LibGit2Sharp.Core
+{
+    [StructLayout(LayoutKind.Sequential)]
+    internal class GitPushUpdate
+    {
+        IntPtr src_refname;
+        IntPtr dst_refname;
+        GitOid src;
+        GitOid dst;
+    }
+}

--- a/LibGit2Sharp/Core/GitRemoteCallbacks.cs
+++ b/LibGit2Sharp/Core/GitRemoteCallbacks.cs
@@ -29,6 +29,10 @@ namespace LibGit2Sharp.Core
 
         internal NativeMethods.push_update_reference_callback push_update_reference;
 
+        internal NativeMethods.push_negotiation_callback push_negotiation;
+
+        internal IntPtr transport;
+
         internal IntPtr payload;
     }
 }

--- a/LibGit2Sharp/Core/GitSmartSubtransportRegistration.cs
+++ b/LibGit2Sharp/Core/GitSmartSubtransportRegistration.cs
@@ -8,9 +8,11 @@ namespace LibGit2Sharp.Core
     {
         public IntPtr SubtransportCallback;
         public uint Rpc;
+        public uint Param;
 
         public delegate int create_callback(
             out IntPtr subtransport,
-            IntPtr transport);
+            IntPtr owner,
+            IntPtr param);
     }
 }

--- a/LibGit2Sharp/Core/GitSubmoduleOptions.cs
+++ b/LibGit2Sharp/Core/GitSubmoduleOptions.cs
@@ -9,7 +9,7 @@ namespace LibGit2Sharp.Core
 
         public GitCheckoutOpts CheckoutOptions;
 
-        public GitRemoteCallbacks RemoteCallbacks;
+        public GitFetchOptions FetchOptions;
 
         public CheckoutStrategy CloneCheckoutStrategy;
     }

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -274,7 +274,13 @@ namespace LibGit2Sharp.Core
         [DllImport(libgit2)]
         internal static extern int git_config_delete_entry(
             ConfigurationSafeHandle cfg,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof (StrictUtf8Marshaler))] string name);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name);
+
+        [DllImport(libgit2)]
+        internal static extern int git_config_delete_multivar(
+            ConfigurationSafeHandle cfg,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof (StrictUtf8Marshaler))] string name,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string regexp);
 
         [DllImport(libgit2)]
         internal static extern int git_config_find_global(GitBuf global_config_path);
@@ -746,7 +752,7 @@ namespace LibGit2Sharp.Core
 
         [DllImport(libgit2)]
         internal static extern int git_note_default_ref(
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))] out string notes_ref,
+            GitBuf notes_ref,
             RepositorySafeHandle repo);
 
         internal delegate int git_note_foreach_cb(
@@ -781,7 +787,7 @@ namespace LibGit2Sharp.Core
             IntPtr payload);
 
         [DllImport(libgit2)]
-        internal static extern int git_odb_open_wstream(out OdbStreamSafeHandle stream, ObjectDatabaseSafeHandle odb, UIntPtr size, GitObjectType type);
+        internal static extern int git_odb_open_wstream(out OdbStreamSafeHandle stream, ObjectDatabaseSafeHandle odb, Int64 size, GitObjectType type);
 
         [DllImport(libgit2)]
         internal static extern void git_odb_free(IntPtr odb);
@@ -998,7 +1004,10 @@ namespace LibGit2Sharp.Core
         internal static extern int git_remote_autotag(RemoteSafeHandle remote);
 
         [DllImport(libgit2)]
-        internal static extern int git_remote_connect(RemoteSafeHandle remote, GitDirection direction);
+        internal static extern int git_remote_connect(
+            RemoteSafeHandle remote,
+            GitDirection direction,
+            ref GitRemoteCallbacks callbacks);
 
         [DllImport(libgit2)]
         internal static extern int git_remote_create(
@@ -1011,8 +1020,7 @@ namespace LibGit2Sharp.Core
         internal static extern int git_remote_create_anonymous(
             out RemoteSafeHandle remote,
             RepositorySafeHandle repo,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string url,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string refspec);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string url);
 
 
         [DllImport(libgit2)]
@@ -1032,6 +1040,7 @@ namespace LibGit2Sharp.Core
         internal static extern int git_remote_fetch(
             RemoteSafeHandle remote,
             ref GitStrArray refspecs,
+            GitFetchOptions fetch_opts,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string log_message);
 
         [DllImport(libgit2)]
@@ -1063,12 +1072,26 @@ namespace LibGit2Sharp.Core
 
         [DllImport(libgit2)]
         internal static extern int git_remote_set_url(
-            RemoteSafeHandle remote,
+            RepositorySafeHandle repo,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string remote,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string url);
+
+        [DllImport(libgit2)]
+        internal static extern int git_remote_add_fetch(
+            RepositorySafeHandle repo,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string remote,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string url);
 
         [DllImport(libgit2)]
         internal static extern int git_remote_set_pushurl(
-            RemoteSafeHandle remote,
+            RepositorySafeHandle repo,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string remote,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string url);
+
+        [DllImport(libgit2)]
+        internal static extern int git_remote_add_push(
+            RepositorySafeHandle repo,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string remote,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string url);
 
         [DllImport(libgit2)]
@@ -1094,9 +1117,6 @@ namespace LibGit2Sharp.Core
         internal static extern string git_remote_name(RemoteSafeHandle remote);
 
         [DllImport(libgit2)]
-        internal static extern int git_remote_save(RemoteSafeHandle remote);
-
-        [DllImport(libgit2)]
         [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))]
         internal static extern string git_remote_url(RemoteSafeHandle remote);
 
@@ -1105,12 +1125,10 @@ namespace LibGit2Sharp.Core
         internal static extern string git_remote_pushurl(RemoteSafeHandle remote);
 
         [DllImport(libgit2)]
-        internal static extern void git_remote_set_autotag(RemoteSafeHandle remote, TagFetchMode option);
-
-        [DllImport(libgit2)]
-        internal static extern int git_remote_set_callbacks(
-            RemoteSafeHandle remote,
-            ref GitRemoteCallbacks callbacks);
+        internal static extern void git_remote_set_autotag(
+            RepositorySafeHandle repo,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name,
+            TagFetchMode option);
 
         internal delegate int remote_progress_callback(IntPtr str, int len, IntPtr data);
 
@@ -1121,6 +1139,12 @@ namespace LibGit2Sharp.Core
             ref GitOid oldId,
             ref GitOid newId,
             IntPtr data);
+
+        internal delegate int push_negotiation_callback(
+            IntPtr updates, // GitPushUpdate?
+            UIntPtr len,
+            IntPtr payload
+            );
 
         internal delegate int push_update_reference_callback(
             IntPtr refName,

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -272,7 +272,9 @@ namespace LibGit2Sharp.Core
         internal static extern OidSafeHandle git_commit_tree_id(GitObjectSafeHandle commit);
 
         [DllImport(libgit2)]
-        internal static extern int git_config_delete_entry(ConfigurationSafeHandle cfg, string name);
+        internal static extern int git_config_delete_entry(
+            ConfigurationSafeHandle cfg,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof (StrictUtf8Marshaler))] string name);
 
         [DllImport(libgit2)]
         internal static extern int git_config_find_global(GitBuf global_config_path);

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -472,6 +472,24 @@ namespace LibGit2Sharp.Core
             }
         }
 
+        const string anyValue = ".*";
+
+        public static bool git_config_delete_multivar(ConfigurationSafeHandle config, string name)
+        {
+            using (ThreadAffinity())
+            {
+                int res = NativeMethods.git_config_delete_multivar(config, name, anyValue);
+
+                if (res == (int)GitErrorCode.NotFound)
+                {
+                    return false;
+                }
+
+                Ensure.ZeroResult(res);
+                return true;
+            }
+        }
+
         public static FilePath git_config_find_global()
         {
             return ConvertPath(NativeMethods.git_config_find_global);
@@ -1399,12 +1417,12 @@ namespace LibGit2Sharp.Core
         public static string git_note_default_ref(RepositorySafeHandle repo)
         {
             using (ThreadAffinity())
+            using (var buf = new GitBuf())
             {
-                string notes_ref;
-                int res = NativeMethods.git_note_default_ref(out notes_ref, repo);
+                int res = NativeMethods.git_note_default_ref(buf, repo);
                 Ensure.ZeroResult(res);
 
-                return notes_ref;
+                return LaxUtf8Marshaler.FromNative(buf.ptr);
             }
         }
 
@@ -1609,7 +1627,7 @@ namespace LibGit2Sharp.Core
                     IntPtr.Zero));
         }
 
-        public static OdbStreamSafeHandle git_odb_open_wstream(ObjectDatabaseSafeHandle odb, UIntPtr size, GitObjectType type)
+        public static OdbStreamSafeHandle git_odb_open_wstream(ObjectDatabaseSafeHandle odb, long size, GitObjectType type)
         {
             using (ThreadAffinity())
             {
@@ -1996,23 +2014,23 @@ namespace LibGit2Sharp.Core
             }
         }
 
-        public static RemoteSafeHandle git_remote_create_anonymous(RepositorySafeHandle repo, string url, string refspec)
+        public static RemoteSafeHandle git_remote_create_anonymous(RepositorySafeHandle repo, string url)
         {
             using (ThreadAffinity())
             {
                 RemoteSafeHandle handle;
-                int res = NativeMethods.git_remote_create_anonymous(out handle, repo, url, refspec);
+                int res = NativeMethods.git_remote_create_anonymous(out handle, repo, url);
                 Ensure.ZeroResult(res);
 
                 return handle;
             }
         }
 
-        public static void git_remote_connect(RemoteSafeHandle remote, GitDirection direction)
+        public static void git_remote_connect(RemoteSafeHandle remote, GitDirection direction, ref GitRemoteCallbacks remoteCallbacks)
         {
             using (ThreadAffinity())
             {
-                int res = NativeMethods.git_remote_connect(remote, direction);
+                int res = NativeMethods.git_remote_connect(remote, direction, ref remoteCallbacks);
                 Ensure.ZeroResult(res);
             }
         }
@@ -2102,7 +2120,45 @@ namespace LibGit2Sharp.Core
             }
         }
 
-        public static void git_remote_set_fetch_refspecs(RemoteSafeHandle remote, IEnumerable<string> refSpecs)
+        public static void git_remote_set_url(RepositorySafeHandle repo, string remote, string url)
+        {
+            using (ThreadAffinity())
+            {
+                int res = NativeMethods.git_remote_set_url(repo, remote, url);
+                Ensure.ZeroResult(res);
+            }
+        }
+
+        public static void git_remote_add_fetch(RepositorySafeHandle repo, string remote, string url)
+        {
+            using (ThreadAffinity())
+            {
+                int res = NativeMethods.git_remote_add_fetch(repo, remote, url);
+                Ensure.ZeroResult(res);
+            }
+        }
+
+        public static void git_remote_set_pushurl(RepositorySafeHandle repo, string remote, string url)
+        {
+            using (ThreadAffinity())
+            {
+                int res = NativeMethods.git_remote_set_pushurl(repo, remote, url);
+                Ensure.ZeroResult(res);
+            }
+        }
+
+        public static void git_remote_add_push(RepositorySafeHandle repo, string remote, string url)
+        {
+            using (ThreadAffinity())
+            {
+                int res = NativeMethods.git_remote_add_push(repo, remote, url);
+                Ensure.ZeroResult(res);
+            }
+        }
+
+        public static void git_remote_fetch(
+            RemoteSafeHandle remote, IEnumerable<string> refSpecs,
+            GitFetchOptions fetchOptions, string logMessage)
         {
             using (ThreadAffinity())
             {
@@ -2112,63 +2168,7 @@ namespace LibGit2Sharp.Core
                 {
                     array = GitStrArrayManaged.BuildFrom(refSpecs.ToArray());
 
-                    int res = NativeMethods.git_remote_set_fetch_refspecs(remote, ref array.Array);
-                    Ensure.ZeroResult(res);
-                }
-                finally
-                {
-                    array.Dispose();
-                }
-            }
-        }
-
-        public static void git_remote_set_push_refspecs(RemoteSafeHandle remote, IEnumerable<string> refSpecs)
-        {
-            using (ThreadAffinity())
-            {
-                var array = new GitStrArrayManaged();
-
-                try
-                {
-                    array = GitStrArrayManaged.BuildFrom(refSpecs.ToArray());
-
-                    int res = NativeMethods.git_remote_set_push_refspecs(remote, ref array.Array);
-                    Ensure.ZeroResult(res);
-                }
-                finally
-                {
-                    array.Dispose();
-                }
-            }
-        }
-
-        public static void git_remote_set_url(RemoteSafeHandle remote, string url)
-        {
-            using (ThreadAffinity())
-            {
-                int res = NativeMethods.git_remote_set_url(remote, url);
-                Ensure.ZeroResult(res);
-            }
-        }
-
-        public static void git_remote_set_pushurl(RemoteSafeHandle remote, string url)
-        {
-            using (ThreadAffinity())
-            {
-                int res = NativeMethods.git_remote_set_pushurl(remote, url);
-                Ensure.ZeroResult(res);
-            }
-        }
-
-        public static void git_remote_fetch(RemoteSafeHandle remote, string logMessage)
-        {
-            using (ThreadAffinity())
-            {
-                var array = new GitStrArrayNative();
-
-                try
-                {
-                    int res = NativeMethods.git_remote_fetch(remote, ref array.Array, logMessage);
+                    int res = NativeMethods.git_remote_fetch(remote, ref array.Array, fetchOptions, logMessage);
                     Ensure.ZeroResult(res);
                 }
                 finally
@@ -2313,27 +2313,9 @@ namespace LibGit2Sharp.Core
             }
         }
 
-        public static void git_remote_save(RemoteSafeHandle remote)
+        public static void git_remote_set_autotag(RepositorySafeHandle repo, string remote, TagFetchMode value)
         {
-            using (ThreadAffinity())
-            {
-                int res = NativeMethods.git_remote_save(remote);
-                Ensure.ZeroResult(res);
-            }
-        }
-
-        public static void git_remote_set_autotag(RemoteSafeHandle remote, TagFetchMode value)
-        {
-            NativeMethods.git_remote_set_autotag(remote, value);
-        }
-
-        public static void git_remote_set_callbacks(RemoteSafeHandle remote, ref GitRemoteCallbacks callbacks)
-        {
-            using (ThreadAffinity())
-            {
-                int res = NativeMethods.git_remote_set_callbacks(remote, ref callbacks);
-                Ensure.ZeroResult(res);
-            }
+            NativeMethods.git_remote_set_autotag(repo, remote, value);
         }
 
         public static string git_remote_url(RemoteSafeHandle remote)

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\LibGit2Sharp.NativeBinaries.1.0.25\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.25\build\LibGit2Sharp.NativeBinaries.props')" />
+  <Import Project="..\packages\LibGit2Sharp.NativeBinaries.1.0.51\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.51\build\LibGit2Sharp.NativeBinaries.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -70,6 +70,8 @@
     <Compile Include="CommitSortStrategies.cs" />
     <Compile Include="CompareOptions.cs" />
     <Compile Include="Core\FileHistory.cs" />
+    <Compile Include="Core\GitFetchOptions.cs" />
+    <Compile Include="Core\GitPushUpdate.cs" />
     <Compile Include="Core\Platform.cs" />
     <Compile Include="Core\Handles\ConflictIteratorSafeHandle.cs" />
     <Compile Include="DescribeOptions.cs" />
@@ -83,6 +85,7 @@
     <Compile Include="DiffAlgorithm.cs" />
     <Compile Include="EntryExistsException.cs" />
     <Compile Include="FetchOptionsBase.cs" />
+    <Compile Include="Core\FetchPruneStrategy.cs" />
     <Compile Include="LogEntry.cs" />
     <Compile Include="FollowFilter.cs" />
     <Compile Include="IBelongToARepository.cs" />
@@ -375,7 +378,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.25\build\LibGit2Sharp.NativeBinaries.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\LibGit2Sharp.NativeBinaries.1.0.25\build\LibGit2Sharp.NativeBinaries.props'))" />
+    <Error Condition="!Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.51\build\LibGit2Sharp.NativeBinaries.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\LibGit2Sharp.NativeBinaries.1.0.51\build\LibGit2Sharp.NativeBinaries.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/LibGit2Sharp/MergeOptionsBase.cs
+++ b/LibGit2Sharp/MergeOptionsBase.cs
@@ -1,8 +1,4 @@
-﻿using LibGit2Sharp.Core;
-using LibGit2Sharp.Handlers;
-using System;
-
-namespace LibGit2Sharp
+﻿namespace LibGit2Sharp
 {
     /// <summary>
     /// Options controlling the behavior of actions that use merge (merge
@@ -14,7 +10,7 @@ namespace LibGit2Sharp
         /// Initializes a new instance of the <see cref="MergeOptionsBase"/> class.
         /// The default behavior is to attempt to find renames.
         /// </summary>
-        public MergeOptionsBase()
+        protected MergeOptionsBase()
         {
             FindRenames = true;
             RenameThreshold = 50;

--- a/LibGit2Sharp/OdbBackend.cs
+++ b/LibGit2Sharp/OdbBackend.cs
@@ -440,12 +440,10 @@ namespace LibGit2Sharp
             private static int WriteStream(
                 out IntPtr stream_out,
                 IntPtr backend,
-                UIntPtr len,
+                long len,
                 GitObjectType type)
             {
                 stream_out = IntPtr.Zero;
-
-                long length = ConverToLong(len);
 
                 OdbBackend odbBackend = MarshalOdbBackend(backend);
                 if (odbBackend == null)
@@ -458,7 +456,7 @@ namespace LibGit2Sharp
                 try
                 {
                     OdbBackendStream stream;
-                    int toReturn = odbBackend.WriteStream(length, objectType, out stream);
+                    int toReturn = odbBackend.WriteStream(len, objectType, out stream);
 
                     if (toReturn == 0)
                     {

--- a/LibGit2Sharp/RemoteCollection.cs
+++ b/LibGit2Sharp/RemoteCollection.cs
@@ -57,12 +57,11 @@ namespace LibGit2Sharp
         /// <returns>The updated remote.</returns>
         public virtual Remote Update(Remote remote, params Action<RemoteUpdater>[] actions)
         {
-            using (var updater = new RemoteUpdater(this.repository, remote))
+            var updater = new RemoteUpdater(repository, remote);
+
+            foreach (Action<RemoteUpdater> action in actions)
             {
-                foreach (Action<RemoteUpdater> action in actions)
-                {
-                    action(updater);
-                }
+                action(updater);
             }
 
             return this[remote.Name];

--- a/LibGit2Sharp/RemoteUpdater.cs
+++ b/LibGit2Sharp/RemoteUpdater.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using LibGit2Sharp.Core;
 using LibGit2Sharp.Core.Handles;
 
@@ -9,11 +10,12 @@ namespace LibGit2Sharp
     /// <summary>
     /// Exposes properties of a remote that can be updated.
     /// </summary>
-    public class RemoteUpdater : IDisposable
+    public class RemoteUpdater
     {
         private readonly UpdatingCollection<string> fetchRefSpecs;
         private readonly UpdatingCollection<string> pushRefSpecs;
-        private readonly RemoteSafeHandle remoteHandle;
+        private readonly Repository repo;
+        private readonly Remote remote;
 
         /// <summary>
         /// Needed for mocking purposes.
@@ -26,32 +28,47 @@ namespace LibGit2Sharp
             Ensure.ArgumentNotNull(repo, "repo");
             Ensure.ArgumentNotNull(remote, "remote");
 
+            this.repo = repo;
+            this.remote = remote;
+
             fetchRefSpecs = new UpdatingCollection<string>(GetFetchRefSpecs, SetFetchRefSpecs);
             pushRefSpecs = new UpdatingCollection<string>(GetPushRefSpecs, SetPushRefSpecs);
-
-            remoteHandle = Proxy.git_remote_lookup(repo.Handle, remote.Name, true);
         }
 
         private IEnumerable<string> GetFetchRefSpecs()
         {
-            return Proxy.git_remote_get_fetch_refspecs(remoteHandle);
+            using (RemoteSafeHandle remoteHandle = Proxy.git_remote_lookup(repo.Handle, remote.Name, true))
+            {
+                return Proxy.git_remote_get_fetch_refspecs(remoteHandle);
+            }
         }
 
         private void SetFetchRefSpecs(IEnumerable<string> value)
         {
-            Proxy.git_remote_set_fetch_refspecs(remoteHandle, value);
-            Proxy.git_remote_save(remoteHandle);
+            repo.Config.UnsetMultivar(string.Format("remote.{0}.fetch", remote.Name), ConfigurationLevel.Local);
+
+            foreach (var url in value)
+            {
+                Proxy.git_remote_add_fetch(repo.Handle, remote.Name, url);
+            }
         }
 
         private IEnumerable<string> GetPushRefSpecs()
         {
-            return Proxy.git_remote_get_push_refspecs(remoteHandle);
+            using (RemoteSafeHandle remoteHandle = Proxy.git_remote_lookup(repo.Handle, remote.Name, true))
+            {
+                return Proxy.git_remote_get_push_refspecs(remoteHandle);
+            }
         }
 
         private void SetPushRefSpecs(IEnumerable<string> value)
         {
-            Proxy.git_remote_set_push_refspecs(remoteHandle, value);
-            Proxy.git_remote_save(remoteHandle);
+            repo.Config.UnsetMultivar(string.Format("remote.{0}.push", remote.Name), ConfigurationLevel.Local);
+
+            foreach (var url in value)
+            {
+                Proxy.git_remote_add_push(repo.Handle, remote.Name, url);
+            }
         }
 
         /// <summary>
@@ -61,8 +78,7 @@ namespace LibGit2Sharp
         {
             set
             {
-                Proxy.git_remote_set_autotag(remoteHandle, value);
-                Proxy.git_remote_save(remoteHandle);
+                Proxy.git_remote_set_autotag(repo.Handle, remote.Name, value);
             }
         }
 
@@ -73,11 +89,10 @@ namespace LibGit2Sharp
         {
             set
             {
-                Proxy.git_remote_set_url(remoteHandle, value);
-                Proxy.git_remote_save(remoteHandle);
+                Proxy.git_remote_set_url(repo.Handle, remote.Name, value);
             }
         }
-        
+
         /// <summary>
         /// Sets the push url defined for this <see cref="Remote"/>
         /// </summary>
@@ -85,8 +100,7 @@ namespace LibGit2Sharp
         {
             set
             {
-                Proxy.git_remote_set_pushurl(remoteHandle, value);
-                Proxy.git_remote_save(remoteHandle);
+                Proxy.git_remote_set_pushurl(repo.Handle, remote.Name, value);
             }
         }
 
@@ -187,14 +201,6 @@ namespace LibGit2Sharp
             {
                 setter(list.Value);
             }
-        }
-
-        /// <summary>
-        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
-        /// </summary>
-        public void Dispose()
-        {
-            remoteHandle.Dispose();
         }
     }
 }

--- a/LibGit2Sharp/Repository.cs
+++ b/LibGit2Sharp/Repository.cs
@@ -628,7 +628,7 @@ namespace LibGit2Sharp
                     Version = 1,
                     Bare = options.IsBare ? 1 : 0,
                     CheckoutOpts = gitCheckoutOptions,
-                    RemoteCallbacks = gitRemoteCallbacks,
+                    FetchOpts = new GitFetchOptions { RemoteCallbacks = gitRemoteCallbacks },
                 };
 
                 string clonedRepoPath;

--- a/LibGit2Sharp/SmartSubtransportRegistration.cs
+++ b/LibGit2Sharp/SmartSubtransportRegistration.cs
@@ -80,7 +80,8 @@ namespace LibGit2Sharp
 
             private static int Subtransport(
                 out IntPtr subtransport,
-                IntPtr transport)
+                IntPtr transport,
+                IntPtr payload)
             {
                 subtransport = IntPtr.Zero;
 

--- a/LibGit2Sharp/SubmoduleCollection.cs
+++ b/LibGit2Sharp/SubmoduleCollection.cs
@@ -107,7 +107,7 @@ namespace LibGit2Sharp
                     {
                         Version = 1,
                         CheckoutOptions = gitCheckoutOptions,
-                        RemoteCallbacks = gitRemoteCallbacks,
+                        FetchOptions = new GitFetchOptions { RemoteCallbacks = gitRemoteCallbacks },
                         CloneCheckoutStrategy = CheckoutStrategy.GIT_CHECKOUT_SAFE
                     };
 

--- a/LibGit2Sharp/TagFetchMode.cs
+++ b/LibGit2Sharp/TagFetchMode.cs
@@ -7,10 +7,16 @@
     public enum TagFetchMode
     {
         /// <summary>
-        /// Default behavior. Will automatically retrieve tags that
+        /// Use the setting from the configuration
+        /// or, when there isn't any, fallback to default behavior.
+        /// </summary>
+        FromConfigurationOrDefault = 0,  // GIT_REMOTE_DOWNLOAD_TAGS_FALLBACK
+
+        /// <summary>
+        /// Will automatically retrieve tags that
         /// point to objects retrieved during this fetch.
         /// </summary>
-        Auto = 0,  // GIT_REMOTE_DOWNLOAD_TAGS_AUTO
+        Auto,  // GIT_REMOTE_DOWNLOAD_TAGS_AUTO
 
         /// <summary>
         /// No tag will be retrieved.

--- a/LibGit2Sharp/packages.config
+++ b/LibGit2Sharp/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="LibGit2Sharp.NativeBinaries" version="1.0.25" targetFramework="net40" allowedVersions="[1.0.25]" />
+  <package id="LibGit2Sharp.NativeBinaries" version="1.0.51" targetFramework="net40" allowedVersions="[1.0.51]" />
 </packages>


### PR DESCRIPTION
This is an attempt to update to the latest libgit2 while dogfooding the new libgit2 binaries NuGet package.

I've downloaded the Appveyor artifact from https://github.com/libgit2/libgit2sharp.nativebinaries/pull/4 in a local folder. I then reconfigured VS to use this folder as a local NuGet package source.

While going through this process I'm taking notes in order to further update https://github.com/libgit2/libgit2sharp.nativebinaries/pull/5 and fix https://github.com/libgit2/libgit2sharp.nativebinaries/issues/2.

/cc @bording @jamill 