### PR TITLE
Fixes Issue #1071: Deadlock in Submodules when Directory Structure Changes

### DIFF
--- a/LibGit2Sharp/Core/Handles/OidSafeHandle.cs
+++ b/LibGit2Sharp/Core/Handles/OidSafeHandle.cs
@@ -7,7 +7,7 @@ namespace LibGit2Sharp.Core.Handles
     {
         private GitOid? MarshalAsGitOid()
         {
-            return IsInvalid ? null : (GitOid?)MarshalAsGitOid(handle);
+            return IsZero || IsInvalid ? null : (GitOid?)MarshalAsGitOid(handle);
         }
 
         private static GitOid MarshalAsGitOid(IntPtr data)


### PR DESCRIPTION
If the underlying directory structure has changed (deleted, renamed, etc) an invalid handle is correctly returned by Libgit2. Attempting to convert the invalid handle directly into an `ObjectID` results in an exception being thrown, causing the `Lazy<ObjectId>.Value` call to never return, resulting in a deadlock.

This fixes that by examining the handle before calling `.MarshalAsObjectId()` and returning a `null` value if the handle is invalid.

Fixes Issue #1071

PS.
Yes I see the whitespace changes... I've given up in my fight with the Visual Studio auto-formatter, it seems determined to remove those extra ` ` characters; I'm going to let it because I cannot seem to stop it. :sheep: :weary:  