### PR TITLE
Refactor Network Internal API

### DIFF
--- a/LibGit2Sharp/Network.cs
+++ b/LibGit2Sharp/Network.cs
@@ -71,7 +71,7 @@ namespace LibGit2Sharp
 
             using (RemoteSafeHandle remoteHandle = Proxy.git_remote_lookup(repository.Handle, remote.Name, true))
             {
-                var gitCallbacks = new GitRemoteCallbacks {version = 1};
+                var gitCallbacks = new GitRemoteCallbacks { version = 1 };
 
                 if (credentialsProvider != null)
                 {
@@ -113,7 +113,7 @@ namespace LibGit2Sharp
             Debug.Assert(remote != null && remote.Name != null);
 
             RemoteSafeHandle remoteHandle = Proxy.git_remote_lookup(repoHandle, remote.Name, true);
-            Debug.Assert(remoteHandle != null && !remoteHandle.IsClosed && !remoteHandle.IsInvalid);
+            Debug.Assert(remoteHandle != null && !(remoteHandle.IsClosed || remoteHandle.IsInvalid));
 
             return remoteHandle;
         }
@@ -124,7 +124,7 @@ namespace LibGit2Sharp
             Debug.Assert(url != null);
 
             RemoteSafeHandle remoteHandle = Proxy.git_remote_create_anonymous(repoHandle, url);
-            Debug.Assert(remoteHandle != null && !remoteHandle.IsClosed && !remoteHandle.IsInvalid);
+            Debug.Assert(remoteHandle != null && !(remoteHandle.IsClosed || remoteHandle.IsInvalid));
 
             return remoteHandle;
         }


### PR DESCRIPTION
Fixes #1084 

* Splits the `DoFetch` into three overloaded methods.
    * Primary which takes a `RemoteSafeHandle`
    * Overload which takes a `Remote`, acquires a `RemoteSafeHandle`, and calls primary
    * Overload which takes a URL, acquires a `RemoteSafeHandle`, and calls primary
* Updates callers to use the correct instance methods.
* Adds a lot of asserting to help with future debugging.
* Minor beautification in a secondary commit.