### PR TITLE
Add List Remote References without creating a Repository

### DIFF
--- a/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
+++ b/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
@@ -124,6 +124,7 @@
     <Compile Include="TestHelpers\SignatureExtensions.cs" />
     <Compile Include="TestHelpers\SkippableFactAttribute.cs" />
     <Compile Include="LogFixture.cs" />
+    <Compile Include="TestHelpers\TestRemoteRefs.cs" />
     <Compile Include="TreeDefinitionFixture.cs" />
     <Compile Include="TreeFixture.cs" />
     <Compile Include="UnstageFixture.cs" />

--- a/LibGit2Sharp.Tests/NetworkFixture.cs
+++ b/LibGit2Sharp.Tests/NetworkFixture.cs
@@ -34,11 +34,11 @@ namespace LibGit2Sharp.Tests
                 List<Tuple<string, string>> actualRefs = references.
                     Select(directRef => new Tuple<string, string>(directRef.CanonicalName, directRef.TargetIdentifier)).ToList();
 
-                Assert.Equal(ExpectedRemoteRefs.Count, actualRefs.Count);
-                for (int i = 0; i < ExpectedRemoteRefs.Count; i++)
+                Assert.Equal(TestRemoteRefs.ExpectedRemoteRefs.Count, actualRefs.Count);
+                for (int i = 0; i < TestRemoteRefs.ExpectedRemoteRefs.Count; i++)
                 {
-                    Assert.Equal(ExpectedRemoteRefs[i].Item2, actualRefs[i].Item2);
-                    Assert.Equal(ExpectedRemoteRefs[i].Item1, actualRefs[i].Item1);
+                    Assert.Equal(TestRemoteRefs.ExpectedRemoteRefs[i].Item2, actualRefs[i].Item2);
+                    Assert.Equal(TestRemoteRefs.ExpectedRemoteRefs[i].Item1, actualRefs[i].Item1);
                 }
             }
         }
@@ -65,11 +65,11 @@ namespace LibGit2Sharp.Tests
                 List<Tuple<string, string>> actualRefs = references.
                     Select(directRef => new Tuple<string, string>(directRef.CanonicalName, directRef.TargetIdentifier)).ToList();
 
-                Assert.Equal(ExpectedRemoteRefs.Count, actualRefs.Count);
-                for (int i = 0; i < ExpectedRemoteRefs.Count; i++)
+                Assert.Equal(TestRemoteRefs.ExpectedRemoteRefs.Count, actualRefs.Count);
+                for (int i = 0; i < TestRemoteRefs.ExpectedRemoteRefs.Count; i++)
                 {
-                    Assert.Equal(ExpectedRemoteRefs[i].Item2, actualRefs[i].Item2);
-                    Assert.Equal(ExpectedRemoteRefs[i].Item1, actualRefs[i].Item1);
+                    Assert.Equal(TestRemoteRefs.ExpectedRemoteRefs[i].Item2, actualRefs[i].Item2);
+                    Assert.Equal(TestRemoteRefs.ExpectedRemoteRefs[i].Item1, actualRefs[i].Item1);
                 }
             }
         }
@@ -98,11 +98,11 @@ namespace LibGit2Sharp.Tests
                     actualRefs.Add(new Tuple<string, string>(reference.CanonicalName, reference.Target.Id.Sha));
                 }
 
-                Assert.Equal(ExpectedRemoteRefs.Count, actualRefs.Count);
-                for (int i = 0; i < ExpectedRemoteRefs.Count; i++)
+                Assert.Equal(TestRemoteRefs.ExpectedRemoteRefs.Count, actualRefs.Count);
+                for (int i = 0; i < TestRemoteRefs.ExpectedRemoteRefs.Count; i++)
                 {
-                    Assert.Equal(ExpectedRemoteRefs[i].Item1, actualRefs[i].Item1);
-                    Assert.Equal(ExpectedRemoteRefs[i].Item2, actualRefs[i].Item2);
+                    Assert.Equal(TestRemoteRefs.ExpectedRemoteRefs[i].Item1, actualRefs[i].Item1);
+                    Assert.Equal(TestRemoteRefs.ExpectedRemoteRefs[i].Item2, actualRefs[i].Item2);
                 }
             }
         }
