### PR TITLE
Remove union merge driver for sln, csproj files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,5 +3,3 @@
 
 # Custom for Visual Studio
 *.cs     diff=csharp
-*.sln    merge=union
-*.csproj merge=union


### PR DESCRIPTION
The union merge driver is not appropriate for sln or csproj files.  It is useful (as described by Junio) to "merge two shopping lists".

This will work in trivial examples for sln and csproj files, for example when one branch adds a new file and the other branch does too, but it will often silently produce corrupt output.

@Haacked has a nice writeup at http://haacked.com/archive/2014/04/16/csproj-merge-conflicts/