### PR TITLE
Automate NuGet deployment on merge

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -183,6 +183,13 @@ after_test:
         cat .\curl-out.txt
     }
 
+deploy:
+  - provider: NuGet
+    api_key:
+      secure: A/hHqzkaA9isGv9CS3x+rLbz3OI+BRevvYEQRY4J5J3kwLKM5WPhVpBPzrQQH4tc
+    skip_symbols: true
+    artifact: /.*\.nupkg/
+
 notifications:
 - provider: Email
   to:


### PR DESCRIPTION
Cross platform compatibility is ensured as part of the Pull Request lifecycle. Both Travis and AppVeyor should be green before a PR merged. Would the merge build fail, it would only be because of a network hiccup (which could be re-triggered in order to display green badges on the README).

This is an attempt at automating the NuGet publication.

If the appveyor tweaking is correct, upon a successful merge, the generated NuGet package will be automatically deployed.

Currently, only vNext and master branches are monitored by AppVeyor:
- vNext: produces prerelease packages
- master: produces stable packages

Some issues I can think of about this proposal:
- Usage of the matrix: I'm under the impression that each job will trigger the deployment.
- Would someone trigger a rebuild of a merged commit, how to avoid the repeated publication of the NuGet package? FWIW, I don't know for sure how nuget.org reacts to this, but I suspect that this should lead to some failure, which in turn would fail the build.

/cc @FeodorFitsner 