@@ -254,33 +254,5 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(mergeResult.Status, MergeStatus.NonFastForward);
             }
         }
-
-        /*
-        * git ls-remote http://github.com/libgit2/TestGitRepository
-        * 49322bb17d3acc9146f98c97d078513228bbf3c0        HEAD
-        * 0966a434eb1a025db6b71485ab63a3bfbea520b6        refs/heads/first-merge
-        * 49322bb17d3acc9146f98c97d078513228bbf3c0        refs/heads/master
-        * 42e4e7c5e507e113ebbb7801b16b52cf867b7ce1        refs/heads/no-parent
-        * d96c4e80345534eccee5ac7b07fc7603b56124cb        refs/tags/annotated_tag
-        * c070ad8c08840c8116da865b2d65593a6bb9cd2a        refs/tags/annotated_tag^{}
-        * 55a1a760df4b86a02094a904dfa511deb5655905        refs/tags/blob
-        * 8f50ba15d49353813cc6e20298002c0d17b0a9ee        refs/tags/commit_tree
-        * 6e0c7bdb9b4ed93212491ee778ca1c65047cab4e        refs/tags/nearly-dangling
-        */
-        /// <summary>
-        /// Expected references on http://github.com/libgit2/TestGitRepository
-        /// </summary>
-        private static List<Tuple<string, string>> ExpectedRemoteRefs = new List<Tuple<string, string>>()
-        {
-            new Tuple<string, string>("HEAD", "49322bb17d3acc9146f98c97d078513228bbf3c0"),
-            new Tuple<string, string>("refs/heads/first-merge", "0966a434eb1a025db6b71485ab63a3bfbea520b6"),
-            new Tuple<string, string>("refs/heads/master", "49322bb17d3acc9146f98c97d078513228bbf3c0"),
-            new Tuple<string, string>("refs/heads/no-parent", "42e4e7c5e507e113ebbb7801b16b52cf867b7ce1"),
-            new Tuple<string, string>("refs/tags/annotated_tag", "d96c4e80345534eccee5ac7b07fc7603b56124cb"),
-            new Tuple<string, string>("refs/tags/annotated_tag^{}", "c070ad8c08840c8116da865b2d65593a6bb9cd2a"),
-            new Tuple<string, string>("refs/tags/blob", "55a1a760df4b86a02094a904dfa511deb5655905"),
-            new Tuple<string, string>("refs/tags/commit_tree", "8f50ba15d49353813cc6e20298002c0d17b0a9ee"),
-            new Tuple<string, string>("refs/tags/nearly-dangling", "6e0c7bdb9b4ed93212491ee778ca1c65047cab4e"),
-        };
     }
 }

