### PR TITLE
Expose a more generic DiffAlgorithm property in CompareOptions

### DIFF
--- a/LibGit2Sharp.Tests/DiffTreeToTreeFixture.cs
+++ b/LibGit2Sharp.Tests/DiffTreeToTreeFixture.cs
@@ -1200,7 +1200,7 @@ namespace LibGit2Sharp.Tests
 
                 Assert.Equal(diffDefault, repo.Diff.Compare<Patch>(treeOld, treeNew));
                 Assert.Equal(diffPatience, repo.Diff.Compare<Patch>(treeOld, treeNew,
-                    compareOptions: new CompareOptions { UsePatienceAlgorithm = true }));
+                    compareOptions: new CompareOptions { Algorithm = DiffAlgorithm.Patience }));
             }
         }
     }

--- a/LibGit2Sharp/CompareOptions.cs
+++ b/LibGit2Sharp/CompareOptions.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace LibGit2Sharp
 {
     /// <summary>
@@ -12,6 +14,7 @@ namespace LibGit2Sharp
         {
             ContextLines = 3;
             InterhunkLines = 0;
+            Algorithm = DiffAlgorithm.Meyers;
         }
 
         /// <summary>
@@ -39,6 +42,13 @@ namespace LibGit2Sharp
         /// <summary>
         /// Use the "patience diff" algorithm.
         /// </summary>
+        [Obsolete("This property will be removed in the next release. Please use Algorithm instead.")]
         public bool UsePatienceAlgorithm { get; set; }
+
+        /// <summary>
+        /// Algorithm to be used when performing a Diff.
+        /// By default, <see cref="DiffAlgorithm.Meyers"/> will be used.
+        /// </summary>
+        public DiffAlgorithm Algorithm { get; set; }
     }
 }

--- a/LibGit2Sharp/Diff.cs
+++ b/LibGit2Sharp/Diff.cs
@@ -49,7 +49,7 @@ namespace LibGit2Sharp
                 options.Flags |= GitDiffOptionFlags.GIT_DIFF_INCLUDE_UNMODIFIED;
             }
 
-            if (compareOptions.UsePatienceAlgorithm)
+            if (compareOptions.Algorithm == DiffAlgorithm.Patience)
             {
                 options.Flags |= GitDiffOptionFlags.GIT_DIFF_PATIENCE;
             }

--- a/LibGit2Sharp/DiffAlgorithm.cs
+++ b/LibGit2Sharp/DiffAlgorithm.cs
@@ -1,0 +1,18 @@
+namespace LibGit2Sharp
+{
+    /// <summary>
+    /// Algorithm used when performing a Diff.
+    /// </summary>
+    public enum DiffAlgorithm
+    {
+        /// <summary>
+        /// The basic greedy diff algorithm.
+        /// </summary>
+        Meyers = 0,
+
+        /// <summary>
+        /// Use "patience diff" algorithm when generating patches.
+        /// </summary>
+        Patience = 2,
+    }
+}

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Core\Handles\DescribeResultSafeHandle.cs" />
     <Compile Include="Core\Handles\IndexNameEntrySafeHandle.cs" />
     <Compile Include="Core\Handles\IndexReucEntrySafeHandle.cs" />
+    <Compile Include="DiffAlgorithm.cs" />
     <Compile Include="EntryExistsException.cs" />
     <Compile Include="FetchOptionsBase.cs" />
     <Compile Include="LogEntry.cs" />


### PR DESCRIPTION
Following #1039 and in order to avoid future breaking changes maybe would it be wise to expose a property accepting an enum of Diff algorithms (Meyer, Minimal, ...).

/cc @dmalikov 

- Add new property
- Obsolete current property
- Implement minimal tests to cover each algorithm