### PR TITLE
Fixes a trio of concurrency issues found by Coverity

### DIFF
--- a/LibGit2Sharp/Core/Handles/SafeHandleBase.cs
+++ b/LibGit2Sharp/Core/Handles/SafeHandleBase.cs
@@ -66,7 +66,15 @@ namespace LibGit2Sharp.Core
         /// </summary>
         public static IEnumerable<string> TypeNames
         {
-            get { return _typeNames.ToArray(); }
+            get
+            {
+                string[] result = null;
+                lock (_lockpad)
+                {
+                    result = _typeNames.ToArray();
+                }
+                return result;
+            }
         }
     }
 }

--- a/LibGit2Sharp/Core/LazyGroup.cs
+++ b/LibGit2Sharp/Core/LazyGroup.cs
@@ -24,18 +24,19 @@ namespace LibGit2Sharp.Core
 
         public void Evaluate()
         {
-            if (evaluated)
-                return;
-
             lock (@lock)
             {
                 if (evaluated)
+                {
                     return;
+                }
 
                 EvaluateInternal(input =>
                                  {
                                      foreach (var e in evaluators)
+                                     {
                                          e.Evaluate(input);
+                                     }
                                  });
                 evaluated = true;
             }


### PR DESCRIPTION
The new-again Coverity scanning @nulltoken setup recently has started to bear fruit. The first items reported and tackled are these concurrency issues. Minor fixes, low risk.

1. Don't check thread-shared variables outside of critical-sections.
2. Don't process potentially long chains of thread-shared data without a mutex.