### PR TITLE
Introduce CheckoutConflictException

### DIFF
--- a/LibGit2Sharp.Tests/CheckoutFixture.cs
+++ b/LibGit2Sharp.Tests/CheckoutFixture.cs
@@ -266,7 +266,7 @@ namespace LibGit2Sharp.Tests
 
                 // Assert that normal checkout throws exception
                 // for the conflict.
-                Assert.Throws<MergeConflictException>(() => repo.Checkout(master.CanonicalName));
+                Assert.Throws<CheckoutConflictException>(() => repo.Checkout(master.CanonicalName));
 
                 // Checkout with force option should succeed.
                 repo.Checkout(master.CanonicalName, new CheckoutOptions() { CheckoutModifiers = CheckoutModifiers.Force});
@@ -304,11 +304,11 @@ namespace LibGit2Sharp.Tests
 
                 // Assert that checking out master throws
                 // when there are unstaged commits
-                Assert.Throws<MergeConflictException>(() => repo.Checkout("master"));
+                Assert.Throws<CheckoutConflictException>(() => repo.Checkout("master"));
 
                 // And when there are staged commits
                 repo.Stage(originalFilePath);
-                Assert.Throws<MergeConflictException>(() => repo.Checkout("master"));
+                Assert.Throws<CheckoutConflictException>(() => repo.Checkout("master"));
             }
         }
 
@@ -505,7 +505,7 @@ namespace LibGit2Sharp.Tests
                     CheckoutNotifyFlags = notifyFlags,
                 };
 
-                Assert.Throws<MergeConflictException>(() => repo.Checkout("master", options));
+                Assert.Throws<CheckoutConflictException>(() => repo.Checkout("master", options));
 
                 Assert.True(wasCalled);
                 Assert.Equal(expectedNotificationPath, actualNotificationPath);

--- a/LibGit2Sharp.Tests/MergeFixture.cs
+++ b/LibGit2Sharp.Tests/MergeFixture.cs
@@ -584,7 +584,7 @@ namespace LibGit2Sharp.Tests
             // Merging the fast_forward branch results in a change to file
             // b.txt. In this test we modify the file in the working directory
             // and then attempt to perform a merge. We expect the merge to fail
-            // due to merge conflicts.
+            // due to checkout conflicts.
             string committishToMerge = "fast_forward";
 
             using (var repo = new Repository(SandboxMergeTestRepo()))
@@ -596,7 +596,7 @@ namespace LibGit2Sharp.Tests
                     repo.Stage("b.txt");
                 }
 
-                Assert.Throws<MergeConflictException>(() => repo.Merge(committishToMerge, Constants.Signature, new MergeOptions() { FastForwardStrategy = strategy }));
+                Assert.Throws<CheckoutConflictException>(() => repo.Merge(committishToMerge, Constants.Signature, new MergeOptions() { FastForwardStrategy = strategy }));
             }
         }
 

--- a/LibGit2Sharp/CheckoutConflictException.cs
+++ b/LibGit2Sharp/CheckoutConflictException.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Runtime.Serialization;
+using LibGit2Sharp.Core;
+
+namespace LibGit2Sharp
+{
+    /// <summary>
+    /// The exception that is thrown when a checkout cannot be performed
+    /// because of a conflicting change staged in the index, or unstaged
+    /// in the working directory.
+    /// </summary>
+    [Serializable]
+    public class CheckoutConflictException : LibGit2SharpException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LibGit2Sharp.CheckoutConflictException"/> class.
+        /// </summary>
+        public CheckoutConflictException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LibGit2Sharp.CheckoutConflictException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="message">A message that describes the error.</param>
+        public CheckoutConflictException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LibGit2Sharp.CheckoutConflictException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception. If the <paramref name="innerException"/> parameter is not a null reference, the current exception is raised in a catch block that handles the inner exception.</param>
+        public CheckoutConflictException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LibGit2Sharp.CheckoutConflictException"/> class with a serialized data.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        protected CheckoutConflictException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+
+        internal CheckoutConflictException(string message, GitErrorCode code, GitErrorCategory category)
+            : base(message, code, category)
+        {
+        }
+    }
+}

