### PR TITLE
Should we allow Configuration to parse a local repository config?

### DIFF
--- a/LibGit2Sharp.Tests/ConfigurationFixture.cs
+++ b/LibGit2Sharp.Tests/ConfigurationFixture.cs
@@ -14,35 +14,6 @@ namespace LibGit2Sharp.Tests
             AssertValueInConfigFile(configFilePath, regex);
         }
 
-        private static string RetrieveGlobalConfigLocation()
-        {
-            string[] variables = { "HOME", "USERPROFILE", };
-
-            foreach (string variable in variables)
-            {
-                string potentialLocation = Environment.GetEnvironmentVariable(variable);
-                if (string.IsNullOrEmpty(potentialLocation))
-                {
-                    continue;
-                }
-
-                string potentialPath = Path.Combine(potentialLocation, ".gitconfig");
-
-                if (File.Exists(potentialPath))
-                {
-                    return potentialPath;
-                }
-            }
-
-            throw new InvalidOperationException("Unable to determine the location of '.gitconfig' file.");
-        }
-
-        private static void AssertValueInGlobalConfigFile(string regex)
-        {
-            string configFilePath = RetrieveGlobalConfigLocation();
-            AssertValueInConfigFile(configFilePath, regex);
-        }
-
         [Fact]
         public void CanUnsetAnEntryFromTheLocalConfiguration()
         {

--- a/LibGit2Sharp.Tests/ConfigurationFixture.cs
+++ b/LibGit2Sharp.Tests/ConfigurationFixture.cs
@@ -227,7 +227,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void SettingLocalConfigurationOutsideAReposThrows()
         {
-            using (var config = new Configuration(null, null, null))
+            using (var config = Configuration.BuildFrom(null, null, null, null))
             {
                 Assert.Throws<LibGit2SharpException>(() => config.Set("unittests.intsetting", 3));
             }
@@ -364,6 +364,27 @@ namespace LibGit2Sharp.Tests
                 Assert.True(repo.Config.HasConfig(ConfigurationLevel.System));
 
                 Assert.Null(repo.Config.Get<string>("MCHammer.You-cant-touch-this", ConfigurationLevel.System));
+            }
+        }
+
+        [Fact]
+        public void CanAccessConfigurationWithoutARepository()
+        {
+            var path = SandboxStandardTestRepoGitDir();
+
+            string globalConfigPath = CreateConfigurationWithDummyUser(Constants.Signature);
+            var options = new RepositoryOptions { GlobalConfigurationLocation = globalConfigPath };
+
+            using (var repo = new Repository(path, options))
+            {
+                repo.Config.Set("my.key", "local");
+                repo.Config.Set("my.key", "mouse", ConfigurationLevel.Global);
+            }
+
+            using (var config = Configuration.BuildFrom(Path.Combine(path, ".git", "config"), globalConfigPath))
+            {
+                Assert.Equal("local", config.Get<string>("my.key").Value);
+                Assert.Equal("mouse", config.Get<string>("my.key", ConfigurationLevel.Global).Value);
             }
         }
     }

