### PR TITLE
Fixes Coverity NullReferenceException Issues

### DIFF
--- a/LibGit2Sharp/ObjectDatabase.cs
+++ b/LibGit2Sharp/ObjectDatabase.cs
@@ -365,7 +365,9 @@ namespace LibGit2Sharp
 
             ObjectId commitId = Proxy.git_commit_create(repo.Handle, null, author, committer, message, tree, parentIds);
 
-            return repo.Lookup<Commit>(commitId);
+            Commit commit = repo.Lookup<Commit>(commitId);
+            Ensure.GitObjectIsNotNull(commit, commitId.Sha);
+            return commit;
         }
 
         /// <summary>
@@ -454,6 +456,8 @@ namespace LibGit2Sharp
         /// <returns>A short string representation of the <see cref="ObjectId"/>.</returns>
         public virtual string ShortenObjectId(GitObject gitObject, int minLength)
         {
+            Ensure.ArgumentNotNull(gitObject, "gitObject");
+
             if (minLength <= 0 || minLength > ObjectId.HexSize)
             {
                 throw new ArgumentOutOfRangeException("minLength", minLength,
@@ -461,6 +465,11 @@ namespace LibGit2Sharp
             }
 
             string shortSha = Proxy.git_object_short_id(repo.Handle, gitObject.Id);
+
+            if (shortSha == null)
+            {
+                throw new LibGit2SharpException("Unable to abbreviate SHA-1 value for GitObject " + gitObject.Id);
+            }
 
             if (minLength <= shortSha.Length)
             {

--- a/LibGit2Sharp/Repository.cs
+++ b/LibGit2Sharp/Repository.cs
@@ -476,7 +476,7 @@ namespace LibGit2Sharp
 
             using (GitObjectSafeHandle obj = Proxy.git_object_lookup(handle, id, type))
             {
-                if (obj == null)
+                if (obj == null || obj.IsInvalid)
                 {
                     return null;
                 }


### PR DESCRIPTION
The new-again Coverity scanning has started to bear fruit. Here are some of the NRE issues identified by the scan. Minor fixes, low risk. **Not sure if I'm throwing the correct exception types** here (/CC @nulltoken).

1. Do not assume disk reads always succeed, check results before processing.
2. Verify parameters being using.
3. There's more than one kind of `null` when dealing with p/invoke and handles.
4. Better to give specific exceptions than general exceptions when reading in bad data.