--- a/LibGit2Sharp.Tests/TestHelpers/TestRemoteRefs.cs
+++ b/LibGit2Sharp.Tests/TestHelpers/TestRemoteRefs.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace LibGit2Sharp.Tests.TestHelpers
+{
+    public class TestRemoteRefs
+    {
+        /*
+        * git ls-remote http://github.com/libgit2/TestGitRepository
+        * 49322bb17d3acc9146f98c97d078513228bbf3c0        HEAD
+        * 0966a434eb1a025db6b71485ab63a3bfbea520b6        refs/heads/first-merge
+        * 49322bb17d3acc9146f98c97d078513228bbf3c0        refs/heads/master
+        * 42e4e7c5e507e113ebbb7801b16b52cf867b7ce1        refs/heads/no-parent
+        * d96c4e80345534eccee5ac7b07fc7603b56124cb        refs/tags/annotated_tag
+        * c070ad8c08840c8116da865b2d65593a6bb9cd2a        refs/tags/annotated_tag^{}
+        * 55a1a760df4b86a02094a904dfa511deb5655905        refs/tags/blob
+        * 8f50ba15d49353813cc6e20298002c0d17b0a9ee        refs/tags/commit_tree
+        * 6e0c7bdb9b4ed93212491ee778ca1c65047cab4e        refs/tags/nearly-dangling
+        */
+        /// <summary>
+        /// Expected references on http://github.com/libgit2/TestGitRepository
+        /// </summary>
+        public static List<Tuple<string, string>> ExpectedRemoteRefs = new List<Tuple<string, string>>()
+        {
+            new Tuple<string, string>("HEAD", "49322bb17d3acc9146f98c97d078513228bbf3c0"),
+            new Tuple<string, string>("refs/heads/first-merge", "0966a434eb1a025db6b71485ab63a3bfbea520b6"),
+            new Tuple<string, string>("refs/heads/master", "49322bb17d3acc9146f98c97d078513228bbf3c0"),
+            new Tuple<string, string>("refs/heads/no-parent", "42e4e7c5e507e113ebbb7801b16b52cf867b7ce1"),
+            new Tuple<string, string>("refs/tags/annotated_tag", "d96c4e80345534eccee5ac7b07fc7603b56124cb"),
+            new Tuple<string, string>("refs/tags/annotated_tag^{}", "c070ad8c08840c8116da865b2d65593a6bb9cd2a"),
+            new Tuple<string, string>("refs/tags/blob", "55a1a760df4b86a02094a904dfa511deb5655905"),
+            new Tuple<string, string>("refs/tags/commit_tree", "8f50ba15d49353813cc6e20298002c0d17b0a9ee"),
+            new Tuple<string, string>("refs/tags/nearly-dangling", "6e0c7bdb9b4ed93212491ee778ca1c65047cab4e"),
+        };
+    }
+}

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -1286,6 +1286,9 @@ namespace LibGit2Sharp.Core
         internal static extern FilePath git_repository_workdir(RepositorySafeHandle repository);
 
         [DllImport(libgit2)]
+        internal static extern int git_repository_new(out RepositorySafeHandle repo);
+
+        [DllImport(libgit2)]
         internal static extern int git_reset(
             RepositorySafeHandle repo,
             GitObjectSafeHandle target,

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -2167,6 +2167,16 @@ namespace LibGit2Sharp.Core
             return repo;
         }
 
+        public static RepositorySafeHandle git_repository_new()
+        {
+            RepositorySafeHandle repo;
+            int res = NativeMethods.git_repository_new(out repo);
+
+            Ensure.ZeroResult(res);
+
+            return repo;
+        }
+
         public static void git_repository_open_ext(string path, RepositoryOpenFlags flags, string ceilingDirs)
         {
             int res;

--- a/LibGit2Sharp/DirectReference.cs
+++ b/LibGit2Sharp/DirectReference.cs
@@ -18,12 +18,21 @@ namespace LibGit2Sharp
         internal DirectReference(string canonicalName, IRepository repo, ObjectId targetId)
             : base(repo, canonicalName, targetId.Sha)
         {
-            targetBuilder = new Lazy<GitObject>(() => repo.Lookup(targetId));
+            targetBuilder = new Lazy<GitObject>(() =>
+            {
+                if (repo == null)
+                {
+                    throw new InvalidOperationException("Target requires a local repository");
+                }
+
+                return repo.Lookup(targetId);
+            });
         }
 
         /// <summary>
         /// Gets the target of this <see cref="DirectReference"/>
         /// </summary>
+        /// <exception cref="InvalidOperationException">Throws if Local Repository is not set.</exception>
         public virtual GitObject Target
         {
             get { return targetBuilder.Value; }

--- a/LibGit2Sharp/Reference.cs
+++ b/LibGit2Sharp/Reference.cs
@@ -199,6 +199,17 @@ namespace LibGit2Sharp
             }
         }
 
-        IRepository IBelongToARepository.Repository { get { return repo; } }
+        IRepository IBelongToARepository.Repository
+        {
+            get
+            {
+                if (repo == null)
+                {
+                    throw new InvalidOperationException("Repository requires a local repository");
+                }
+
+                return repo;
+            }
+        }
     }
 }


### PR DESCRIPTION
As mentioned #985, used git_repository_new() from the native side to implement this. Also introduced new public class RemoteHead as a container for the results.