--- a/LibGit2Sharp.Tests/TestHelpers/BaseFixture.cs
+++ b/LibGit2Sharp.Tests/TestHelpers/BaseFixture.cs
@@ -337,18 +337,18 @@ namespace LibGit2Sharp.Tests.TestHelpers
         {
             SelfCleaningDirectory scd = BuildSelfCleaningDirectory();
             Directory.CreateDirectory(scd.DirectoryPath);
-            string configFilePath = Path.Combine(scd.DirectoryPath, "global-config");
+            string configFilePath = Path.Combine(scd.DirectoryPath, "fake-config");
 
-            using (Configuration config = new Configuration(configFilePath))
+            using (Configuration config = Configuration.BuildFrom(configFilePath))
             {
                 if (name != null)
                 {
-                    config.Set("user.name", name, ConfigurationLevel.Global);
+                    config.Set("user.name", name);
                 }
 
                 if (email != null)
                 {
-                    config.Set("user.email", email, ConfigurationLevel.Global);
+                    config.Set("user.email", email);
                 }
             }
 

--- a/LibGit2Sharp.Tests/TestHelpers/BaseFixture.cs
+++ b/LibGit2Sharp.Tests/TestHelpers/BaseFixture.cs
@@ -336,8 +336,8 @@ namespace LibGit2Sharp.Tests.TestHelpers
         protected string CreateConfigurationWithDummyUser(string name, string email)
         {
             SelfCleaningDirectory scd = BuildSelfCleaningDirectory();
-            Directory.CreateDirectory(scd.DirectoryPath);
-            string configFilePath = Path.Combine(scd.DirectoryPath, "fake-config");
+
+            string configFilePath = Touch(scd.DirectoryPath, "fake-config");
 
             using (Configuration config = Configuration.BuildFrom(configFilePath))
             {

--- a/LibGit2Sharp/Configuration.cs
+++ b/LibGit2Sharp/Configuration.cs
@@ -15,11 +15,10 @@ namespace LibGit2Sharp
     public class Configuration : IDisposable,
         IEnumerable<ConfigurationEntry<string>>
     {
+        private readonly FilePath repoConfigPath;
         private readonly FilePath globalConfigPath;
         private readonly FilePath xdgConfigPath;
         private readonly FilePath systemConfigPath;
-
-        private readonly Repository repository;
 
         private ConfigurationSafeHandle configHandle;
 
@@ -29,19 +28,18 @@ namespace LibGit2Sharp
         protected Configuration()
         { }
 
-        internal Configuration(Repository repository, string globalConfigurationFileLocation,
+        internal Configuration(Repository repository, string repositoryConfigurationFileLocation, string globalConfigurationFileLocation,
             string xdgConfigurationFileLocation, string systemConfigurationFileLocation)
         {
-            this.repository = repository;
-
+            repoConfigPath = repositoryConfigurationFileLocation;
             globalConfigPath = globalConfigurationFileLocation ?? Proxy.git_config_find_global();
             xdgConfigPath = xdgConfigurationFileLocation ?? Proxy.git_config_find_xdg();
             systemConfigPath = systemConfigurationFileLocation ?? Proxy.git_config_find_system();
 
-            Init();
+            Init(repository);
         }
 
-        private void Init()
+        private void Init(Repository repository)
         {
             configHandle = Proxy.git_config_new();
 
@@ -55,6 +53,10 @@ namespace LibGit2Sharp
                 Proxy.git_config_add_file_ondisk(configHandle, repoConfigLocation, ConfigurationLevel.Local);
 
                 Proxy.git_repository_set_config(repository.Handle, configHandle);
+            }
+            else if (repoConfigPath != null)
+            {
+                Proxy.git_config_add_file_ondisk(configHandle, repoConfigPath, ConfigurationLevel.Local);
             }
 
             if (globalConfigPath != null)
@@ -74,11 +76,80 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
+        /// Access configuration values without a repository.
+        /// <para>
+        ///   Generally you want to access configuration via an instance of <see cref="Repository"/> instead.
+        /// </para>
+        /// </summary>
+        /// <param name="repositoryConfigurationFileLocation">Path to a Repository configuration file.</param>
+        /// <returns>An instance of <see cref="Configuration"/>.</returns>
+        public static Configuration BuildFrom(
+            string repositoryConfigurationFileLocation)
+        {
+            return BuildFrom(repositoryConfigurationFileLocation, null, null, null);
+        }
+
+        /// <summary>
+        /// Access configuration values without a repository.
+        /// <para>
+        ///   Generally you want to access configuration via an instance of <see cref="Repository"/> instead.
+        /// </para>
+        /// </summary>
+        /// <param name="repositoryConfigurationFileLocation">Path to a Repository configuration file.</param>
+        /// <param name="globalConfigurationFileLocation">Path to a Global configuration file. If null, the default path for a Global configuration file will be probed.</param>
+        /// <returns>An instance of <see cref="Configuration"/>.</returns>
+        public static Configuration BuildFrom(
+            string repositoryConfigurationFileLocation,
+            string globalConfigurationFileLocation)
+        {
+            return BuildFrom(repositoryConfigurationFileLocation, globalConfigurationFileLocation, null, null);
+        }
+
+        /// <summary>
+        /// Access configuration values without a repository.
+        /// <para>
+        ///   Generally you want to access configuration via an instance of <see cref="Repository"/> instead.
+        /// </para>
+        /// </summary>
+        /// <param name="repositoryConfigurationFileLocation">Path to a Repository configuration file.</param>
+        /// <param name="globalConfigurationFileLocation">Path to a Global configuration file. If null, the default path for a Global configuration file will be probed.</param>
+        /// <param name="xdgConfigurationFileLocation">Path to a XDG configuration file. If null, the default path for a XDG configuration file will be probed.</param>
+        /// <returns>An instance of <see cref="Configuration"/>.</returns>
+        public static Configuration BuildFrom(
+            string repositoryConfigurationFileLocation,
+            string globalConfigurationFileLocation,
+            string xdgConfigurationFileLocation)
+        {
+            return BuildFrom(repositoryConfigurationFileLocation, globalConfigurationFileLocation, xdgConfigurationFileLocation, null);
+        }
+
+        /// <summary>
+        /// Access configuration values without a repository.
+        /// <para>
+        ///   Generally you want to access configuration via an instance of <see cref="Repository"/> instead.
+        /// </para>
+        /// </summary>
+        /// <param name="repositoryConfigurationFileLocation">Path to a Repository configuration file.</param>
+        /// <param name="globalConfigurationFileLocation">Path to a Global configuration file. If null, the default path for a Global configuration file will be probed.</param>
+        /// <param name="xdgConfigurationFileLocation">Path to a XDG configuration file. If null, the default path for a XDG configuration file will be probed.</param>
+        /// <param name="systemConfigurationFileLocation">Path to a System configuration file. If null, the default path for a System configuration file will be probed.</param>
+        /// <returns>An instance of <see cref="Configuration"/>.</returns>
+        public static Configuration BuildFrom(
+            string repositoryConfigurationFileLocation,
+            string globalConfigurationFileLocation,
+            string xdgConfigurationFileLocation,
+            string systemConfigurationFileLocation)
+        {
+            return new Configuration(null, repositoryConfigurationFileLocation, globalConfigurationFileLocation, xdgConfigurationFileLocation, systemConfigurationFileLocation);
+        }
+
+        /// <summary>
         /// Access configuration values without a repository. Generally you want to access configuration via an instance of <see cref="Repository"/> instead.
         /// </summary>
         /// <param name="globalConfigurationFileLocation">Path to a Global configuration file. If null, the default path for a global configuration file will be probed.</param>
+        [Obsolete("This method will be removed in the next release. Please use Configuration.BuildFrom(string, string) instead.")]
         public Configuration(string globalConfigurationFileLocation)
-            : this(null, globalConfigurationFileLocation, null, null)
+            : this(null, null, globalConfigurationFileLocation, null, null)
         { }
 
         /// <summary>
@@ -86,8 +157,9 @@ namespace LibGit2Sharp
         /// </summary>
         /// <param name="globalConfigurationFileLocation">Path to a Global configuration file. If null, the default path for a global configuration file will be probed.</param>
         /// <param name="xdgConfigurationFileLocation">Path to a XDG configuration file. If null, the default path for a XDG configuration file will be probed.</param>
+        [Obsolete("This method will be removed in the next release. Please use Configuration.BuildFrom(string, string, string) instead.")]
         public Configuration(string globalConfigurationFileLocation, string xdgConfigurationFileLocation)
-            : this(null, globalConfigurationFileLocation, xdgConfigurationFileLocation, null)
+            : this(null, null, globalConfigurationFileLocation, xdgConfigurationFileLocation, null)
         { }
 
         /// <summary>
@@ -96,10 +168,10 @@ namespace LibGit2Sharp
         /// <param name="globalConfigurationFileLocation">Path to a Global configuration file. If null, the default path for a global configuration file will be probed.</param>
         /// <param name="xdgConfigurationFileLocation">Path to a XDG configuration file. If null, the default path for a XDG configuration file will be probed.</param>
         /// <param name="systemConfigurationFileLocation">Path to a System configuration file. If null, the default path for a system configuration file will be probed.</param>
+        [Obsolete("This method will be removed in the next release. Please use Configuration.BuildFrom(string, string, string, string) instead.")]
         public Configuration(string globalConfigurationFileLocation, string xdgConfigurationFileLocation, string systemConfigurationFileLocation)
-            : this(null, globalConfigurationFileLocation, xdgConfigurationFileLocation, systemConfigurationFileLocation)
-        {
-        }
+            : this(null, null, globalConfigurationFileLocation, xdgConfigurationFileLocation, systemConfigurationFileLocation)
+        { }
 
         /// <summary>
         /// Determines which configuration file has been found.

--- a/LibGit2Sharp/Configuration.cs
+++ b/LibGit2Sharp/Configuration.cs
@@ -31,7 +31,11 @@ namespace LibGit2Sharp
         internal Configuration(Repository repository, string repositoryConfigurationFileLocation, string globalConfigurationFileLocation,
             string xdgConfigurationFileLocation, string systemConfigurationFileLocation)
         {
-            repoConfigPath = repositoryConfigurationFileLocation;
+            if (repositoryConfigurationFileLocation != null)
+            {
+                repoConfigPath = NormalizeConfigPath(repositoryConfigurationFileLocation);
+            }
+
             globalConfigPath = globalConfigurationFileLocation ?? Proxy.git_config_find_global();
             xdgConfigPath = xdgConfigurationFileLocation ?? Proxy.git_config_find_xdg();
             systemConfigPath = systemConfigurationFileLocation ?? Proxy.git_config_find_system();
@@ -75,13 +79,46 @@ namespace LibGit2Sharp
             }
         }
 
+        private FilePath NormalizeConfigPath(FilePath path)
+        {
+            if (File.Exists(path.Native))
+            {
+                return path;
+            }
+
+            if (!Directory.Exists(path.Native))
+            {
+                throw new FileNotFoundException("Cannot find repository configuration file", path.Native);
+            }
+
+            var configPath = Path.Combine(path.Native, "config");
+
+            if (File.Exists(configPath))
+            {
+                return configPath;
+            }
+
+            var gitConfigPath = Path.Combine(path.Native, ".git", "config");
+
+            if (File.Exists(gitConfigPath))
+            {
+                return gitConfigPath;
+            }
+
+            throw new FileNotFoundException("Cannot find repository configuration file", path.Native);
+        }
+
         /// <summary>
         /// Access configuration values without a repository.
         /// <para>
         ///   Generally you want to access configuration via an instance of <see cref="Repository"/> instead.
         /// </para>
+        /// <para>
+        ///   <paramref name="repositoryConfigurationFileLocation"/> can either contains a path to a file or a directory. In the latter case,
+        ///   this can be the working directory, the .git directory or the directory containing a bare repository.
+        /// </para>
         /// </summary>
-        /// <param name="repositoryConfigurationFileLocation">Path to a Repository configuration file.</param>
+        /// <param name="repositoryConfigurationFileLocation">Path to an existing Repository configuration file.</param>
         /// <returns>An instance of <see cref="Configuration"/>.</returns>
         public static Configuration BuildFrom(
             string repositoryConfigurationFileLocation)
@@ -94,8 +131,12 @@ namespace LibGit2Sharp
         /// <para>
         ///   Generally you want to access configuration via an instance of <see cref="Repository"/> instead.
         /// </para>
+        /// <para>
+        ///   <paramref name="repositoryConfigurationFileLocation"/> can either contains a path to a file or a directory. In the latter case,
+        ///   this can be the working directory, the .git directory or the directory containing a bare repository.
+        /// </para>
         /// </summary>
-        /// <param name="repositoryConfigurationFileLocation">Path to a Repository configuration file.</param>
+        /// <param name="repositoryConfigurationFileLocation">Path to an existing Repository configuration file.</param>
         /// <param name="globalConfigurationFileLocation">Path to a Global configuration file. If null, the default path for a Global configuration file will be probed.</param>
         /// <returns>An instance of <see cref="Configuration"/>.</returns>
         public static Configuration BuildFrom(
@@ -110,8 +151,12 @@ namespace LibGit2Sharp
         /// <para>
         ///   Generally you want to access configuration via an instance of <see cref="Repository"/> instead.
         /// </para>
+        /// <para>
+        ///   <paramref name="repositoryConfigurationFileLocation"/> can either contains a path to a file or a directory. In the latter case,
+        ///   this can be the working directory, the .git directory or the directory containing a bare repository.
+        /// </para>
         /// </summary>
-        /// <param name="repositoryConfigurationFileLocation">Path to a Repository configuration file.</param>
+        /// <param name="repositoryConfigurationFileLocation">Path to an existing Repository configuration file.</param>
         /// <param name="globalConfigurationFileLocation">Path to a Global configuration file. If null, the default path for a Global configuration file will be probed.</param>
         /// <param name="xdgConfigurationFileLocation">Path to a XDG configuration file. If null, the default path for a XDG configuration file will be probed.</param>
         /// <returns>An instance of <see cref="Configuration"/>.</returns>
@@ -128,8 +173,12 @@ namespace LibGit2Sharp
         /// <para>
         ///   Generally you want to access configuration via an instance of <see cref="Repository"/> instead.
         /// </para>
+        /// <para>
+        ///   <paramref name="repositoryConfigurationFileLocation"/> can either contains a path to a file or a directory. In the latter case,
+        ///   this can be the working directory, the .git directory or the directory containing a bare repository.
+        /// </para>
         /// </summary>
-        /// <param name="repositoryConfigurationFileLocation">Path to a Repository configuration file.</param>
+        /// <param name="repositoryConfigurationFileLocation">Path to an existing Repository configuration file.</param>
         /// <param name="globalConfigurationFileLocation">Path to a Global configuration file. If null, the default path for a Global configuration file will be probed.</param>
         /// <param name="xdgConfigurationFileLocation">Path to a XDG configuration file. If null, the default path for a XDG configuration file will be probed.</param>
         /// <param name="systemConfigurationFileLocation">Path to a System configuration file. If null, the default path for a System configuration file will be probed.</param>

--- a/LibGit2Sharp/Repository.cs
+++ b/LibGit2Sharp/Repository.cs
@@ -125,7 +125,7 @@ namespace LibGit2Sharp
                 config =
                     new Lazy<Configuration>(
                         () =>
-                        RegisterForCleanup(new Configuration(this, configurationGlobalFilePath, configurationXDGFilePath,
+                        RegisterForCleanup(new Configuration(this, null, configurationGlobalFilePath, configurationXDGFilePath,
                                                              configurationSystemFilePath)));
                 odb = new Lazy<ObjectDatabase>(() => new ObjectDatabase(this));
                 diff = new Diff(this);


### PR DESCRIPTION
@shiftkey in #1031 made an amazing job getting rid of the optional parameters in favor of overloads. While taking a look at the changes in **[Configuration](https://github.com/libgit2/libgit2sharp/pull/1031/files#diff-68ea54fb16f8127b60527299a954770d)**, I wondered if there was a use case where one would need to access the config of a repository without instantiating it.

Should this need be fulfilled, we'd rather make it happen in v0.22 as it will be quite a nasty breaking change.

/cc @jamill @ethomson 