### PR TITLE
Fix Coverity NullReferenceException Issues w/ Remotes

### DIFF
--- a/LibGit2Sharp/Network.cs
+++ b/LibGit2Sharp/Network.cs
@@ -71,7 +71,7 @@ namespace LibGit2Sharp
 
             using (RemoteSafeHandle remoteHandle = Proxy.git_remote_lookup(repository.Handle, remote.Name, true))
             {
-                var gitCallbacks = new GitRemoteCallbacks {version = 1};
+                var gitCallbacks = new GitRemoteCallbacks { version = 1 };
 
                 if (credentialsProvider != null)
                 {
@@ -148,14 +148,14 @@ namespace LibGit2Sharp
                 // Also, if GitRemoteCallbacks were a class instead of a struct, we would need to guard against
                 // GC occuring in between setting the remote callbacks and actual usage in one of the functions afterwords.
                 var fetchOptions = new GitFetchOptions
-                                    {
-                                        RemoteCallbacks = gitCallbacks,
-                                        download_tags = Proxy.git_remote_autotag(remoteHandle),
-                                    };
+                {
+                    RemoteCallbacks = gitCallbacks,
+                    download_tags = Proxy.git_remote_autotag(remoteHandle),
+                };
 
                 if (options.TagFetchMode.HasValue)
                 {
-                    fetchOptions.download_tags =  options.TagFetchMode.Value;
+                    fetchOptions.download_tags = options.TagFetchMode.Value;
                 }
 
                 Proxy.git_remote_fetch(remoteHandle, refspecs, fetchOptions, logMessage);

--- a/LibGit2Sharp/Network.cs
+++ b/LibGit2Sharp/Network.cs
@@ -111,13 +111,13 @@ namespace LibGit2Sharp
         {
             Debug.Assert((remote == null) ^ (url == null));
 
-            RemoteSafeHandle remoteHandle;
+            RemoteSafeHandle remoteHandle = null;
 
             if (url != null)
             {
                 remoteHandle = Proxy.git_remote_create_anonymous(repoHandle, url);
             }
-            else
+            else if (remote != null)
             {
                 remoteHandle = Proxy.git_remote_lookup(repoHandle, remote.Name, true);
             }


### PR DESCRIPTION
The issue here is that the method asserts that both parameters are null or neither are, then proceeds to behave like only one is. This results in a NRE too deep into the stack to easily debug/resolve the issue. Moving the error upstream makes it easier to identify the problem.

Question: should we just throw at the call-site if both arguments (`remote` and `url`) are `null`?

Included some beautification as a separate commit.