### PR TITLE
Add .gitattributes to test resources

### DIFF
--- a/LibGit2Sharp.Tests/Resources/assume_unchanged_wd/.gitattributes
+++ b/LibGit2Sharp.Tests/Resources/assume_unchanged_wd/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/LibGit2Sharp.Tests/Resources/merge_testrepo_wd/.gitattributes
+++ b/LibGit2Sharp.Tests/Resources/merge_testrepo_wd/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/LibGit2Sharp.Tests/Resources/mergedrepo_wd/.gitattributes
+++ b/LibGit2Sharp.Tests/Resources/mergedrepo_wd/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/LibGit2Sharp.Tests/Resources/mergerenames_wd/.gitattributes
+++ b/LibGit2Sharp.Tests/Resources/mergerenames_wd/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/LibGit2Sharp.Tests/Resources/revert_testrepo_wd/.gitattributes
+++ b/LibGit2Sharp.Tests/Resources/revert_testrepo_wd/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/LibGit2Sharp.Tests/Resources/submodule_small_wd/.gitattributes
+++ b/LibGit2Sharp.Tests/Resources/submodule_small_wd/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/LibGit2Sharp.Tests/Resources/submodule_target_wd/.gitattributes
+++ b/LibGit2Sharp.Tests/Resources/submodule_target_wd/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/LibGit2Sharp.Tests/Resources/submodule_wd/.gitattributes
+++ b/LibGit2Sharp.Tests/Resources/submodule_wd/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/LibGit2Sharp.Tests/Resources/testrepo_wd/.gitattributes
+++ b/LibGit2Sharp.Tests/Resources/testrepo_wd/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
When the test resources are "sandboxed" for test execution, they
are copied from the test resources directory, which was checked out
by the end user using the LibGit2Sharp repository's .gitattributes,
which specifies `* text=auto`.  As a result, the test resources have
had their line endings normalized.

The test repositories, however, do not have a setting that indicates
that their working directories have had normalized data written.
Our test repositories must therefore match the mechanism by which
they were written.

This sort of problem is evident when you "touch" a file in the test repository.  A more timely example is when a file does not exist locally (perhaps because it has been removed from the working directory) in the test resource working directory but has not been removed from the index.  If the test then adds the file back on disk, one would expect the status of this repository to be clean.  In fact, if your line ending configuration is wrong, this will not be the case.

(Three cheers for line ending normalization by default!)