--- a/LibGit2Sharp/Core/Ensure.cs
+++ b/LibGit2Sharp/Core/Ensure.cs
@@ -97,7 +97,7 @@ namespace LibGit2Sharp.Core
                     { GitErrorCode.InvalidSpecification, (m, r, c) => new InvalidSpecificationException(m, r, c) },
                     { GitErrorCode.UnmergedEntries, (m, r, c) => new UnmergedIndexEntriesException(m, r, c) },
                     { GitErrorCode.NonFastForward, (m, r, c) => new NonFastForwardException(m, r, c) },
-                    { GitErrorCode.MergeConflict, (m, r, c) => new MergeConflictException(m, r, c) },
+                    { GitErrorCode.Conflict, (m, r, c) => new CheckoutConflictException(m, r, c) },
                     { GitErrorCode.LockedFile, (m, r, c) => new LockedFileException(m, r, c) },
                     { GitErrorCode.NotFound, (m, r, c) => new NotFoundException(m, r, c) },
                     { GitErrorCode.Peel, (m, r, c) => new PeelException(m, r, c)  },

--- a/LibGit2Sharp/Core/GitErrorCode.cs
+++ b/LibGit2Sharp/Core/GitErrorCode.cs
@@ -56,9 +56,10 @@
         InvalidSpecification = -12,
 
         /// <summary>
-        /// A conflicting change has been detected.
+        /// A conflicting change has been detected in the index
+        /// or working directory.
         /// </summary>
-        MergeConflict = -13,
+        Conflict = -13,
 
         /// <summary>
         /// A file operation failed because the file was locked.

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -105,6 +105,7 @@
     <Compile Include="IndexReucEntryCollection.cs" />
     <Compile Include="IndexNameEntry.cs" />
     <Compile Include="MergeAndCheckoutOptionsBase.cs" />
+    <Compile Include="MergeConflictException.cs" />
     <Compile Include="MergeOptions.cs" />
     <Compile Include="MergeOptionsBase.cs" />
     <Compile Include="MergeResult.cs" />
@@ -228,7 +229,7 @@
     <Compile Include="FetchHead.cs" />
     <Compile Include="Handlers.cs" />
     <Compile Include="Ignore.cs" />
-    <Compile Include="MergeConflictException.cs" />
+    <Compile Include="CheckoutConflictException.cs" />
     <Compile Include="MergeHead.cs" />
     <Compile Include="NameConflictException.cs" />
     <Compile Include="NetworkExtensions.cs" />

--- a/LibGit2Sharp/MergeConflictException.cs
+++ b/LibGit2Sharp/MergeConflictException.cs
@@ -1,55 +1,18 @@
 ﻿using System;
-using System.Runtime.Serialization;
-using LibGit2Sharp.Core;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 
 namespace LibGit2Sharp
 {
     /// <summary>
-    /// The exception that is thrown when a merge cannot be performed because
-    /// of a conflicting change.
+    /// The exception that is thrown when a checkout cannot be performed
+    /// because of a conflicting change staged in the index, or unstaged
+    /// in the working directory.
     /// </summary>
     [Serializable]
-    public class MergeConflictException : LibGit2SharpException
+    [Obsolete("This type will be removed in the next release. Please use CheckoutConflictException instead.")]
+    public class MergeConflictException : CheckoutConflictException
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="LibGit2Sharp.MergeConflictException"/> class.
-        /// </summary>
-        public MergeConflictException()
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="LibGit2Sharp.MergeConflictException"/> class with a specified error message.
-        /// </summary>
-        /// <param name="message">A message that describes the error.</param>
-        public MergeConflictException(string message)
-            : base(message)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="LibGit2Sharp.MergeConflictException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
-        /// </summary>
-        /// <param name="message">The error message that explains the reason for the exception.</param>
-        /// <param name="innerException">The exception that is the cause of the current exception. If the <paramref name="innerException"/> parameter is not a null reference, the current exception is raised in a catch block that handles the inner exception.</param>
-        public MergeConflictException(string message, Exception innerException)
-            : base(message, innerException)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="LibGit2Sharp.MergeConflictException"/> class with a serialized data.
-        /// </summary>
-        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
-        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
-        protected MergeConflictException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
-        {
-        }
-
-        internal MergeConflictException(string message, GitErrorCode code, GitErrorCategory category)
-            : base(message, code, category)
-        {
-        }
     }
 }


### PR DESCRIPTION
A merge conflict is a perfectly reasonable thing to occur during a merge, and does not produce an exception.  libgit2 only produces [an error of `GIT_ECONFLICT`](https://github.com/libgit2/libgit2/pull/3163) when there's a *checkout* conflict.  Rename our exception type to match.