### PR TITLE
Ensure that conflicts are staged and never ignored

### DIFF
--- a/LibGit2Sharp.Tests/Resources/mergedrepo_wd/dot_git/config
+++ b/LibGit2Sharp.Tests/Resources/mergedrepo_wd/dot_git/config
@@ -6,3 +6,4 @@
 	symlinks = false
 	ignorecase = true
 	hideDotFiles = dotGitOnly
+	autocrlf = false

--- a/LibGit2Sharp.Tests/StageFixture.cs
+++ b/LibGit2Sharp.Tests/StageFixture.cs
@@ -334,5 +334,21 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(FileStatus.NewInIndex, repo.RetrieveStatus(path));
             }
         }
+
+        [Theory]
+        [InlineData("new_untracked_file.txt", FileStatus.Ignored)]
+        [InlineData("modified_unstaged_file.txt", FileStatus.ModifiedInIndex)]
+        public void IgnoredFilesAreOnlyStagedIfTheyreInTheRepo(string filename, FileStatus expected)
+        {
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
+            {
+                File.WriteAllText(Path.Combine(repo.Info.WorkingDirectory, ".gitignore"),
+                    String.Format("{0}\n", filename));
+
+                repo.Stage(filename);
+                Assert.Equal(expected, repo.RetrieveStatus(filename));
+            }
+        }
     }
 }

--- a/LibGit2Sharp.Tests/StageFixture.cs
+++ b/LibGit2Sharp.Tests/StageFixture.cs
@@ -350,5 +350,27 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(expected, repo.RetrieveStatus(filename));
             }
         }
+
+        [Theory]
+        [InlineData("ancestor-and-ours.txt", FileStatus.Unaltered)]
+        [InlineData("ancestor-and-theirs.txt", FileStatus.NewInIndex)]
+        [InlineData("ancestor-only.txt", FileStatus.Nonexistent)]
+        [InlineData("conflicts-one.txt", FileStatus.ModifiedInIndex)]
+        [InlineData("conflicts-two.txt", FileStatus.ModifiedInIndex)]
+        [InlineData("ours-only.txt", FileStatus.Unaltered)]
+        [InlineData("ours-and-theirs.txt", FileStatus.ModifiedInIndex)]
+        [InlineData("theirs-only.txt", FileStatus.NewInIndex)]
+        public void CanStageConflictedIgnoredFiles(string filename, FileStatus expected)
+        {
+            var path = SandboxMergedTestRepo();
+            using (var repo = new Repository(path))
+            {
+                File.WriteAllText(Path.Combine(repo.Info.WorkingDirectory, ".gitignore"),
+                    String.Format("{0}\n", filename));
+
+                repo.Stage(filename);
+                Assert.Equal(expected, repo.RetrieveStatus(filename));
+            }
+        }
     }
 }

--- a/LibGit2Sharp/ChangeKind.cs
+++ b/LibGit2Sharp/ChangeKind.cs
@@ -55,5 +55,10 @@ namespace LibGit2Sharp
         /// Entry is unreadable.
         /// </summary>
         Unreadable = 9,
+
+        /// <summary>
+        /// Entry is currently in conflict.
+        /// </summary>
+        Conflicted = 10,
     }
 }

--- a/LibGit2Sharp/Core/GitDiff.cs
+++ b/LibGit2Sharp/Core/GitDiff.cs
@@ -231,6 +231,7 @@ namespace LibGit2Sharp.Core
         GIT_DIFF_FLAG_BINARY = (1 << 0),
         GIT_DIFF_FLAG_NOT_BINARY = (1 << 1),
         GIT_DIFF_FLAG_VALID_ID = (1 << 2),
+        GIT_DIFF_FLAG_EXISTS = (1 << 3),
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/LibGit2Sharp/FileStatus.cs
+++ b/LibGit2Sharp/FileStatus.cs
@@ -125,5 +125,10 @@ namespace LibGit2Sharp
         /// The file is <see cref="NewInWorkdir"/> but its name and/or path matches an exclude pattern in a <c>gitignore</c> file.
         /// </summary>
         Ignored = (1 << 14), /* GIT_STATUS_IGNORED */
