### PR TITLE
Drop PublishCoverity usage

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,14 +49,13 @@ install:
     Write-Host "Assembly informational version = " -NoNewLine
     Write-Host $Env:ASSEMBLY_INFORMATIONAL_VERSION -ForegroundColor "Green"
 
-    $ShouldPublishNugetArtifact = $($Env:APPVEYOR_PULL_REQUEST_NUMBER -eq $null)
-    $Env:SHOULD_PUBLISH_NUGET_ARTIFACT = $ShouldPublishNugetArtifact
-    Write-Host "Should publish Nuget artifact = " -NoNewLine
-    Write-Host $Env:SHOULD_PUBLISH_NUGET_ARTIFACT -ForegroundColor "Green"
-
     $Env:SHOULD_PUBLISH_COVERITY_ANALYSIS = $($Env:APPVEYOR_SCHEDULED_BUILD -eq $True)
     Write-Host "Should publish Coverity analysis = " -NoNewLine
     Write-Host $Env:SHOULD_PUBLISH_COVERITY_ANALYSIS -ForegroundColor "Green"
+
+    $Env:SHOULD_PUBLISH_NUGET_ARTIFACT = $($Env:APPVEYOR_PULL_REQUEST_NUMBER -eq $null -and $Env:SHOULD_PUBLISH_COVERITY_ANALYSIS -eq $False)
+    Write-Host "Should publish Nuget artifact = " -NoNewLine
+    Write-Host $Env:SHOULD_PUBLISH_NUGET_ARTIFACT -ForegroundColor "Green"
 
     cinst sourcelink -y
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,6 +58,7 @@ install:
     Write-Host $Env:SHOULD_PUBLISH_NUGET_ARTIFACT -ForegroundColor "Green"
 
     cinst sourcelink -y
+    cinst curl -y
 
 assembly_info:
   patch: true
@@ -112,20 +113,17 @@ after_test:
     }
     Else
     {
-      & nuget install PublishCoverity -Version 0.9.0 -ExcludeVersion -OutputDirectory .\packages
+      & 7z a "$Env:APPVEYOR_BUILD_FOLDER\$Env:APPVEYOR_PROJECT_NAME.zip" "$Env:APPVEYOR_BUILD_FOLDER\cov-int\"
 
-      & .\packages\PublishCoverity\PublishCoverity.exe compress `
-        -i "$Env:APPVEYOR_BUILD_FOLDER\cov-int" `
-        -o "$Env:APPVEYOR_BUILD_FOLDER\$Env:APPVEYOR_PROJECT_NAME.zip"
+      # cf. http://stackoverflow.com/a/25045154/335418
+      Remove-item alias:curl
 
-      & .\packages\PublishCoverity\PublishCoverity.exe publish `
-        -t "$Env:coverity_token" `
-        -e "$Env:coverity_email" `
-        -r "$Env:APPVEYOR_REPO_NAME" `
-        -z "$Env:APPVEYOR_BUILD_FOLDER\$env:APPVEYOR_PROJECT_NAME.zip" `
-        -d "CI server scheduled build." `
-        --codeVersion "$Env:ASSEMBLY_INFORMATIONAL_VERSION" `
-        --nologo
+      & curl --form token="$Env:coverity_token" `
+        --form email="$Env:coverity_email" `
+        --form "file=@$Env:APPVEYOR_BUILD_FOLDER\$env:APPVEYOR_PROJECT_NAME.zip" `
+        --form version="$Env:ASSEMBLY_INFORMATIONAL_VERSION" `
+        --form description="CI server scheduled build." `
+        https://scan.coverity.com/builds?project=libgit2%2Flibgit2sharp
     }
 
 notifications:


### PR DESCRIPTION
This **[scheduled build](https://ci.appveyor.com/project/libgit2/libgit2sharp/build/858/job/4ebxg6lal53ffsq0)** failed with an `Unauthorized` error.

Some locally run tests show that using plain curl do not reproduce the same behavior.