### PR TITLE
Added secure string support for credentials

### DIFF
--- a/LibGit2Sharp.Tests/TestHelpers/Constants.cs
+++ b/LibGit2Sharp.Tests/TestHelpers/Constants.cs
@@ -22,6 +22,9 @@ namespace LibGit2Sharp.Tests.TestHelpers
         // ... return new UsernamePasswordCredentials { Username = "username", Password = "swordfish" };
         //
         // Or:
+        // ... return new SecureUsernamePasswordCredentials() { Username = "username", Password = StringToSecureString("swordfish") };
+        //
+        // Or:
         // public const string PrivateRepoUrl = "https://tfs.contoso.com/tfs/DefaultCollection/project/_git/project";
         // ... return new DefaultCredentials();
 
@@ -67,6 +70,22 @@ namespace LibGit2Sharp.Tests.TestHelpers
             string testWorkingDirectory = Path.Combine(tempPath, "LibGit2Sharp-TestRepos");
             Trace.TraceInformation("Test working directory set to '{0}'", testWorkingDirectory);
             return testWorkingDirectory;
+        }
+
+        // To help with creating secure strings to test with.
+        private static System.Security.SecureString StringToSecureString(string str)
+        {
+            var chars = str.ToCharArray();
+
+            var secure = new System.Security.SecureString();
+            for (var i = 0; i < chars.Length; i++)
+            {
+                secure.AppendChar(chars[i]);
+            }
+
+            secure.MakeReadOnly();
+
+            return secure;
         }
     }
 }

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -143,6 +143,7 @@
     <Compile Include="RenameDetails.cs" />
     <Compile Include="RevertResult.cs" />
     <Compile Include="RevertOptions.cs" />
+    <Compile Include="SecureUsernamePasswordCredentials.cs" />
     <Compile Include="StageOptions.cs" />
     <Compile Include="StatusOptions.cs" />
     <Compile Include="SimilarityOptions.cs" />

--- a/LibGit2Sharp/SecureUsernamePasswordCredentials.cs
+++ b/LibGit2Sharp/SecureUsernamePasswordCredentials.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using LibGit2Sharp.Core;
+using System.Security;
+using System.Runtime.InteropServices;
+
+namespace LibGit2Sharp
+{
+    /// <summary>
+    /// Class that uses <see cref="SecureString"/> to hold username and password credentials for remote repository access.
+    /// </summary>
+    public sealed class SecureUsernamePasswordCredentials : Credentials
+    {
+        /// <summary>
+        /// Callback to acquire a credential object.
+        /// </summary>
+        /// <param name="cred">The newly created credential object.</param>
+        /// <returns>0 for success, &lt; 0 to indicate an error, &gt; 0 to indicate no credential was acquired.</returns>
+        protected internal override int GitCredentialHandler(out IntPtr cred)
+        {
+            if (Username == null || Password == null)
+            {
+                throw new InvalidOperationException("UsernamePasswordCredentials contains a null Username or Password.");
+            }
+
+            IntPtr passwordPtr = IntPtr.Zero;
+
+            try
+            {
+                passwordPtr = Marshal.SecureStringToGlobalAllocUnicode(Password);
+
+                return NativeMethods.git_cred_userpass_plaintext_new(out cred, Username, Marshal.PtrToStringUni(passwordPtr));
+            }
+            finally
+            {
+                Marshal.ZeroFreeGlobalAllocUnicode(passwordPtr);
+            }
+
+        }
+
+        /// <summary>
+        /// Username for username/password authentication (as in HTTP basic auth).
+        /// </summary>
+        public string Username { get; set; }
+
+        /// <summary>
+        /// Password for username/password authentication (as in HTTP basic auth).
+        /// </summary>
+        public SecureString Password { get; set; }
+    }
+}


### PR DESCRIPTION
Issue  #1048

I added some extra comments and a helper function in the constants class as well. Obviously I removed my credentials before committing and turned the tests back off, but they passed. You can use this snippet to re-instate them for this change.

            return new SecureUsernamePasswordCredentials() 
            { 
                Username = StringToSecureString("username"), 
                Password = StringToSecureString("swordfish") 
            };