+
+        /// <summary>
+        /// The file is <see cref="Conflicted"/> due to a merge.
+        /// </summary>
+        Conflicted = (1 << 15), /* GIT_STATUS_CONFLICTED */
     }
 }

--- a/LibGit2Sharp/TreeChanges.cs
+++ b/LibGit2Sharp/TreeChanges.cs
@@ -25,6 +25,7 @@ namespace LibGit2Sharp
         private readonly List<TreeEntryChanges> unmodified = new List<TreeEntryChanges>();
         private readonly List<TreeEntryChanges> renamed = new List<TreeEntryChanges>();
         private readonly List<TreeEntryChanges> copied = new List<TreeEntryChanges>();
+        private readonly List<TreeEntryChanges> conflicted = new List<TreeEntryChanges>();
 
         private readonly IDictionary<ChangeKind, Action<TreeChanges, TreeEntryChanges>> fileDispatcher = Build();
 
@@ -39,6 +40,7 @@ namespace LibGit2Sharp
                            { ChangeKind.Unmodified,  (de, d) => de.unmodified.Add(d) },
                            { ChangeKind.Renamed,     (de, d) => de.renamed.Add(d) },
                            { ChangeKind.Copied,      (de, d) => de.copied.Add(d) },
+                           { ChangeKind.Conflicted,  (de, d) => de.conflicted.Add(d) },
                        };
         }
 
@@ -144,6 +146,14 @@ namespace LibGit2Sharp
         public virtual IEnumerable<TreeEntryChanges> Unmodified
         {
             get { return unmodified; }
+        }
+
+        /// <summary>
+        /// List of <see cref="TreeEntryChanges"/> which are conflicted
+        /// </summary>
+        public virtual IEnumerable<TreeEntryChanges> Conflicted
+        {
+            get { return conflicted; }
         }
 
         private string DebuggerDisplay

--- a/LibGit2Sharp/TreeEntryChanges.cs
+++ b/LibGit2Sharp/TreeEntryChanges.cs
@@ -25,6 +25,8 @@ namespace LibGit2Sharp
             OldMode = (Mode)delta.OldFile.Mode;
             Oid = delta.NewFile.Id;
             OldOid = delta.OldFile.Id;
+            Exists = (delta.NewFile.Flags & GitDiffFlags.GIT_DIFF_FLAG_EXISTS) != 0;
+            OldExists = (delta.OldFile.Flags & GitDiffFlags.GIT_DIFF_FLAG_EXISTS) != 0;
 
             Status = (delta.Status == ChangeKind.Untracked || delta.Status == ChangeKind.Ignored)
                 ? ChangeKind.Added
@@ -47,6 +49,17 @@ namespace LibGit2Sharp
         public virtual ObjectId Oid { get; private set; }
 
         /// <summary>
+        /// The file exists in the new side of the diff.
+        /// This is useful in determining if you have content in
+        /// the ours or theirs side of a conflict.  This will
+        /// be false during a conflict that deletes both the
+        /// "ours" and "theirs" sides, or when the diff is a
+        /// delete and the status is
+        /// <see cref="ChangeType.Deleted"/>.
+        /// </summary>
+        public virtual bool Exists { get; private set; }
+
+        /// <summary>
         /// The kind of change that has been done (added, deleted, modified ...).
         /// </summary>
         public virtual ChangeKind Status { get; private set; }
@@ -65,6 +78,16 @@ namespace LibGit2Sharp
         /// The old content hash.
         /// </summary>
         public virtual ObjectId OldOid { get; private set; }
+
+        /// <summary>        
+        /// The file exists in the old side of the diff.
+        /// This is useful in determining if you have an ancestor
+        /// side to a conflict.  This will be false during a
+        /// conflict that involves both the "ours" and "theirs"
+        /// side being added, or when the diff is an add and the
+        /// status is <see cref="ChangeType.Added"/>.
+        /// </summary>
+        public virtual bool OldExists { get; private set; }
 
         private string DebuggerDisplay
         {


### PR DESCRIPTION
Like https://github.com/libgit2/libgit2/pull/3139, LibGit2Sharp erroneously does not stage conflicted files, if the filenames match `.gitignore`.  Update stage to take conflict data into account.