### PR TITLE
Refactor the Reflog entries datetime comparisons

### DIFF
--- a/LibGit2Sharp.Tests/ArchiveFixture.cs
+++ b/LibGit2Sharp.Tests/ArchiveFixture.cs
@@ -18,6 +18,8 @@ namespace LibGit2Sharp.Tests
 
                 var archiver = new MockArchiver();
 
+                var before = DateTimeOffset.Now.TruncateMilliseconds();
+
                 repo.ObjectDatabase.Archive(tree, archiver);
 
                 var expected = new ArrayList
@@ -30,7 +32,7 @@ namespace LibGit2Sharp.Tests
                 };
                 Assert.Equal(expected, archiver.Files);
                 Assert.Null(archiver.ReceivedCommitSha);
-                Assert.InRange(archiver.ModificationTime, DateTimeOffset.UtcNow.Subtract(TimeSpan.FromMilliseconds(100)), DateTimeOffset.UtcNow);
+                Assert.InRange(archiver.ModificationTime, before, DateTimeOffset.UtcNow);
             }
         }
 

--- a/LibGit2Sharp.Tests/BranchFixture.cs
+++ b/LibGit2Sharp.Tests/BranchFixture.cs
@@ -24,6 +24,8 @@ namespace LibGit2Sharp.Tests
 
                 const string committish = "be3563ae3f795b2b4353bcce3a527ad0a4f7f644";
 
+                var before = DateTimeOffset.Now.TruncateMilliseconds();
+
                 Branch newBranch = repo.CreateBranch(name, committish);
                 Assert.NotNull(newBranch);
                 Assert.Equal(name, newBranch.FriendlyName);
@@ -42,7 +44,7 @@ namespace LibGit2Sharp.Tests
                                   "branch: Created from " + committish,
                                   null,
                                   newBranch.Tip.Id,
-                                  Constants.Identity, DateTimeOffset.Now);
+                                  Constants.Identity, before);
 
                 repo.Branches.Remove(newBranch.FriendlyName);
                 Assert.Null(repo.Branches[name]);
@@ -95,6 +97,8 @@ namespace LibGit2Sharp.Tests
                 const string name = "unit_test";
                 const string committish = "be3563a";
 
+                var before = DateTimeOffset.Now.TruncateMilliseconds();
+
                 Branch newBranch = repo.CreateBranch(name, committish);
                 Assert.Equal("refs/heads/" + name, newBranch.CanonicalName);
                 Assert.Equal("be3563ae3f795b2b4353bcce3a527ad0a4f7f644", newBranch.Tip.Sha);
@@ -103,7 +107,7 @@ namespace LibGit2Sharp.Tests
                                   "branch: Created from " + committish,
                                   null,
                                   newBranch.Tip.Id,
-                                  Constants.Identity, DateTimeOffset.Now);
+                                  Constants.Identity, before);
             }
         }
 
@@ -120,6 +124,9 @@ namespace LibGit2Sharp.Tests
                 repo.Checkout(headCommitOrBranchSpec);
 
                 const string name = "unit_test";
+
+                var before = DateTimeOffset.Now.TruncateMilliseconds();
+
                 Branch newBranch = repo.CreateBranch(name);
                 Assert.NotNull(newBranch);
                 Assert.Equal(name, newBranch.FriendlyName);
@@ -133,7 +140,7 @@ namespace LibGit2Sharp.Tests
                                   "branch: Created from " + headCommitOrBranchSpec,
                                   null,
                                   newBranch.Tip.Id,
-                                  Constants.Identity, DateTimeOffset.Now);
+                                  Constants.Identity, before);
             }
         }
 
@@ -150,6 +157,9 @@ namespace LibGit2Sharp.Tests
                 repo.Checkout(headCommitOrBranchSpec);
 
                 const string name = "unit_test";
+
+                var before = DateTimeOffset.Now.TruncateMilliseconds();
+
                 Branch newBranch = repo.CreateBranch(name, "HEAD");
                 Assert.NotNull(newBranch);
                 Assert.Equal("32eab9cb1f450b5fe7ab663462b77d7f4b703344", newBranch.Tip.Sha);
@@ -158,7 +168,7 @@ namespace LibGit2Sharp.Tests
                                   "branch: Created from HEAD",
                                   null,
                                   newBranch.Tip.Id,
-                                  Constants.Identity, DateTimeOffset.Now);
+                                  Constants.Identity, before);
             }
         }
 
@@ -172,6 +182,9 @@ namespace LibGit2Sharp.Tests
 
                 const string name = "unit_test";
                 var commit = repo.Lookup<Commit>("HEAD");
+
+                var before = DateTimeOffset.Now.TruncateMilliseconds();
+
                 Branch newBranch = repo.CreateBranch(name, commit);
                 Assert.NotNull(newBranch);
                 Assert.Equal("4c062a6361ae6959e06292c1fa5e2822d9c96345", newBranch.Tip.Sha);
@@ -180,7 +193,7 @@ namespace LibGit2Sharp.Tests
                                   "branch: Created from " + newBranch.Tip.Sha,
                                   null,
                                   newBranch.Tip.Id,
-                                  Constants.Identity, DateTimeOffset.Now);
+                                  Constants.Identity, before);
             }
         }
 
@@ -195,6 +208,8 @@ namespace LibGit2Sharp.Tests
                 const string name = "revparse_branch";
                 const string committish = "master~2";
 
+                var before = DateTimeOffset.Now.TruncateMilliseconds();
+
                 Branch newBranch = repo.CreateBranch(name, committish);
                 Assert.NotNull(newBranch);
                 Assert.Equal("9fd738e8f7967c078dceed8190330fc8648ee56a", newBranch.Tip.Sha);
@@ -203,7 +218,7 @@ namespace LibGit2Sharp.Tests
                                   "branch: Created from " + committish,
                                   null,
                                   newBranch.Tip.Id,
-                                  Constants.Identity, DateTimeOffset.Now);
+                                  Constants.Identity, before);
             }
         }
 
@@ -219,6 +234,8 @@ namespace LibGit2Sharp.Tests
 
                 const string name = "i-peel-tag";
 
+                var before = DateTimeOffset.Now.TruncateMilliseconds();
+
                 Branch newBranch = repo.CreateBranch(name, committish);
                 Assert.NotNull(newBranch);
                 Assert.Equal("e90810b8df3e80c413d903f631643c716887138d", newBranch.Tip.Sha);
@@ -227,7 +244,7 @@ namespace LibGit2Sharp.Tests
                                   "branch: Created from " + committish,
                                   null,
                                   newBranch.Tip.Id,
-                                  Constants.Identity, DateTimeOffset.Now);
+                                  Constants.Identity, before);
             }
         }
 
@@ -986,6 +1003,8 @@ namespace LibGit2Sharp.Tests
                 var br2 = repo.Branches["br2"];
                 Assert.NotNull(br2);
 
+                var before = DateTimeOffset.Now.TruncateMilliseconds();
+
                 Branch newBranch = repo.Branches.Rename("br2", "br3");
 
                 Assert.Equal("br3", newBranch.FriendlyName);
@@ -997,7 +1016,7 @@ namespace LibGit2Sharp.Tests
                                   string.Format("branch: renamed {0} to {1}", br2.CanonicalName, newBranch.CanonicalName),
                                   br2.Tip.Id,
                                   newBranch.Tip.Id,
-                                  Constants.Identity, DateTimeOffset.Now);
+                                  Constants.Identity, before);
             }
         }
 
@@ -1025,6 +1044,8 @@ namespace LibGit2Sharp.Tests
                 Branch br2 = repo.Branches["br2"];
                 Assert.NotNull(br2);
 
+                var before = DateTimeOffset.Now.TruncateMilliseconds();
+
                 Branch newBranch = repo.Branches.Rename("br2", "test", true);
                 Assert.Equal("test", newBranch.FriendlyName);
 
@@ -1040,7 +1061,7 @@ namespace LibGit2Sharp.Tests
                                   string.Format("branch: renamed {0} to {1}", br2.CanonicalName, newBranch.CanonicalName),
                                   br2.Tip.Id,
                                   newTest.Tip.Id,
-                                  Constants.Identity, DateTimeOffset.Now);
+                                  Constants.Identity, before);
             }
         }
 
@@ -1149,19 +1170,24 @@ namespace LibGit2Sharp.Tests
             using (var repo = new Repository(path, new RepositoryOptions { Identity = Constants.Identity }))
             {
                 EnableRefLog(repo);
+
+                var before = DateTimeOffset.Now.TruncateMilliseconds();
+
                 var branch = repo.Branches.Add("foo", repo.Head.Tip);
 
                 AssertRefLogEntry(repo, branch.CanonicalName,
                                   string.Format("branch: Created from {0}", repo.Head.Tip.Sha),
                                   null, branch.Tip.Id,
-                                  Constants.Identity, DateTimeOffset.Now);
+                                  Constants.Identity, before);
+
+                before = DateTimeOffset.Now.TruncateMilliseconds();
 
                 branch = repo.Branches.Add("bar", repo.Head.Tip);
 
                 AssertRefLogEntry(repo, branch.CanonicalName,
                                   "branch: Created from " + repo.Head.Tip.Sha,
                                   null, repo.Head.Tip.Id,
-                                  Constants.Identity, DateTimeOffset.Now);
+                                  Constants.Identity, before);
             }
         }
 
@@ -1173,15 +1199,20 @@ namespace LibGit2Sharp.Tests
             {
                 EnableRefLog(repo);
                 var master = repo.Branches["master"];
+
+                var before = DateTimeOffset.Now.TruncateMilliseconds();
+
                 var newMaster = repo.Branches.Rename(master, "new-master");
                 AssertRefLogEntry(repo, newMaster.CanonicalName, "branch: renamed refs/heads/master to refs/heads/new-master",
                                   newMaster.Tip.Id, newMaster.Tip.Id,
-                                  Constants.Identity, DateTimeOffset.Now);
+                                  Constants.Identity, before);
+
+                before = DateTimeOffset.Now.TruncateMilliseconds();
 
                 var newMaster2 = repo.Branches.Rename(newMaster, "new-master2");
                 AssertRefLogEntry(repo, newMaster2.CanonicalName, "branch: renamed refs/heads/new-master to refs/heads/new-master2",
                                   newMaster.Tip.Id, newMaster2.Tip.Id,
-                                  Constants.Identity, DateTimeOffset.Now);
+                                  Constants.Identity, before);
             }
         }
     }

--- a/LibGit2Sharp.Tests/CheckoutFixture.cs
+++ b/LibGit2Sharp.Tests/CheckoutFixture.cs
@@ -789,12 +789,14 @@ namespace LibGit2Sharp.Tests
 
                 Assert.True(repo.Info.IsHeadDetached);
 
+                var before = DateTimeOffset.Now.TruncateMilliseconds();
+
                 Branch newHead = repo.Checkout(repo.Branches["master"]);
 
                 // Assert reflog entry is created
                 AssertRefLogEntry(repo, "HEAD",
                     string.Format("checkout: moving from {0} to {1}", initialHead.Tip.Sha, newHead.FriendlyName),
-                    initialHead.Tip.Id, newHead.Tip.Id, Constants.Identity, DateTimeOffset.Now);
+                    initialHead.Tip.Id, newHead.Tip.Id, Constants.Identity, before);
             }
         }
 
@@ -862,12 +864,15 @@ namespace LibGit2Sharp.Tests
 
                 Assert.Equal(reflogEntriesCount, repo.Refs.Log(repo.Refs.Head).Count());
 
+                var before = DateTimeOffset.Now.TruncateMilliseconds();
+
                 // Checkout in detached mode
                 repo.Checkout(master.Tip.Sha);
 
                 Assert.True(repo.Info.IsHeadDetached);
                 AssertRefLogEntry(repo, "HEAD",
-                    string.Format("checkout: moving from master to {0}", master.Tip.Sha), master.Tip.Id, master.Tip.Id, Constants.Identity, DateTimeOffset.Now);
+                    string.Format("checkout: moving from master to {0}", master.Tip.Sha),
+                    master.Tip.Id, master.Tip.Id, Constants.Identity, before);
 
                 // Checkout detached "HEAD" => nothing should happen
                 reflogEntriesCount = repo.Refs.Log(repo.Refs.Head).Count();

--- a/LibGit2Sharp.Tests/CommitFixture.cs
+++ b/LibGit2Sharp.Tests/CommitFixture.cs
@@ -682,6 +682,8 @@ namespace LibGit2Sharp.Tests
                 const string shortMessage = "Initial egotistic commit";
                 const string commitMessage = shortMessage + "\n\nOnly the coolest commits from us";
 
+                var before = DateTimeOffset.Now.TruncateMilliseconds();
+
                 Commit commit = repo.Commit(commitMessage, author, author);
 
                 AssertBlobContent(repo.Head[relativeFilepath], "nulltoken\n");
@@ -698,7 +700,7 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(identity.Email, reflogEntry.Committer.Email);
 
                 var now = DateTimeOffset.Now;
-                Assert.InRange(reflogEntry.Committer.When, now - TimeSpan.FromSeconds(1), now);
+                Assert.InRange(reflogEntry.Committer.When, before, now);
 
                 Assert.Equal(commit.Id, reflogEntry.To);
                 Assert.Equal(ObjectId.Zero, reflogEntry.From);
@@ -824,6 +826,8 @@ namespace LibGit2Sharp.Tests
                 CreateAndStageANewFile(repo);
                 const string commitMessage = "I'm rewriting the history!";
 
+                var before = DateTimeOffset.Now.TruncateMilliseconds();
+
                 Commit amendedCommit = repo.Commit(commitMessage, Constants.Signature, Constants.Signature,
                     new CommitOptions { AmendPreviousCommit = true });
 
@@ -833,7 +837,7 @@ namespace LibGit2Sharp.Tests
                                   string.Format("commit (amend): {0}", commitMessage),
                                   mergedCommit.Id,
                                   amendedCommit.Id,
-                                  Constants.Identity, DateTimeOffset.Now);
+                                  Constants.Identity, before);
             }
         }
 

--- a/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
+++ b/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
@@ -115,6 +115,7 @@
     <Compile Include="ReferenceFixture.cs" />
     <Compile Include="RepositoryFixture.cs" />
     <Compile Include="TagFixture.cs" />
+    <Compile Include="TestHelpers\DateTimeOffsetExtensions.cs" />
     <Compile Include="TestHelpers\OdbHelper.cs" />
     <Compile Include="TestHelpers\DirectoryHelper.cs" />
     <Compile Include="TestHelpers\ExpectedFetchState.cs" />

--- a/LibGit2Sharp.Tests/PushFixture.cs
+++ b/LibGit2Sharp.Tests/PushFixture.cs
@@ -124,6 +124,9 @@ namespace LibGit2Sharp.Tests
 
                 // Force push the new commit
                 string pushRefSpec = string.Format("+{0}:{0}", localRepo.Head.CanonicalName);
+
+                var before = DateTimeOffset.Now.TruncateMilliseconds();
+
                 localRepo.Network.Push(localRepo.Network.Remotes.Single(), pushRefSpec);
 
                 AssertRemoteHeadTipEquals(localRepo, second.Sha);
@@ -131,7 +134,7 @@ namespace LibGit2Sharp.Tests
                 AssertRefLogEntry(localRepo, "refs/remotes/origin/master",
                     "update by push",
                     oldId, localRepo.Head.Tip.Id,
-                    Constants.Identity, DateTimeOffset.Now);
+                    Constants.Identity, before);
             }
         }
 

--- a/LibGit2Sharp.Tests/ReferenceFixture.cs
+++ b/LibGit2Sharp.Tests/ReferenceFixture.cs
@@ -26,6 +26,8 @@ namespace LibGit2Sharp.Tests
             {
                 EnableRefLog(repo);
 
+                var before = DateTimeOffset.Now.TruncateMilliseconds();
+
                 var newRef = (DirectReference)repo.Refs.Add(name, "be3563ae3f795b2b4353bcce3a527ad0a4f7f644");
                 Assert.NotNull(newRef);
                 Assert.Equal(name, newRef.CanonicalName);
@@ -36,7 +38,7 @@ namespace LibGit2Sharp.Tests
 
                 AssertRefLogEntry(repo, name,
                     "branch: Created from be3563ae3f795b2b4353bcce3a527ad0a4f7f644",
-                    null, newRef.ResolveToDirectReference().Target.Id, Constants.Identity, DateTimeOffset.Now
+                    null, newRef.ResolveToDirectReference().Target.Id, Constants.Identity, before
                     );
             }
         }
@@ -52,6 +54,8 @@ namespace LibGit2Sharp.Tests
             {
                 EnableRefLog(repo);
 
+                var before = DateTimeOffset.Now.TruncateMilliseconds();
+
                 var newRef = (DirectReference)repo.Refs.Add(name, "master^1^2", logMessage);
                 Assert.NotNull(newRef);
                 Assert.Equal(name, newRef.CanonicalName);
@@ -62,7 +66,7 @@ namespace LibGit2Sharp.Tests
 
                 AssertRefLogEntry(repo, name, logMessage,
                                   null, newRef.ResolveToDirectReference().Target.Id,
-                                  Constants.Identity, DateTimeOffset.Now);
+                                  Constants.Identity, before);
             }
         }
 
@@ -157,6 +161,9 @@ namespace LibGit2Sharp.Tests
                 EnableRefLog(repo);
 
                 var oldRef = repo.Refs[name];
+
+                var before = DateTimeOffset.Now.TruncateMilliseconds();
+
                 var newRef = (DirectReference)repo.Refs.Add(name, target, logMessage, true);
                 Assert.NotNull(newRef);
                 Assert.Equal(name, newRef.CanonicalName);
@@ -167,7 +174,7 @@ namespace LibGit2Sharp.Tests
                 AssertRefLogEntry(repo, name,
                                   logMessage, ((DirectReference)oldRef).Target.Id,
                                   newRef.ResolveToDirectReference().Target.Id,
-                                  Constants.Identity, DateTimeOffset.Now);
+                                  Constants.Identity, before);
             }
         }
 
@@ -184,6 +191,9 @@ namespace LibGit2Sharp.Tests
                 EnableRefLog(repo);
 
                 var oldtarget = repo.Refs[name].ResolveToDirectReference().Target.Id;
+
+                var before = DateTimeOffset.Now.TruncateMilliseconds();
+
                 var newRef = (SymbolicReference)repo.Refs.Add(name, target, logMessage, true);
                 Assert.NotNull(newRef);
                 Assert.Equal(name, newRef.CanonicalName);
@@ -194,7 +204,7 @@ namespace LibGit2Sharp.Tests
                 AssertRefLogEntry(repo, name, logMessage,
                                   oldtarget,
                                   newRef.ResolveToDirectReference().Target.Id,
-                                  Constants.Identity, DateTimeOffset.Now);
+                                  Constants.Identity, before);
             }
         }
 
@@ -506,6 +516,8 @@ namespace LibGit2Sharp.Tests
                 Reference head = repo.Refs.Head;
                 Reference test = repo.Refs["refs/heads/test"];
 
+                var before = DateTimeOffset.Now.TruncateMilliseconds();
+
                 Reference direct = repo.Refs.UpdateTarget(head, new ObjectId(test.TargetIdentifier), null);
                 Assert.True((direct is DirectReference));
                 Assert.Equal(test.TargetIdentifier, direct.TargetIdentifier);
@@ -515,9 +527,12 @@ namespace LibGit2Sharp.Tests
                 AssertRefLogEntry(repo, "HEAD", null,
                                   head.ResolveToDirectReference().Target.Id,
                                   testTargetId,
-                                  Constants.Identity, DateTimeOffset.Now);
+                                  Constants.Identity, before);
 
                 const string secondLogMessage = "second update target message";
+
+                before = DateTimeOffset.Now.TruncateMilliseconds();
+
                 Reference symref = repo.Refs.UpdateTarget(head, test, secondLogMessage);
                 Assert.True((symref is SymbolicReference));
                 Assert.Equal(test.CanonicalName, symref.TargetIdentifier);
@@ -527,7 +542,7 @@ namespace LibGit2Sharp.Tests
                                   secondLogMessage,
                                   testTargetId,
                                   testTargetId,
-                                  Constants.Identity, DateTimeOffset.Now);
+                                  Constants.Identity, before);
             }
         }
 
@@ -545,6 +560,9 @@ namespace LibGit2Sharp.Tests
                 var @from = master.Target.Id;
 
                 const string logMessage = "update target message";
+
+                var before = DateTimeOffset.Now.TruncateMilliseconds();
+
                 var newRef = (DirectReference)repo.Refs.UpdateTarget(master, "master^1^2", logMessage);
                 Assert.NotNull(newRef);
                 Assert.Equal(name, newRef.CanonicalName);
@@ -557,7 +575,7 @@ namespace LibGit2Sharp.Tests
                                   logMessage,
                                   @from,
                                   newRef.Target.Id,
-                                  Constants.Identity, DateTimeOffset.Now);
+                                  Constants.Identity, before);
             }
         }
 
@@ -657,6 +675,8 @@ namespace LibGit2Sharp.Tests
 
                 var oldId = repo.Refs[oldName].ResolveToDirectReference().Target.Id;
 
+                var before = DateTimeOffset.Now.TruncateMilliseconds();
+
                 Reference renamed = repo.Refs.Rename(oldName, newName);
                 Assert.NotNull(renamed);
                 Assert.Equal(newName, renamed.CanonicalName);
@@ -666,7 +686,7 @@ namespace LibGit2Sharp.Tests
                     string.Format("reference: renamed {0} to {1}", oldName, newName),
                     oldId,
                     renamed.ResolveToDirectReference().Target.Id,
-                    Constants.Identity, DateTimeOffset.Now);
+                    Constants.Identity, before);
             }
         }
 

--- a/LibGit2Sharp.Tests/ReflogFixture.cs
+++ b/LibGit2Sharp.Tests/ReflogFixture.cs
@@ -72,6 +72,9 @@ namespace LibGit2Sharp.Tests
 
                 var author = Constants.Signature;
                 const string commitMessage = "Hope reflog behaves as it should";
+
+                var before = DateTimeOffset.Now.TruncateMilliseconds();
+
                 Commit commit = repo.Commit(commitMessage, author, author);
 
                 // Assert a reflog entry is created on HEAD
@@ -82,7 +85,7 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(identity.Email, reflogEntry.Committer.Email);
 
                 var now = DateTimeOffset.Now;
-                Assert.InRange(reflogEntry.Committer.When, now - TimeSpan.FromSeconds(1), now);
+                Assert.InRange(reflogEntry.Committer.When, before, now);
 
                 Assert.Equal(commit.Id, reflogEntry.To);
                 Assert.Equal(ObjectId.Zero, reflogEntry.From);
@@ -94,8 +97,7 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(identity.Name, reflogEntry.Committer.Name);
                 Assert.Equal(identity.Email, reflogEntry.Committer.Email);
 
-                now = DateTimeOffset.Now;
-                Assert.InRange(reflogEntry.Committer.When, now - TimeSpan.FromSeconds(1), now);
+                Assert.InRange(reflogEntry.Committer.When, before, now);
 
                 Assert.Equal(commit.Id, reflogEntry.To);
                 Assert.Equal(ObjectId.Zero, reflogEntry.From);
@@ -147,6 +149,9 @@ namespace LibGit2Sharp.Tests
 
                 var author = Constants.Signature;
                 const string commitMessage = "Commit on detached head";
+
+                var before = DateTimeOffset.Now.TruncateMilliseconds();
+
                 var commit = repo.Commit(commitMessage, author, author);
 
                 // Assert a reflog entry is created on HEAD
@@ -156,7 +161,7 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(identity.Email, reflogEntry.Committer.Email);
 
                 var now = DateTimeOffset.Now;
-                Assert.InRange(reflogEntry.Committer.When, now - TimeSpan.FromSeconds(1), now);
+                Assert.InRange(reflogEntry.Committer.When, before, now);
 
                 Assert.Equal(commit.Id, reflogEntry.To);
                 Assert.Equal(string.Format("commit: {0}", commitMessage), repo.Refs.Log("HEAD").First().Message);
@@ -206,8 +211,11 @@ namespace LibGit2Sharp.Tests
                 var commit = repo.ObjectDatabase.CreateCommit(Constants.Signature, Constants.Signature, "yoink",
                                                  tree, Enumerable.Empty<Commit>(), false);
 
+                var before = DateTimeOffset.Now.TruncateMilliseconds();
+
                 var direct = repo.Refs.Add("refs/heads/direct", commit.Id);
-                AssertRefLogEntry(repo, direct.CanonicalName, null, null, direct.ResolveToDirectReference().Target.Id, Constants.Identity, DateTimeOffset.Now);
+                AssertRefLogEntry(repo, direct.CanonicalName, null, null,
+                    direct.ResolveToDirectReference().Target.Id, Constants.Identity, before);
 
                 var symbolic = repo.Refs.Add("refs/heads/symbolic", direct);
                 Assert.Empty(repo.Refs.Log(symbolic)); // creation of symbolic refs doesn't update the reflog

--- a/LibGit2Sharp.Tests/ResetHeadFixture.cs
+++ b/LibGit2Sharp.Tests/ResetHeadFixture.cs
@@ -110,6 +110,8 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(expectedHeadName, repo.Head.FriendlyName);
                 Assert.Equal(branch.Tip.Sha, repo.Head.Tip.Sha);
 
+                var before = DateTimeOffset.Now.TruncateMilliseconds();
+
                 /* Reset --soft the Head to a tag through its canonical name */
                 repo.Reset(ResetMode.Soft, tag.CanonicalName);
                 Assert.Equal(expectedHeadName, repo.Head.FriendlyName);
@@ -121,7 +123,7 @@ namespace LibGit2Sharp.Tests
                                   string.Format("reset: moving to {0}", tag.Target.Sha),
                                   oldHeadId,
                                   tag.Target.Id,
-                                  Constants.Identity, DateTimeOffset.Now);
+                                  Constants.Identity, before);
 
                 if (!shouldHeadBeDetached)
                 {
@@ -129,8 +131,10 @@ namespace LibGit2Sharp.Tests
                                       string.Format("reset: moving to {0}", tag.Target.Sha),
                                       oldHeadId,
                                       tag.Target.Id,
-                                      Constants.Identity, DateTimeOffset.Now);
+                                      Constants.Identity, before);
                 }
+
+                before = DateTimeOffset.Now.TruncateMilliseconds();
 
                 /* Reset --soft the Head to a commit through its sha */
                 repo.Reset(ResetMode.Soft, branch.Tip.Sha);
@@ -143,7 +147,7 @@ namespace LibGit2Sharp.Tests
                                   string.Format("reset: moving to {0}", branch.Tip.Sha),
                                   tag.Target.Id,
                                   branch.Tip.Id,
-                                  Constants.Identity, DateTimeOffset.Now);
+                                  Constants.Identity, before);
 
                 if (!shouldHeadBeDetached)
                 {
@@ -151,7 +155,7 @@ namespace LibGit2Sharp.Tests
                                   string.Format("reset: moving to {0}", branch.Tip.Sha),
                                   tag.Target.Id,
                                   branch.Tip.Id,
-                                  Constants.Identity, DateTimeOffset.Now);
+                                  Constants.Identity, before);
                 }
             }
         }
@@ -188,6 +192,8 @@ namespace LibGit2Sharp.Tests
 
                 Tag tag = repo.Tags["mytag"];
 
+                var before = DateTimeOffset.Now.TruncateMilliseconds();
+
                 repo.Reset(ResetMode.Mixed, tag.CanonicalName);
 
                 Assert.Equal(FileStatus.ModifiedInWorkdir, repo.RetrieveStatus("a.txt"));
@@ -196,13 +202,13 @@ namespace LibGit2Sharp.Tests
                                   string.Format("reset: moving to {0}", tag.Target.Sha),
                                   oldHeadId,
                                   tag.Target.Id,
-                                  Constants.Identity, DateTimeOffset.Now);
+                                  Constants.Identity, before);
 
                 AssertRefLogEntry(repo, "refs/heads/mybranch",
                                   string.Format("reset: moving to {0}", tag.Target.Sha),
                                   oldHeadId,
                                   tag.Target.Id,
-                                  Constants.Identity, DateTimeOffset.Now);
+                                  Constants.Identity, before);
             }
         }
 

--- a/LibGit2Sharp.Tests/TestHelpers/BaseFixture.cs
+++ b/LibGit2Sharp.Tests/TestHelpers/BaseFixture.cs
@@ -412,7 +412,7 @@ namespace LibGit2Sharp.Tests.TestHelpers
 
         protected static void AssertRefLogEntry(IRepository repo, string canonicalName,
                                                 string message, ObjectId @from, ObjectId to,
-                                                Identity committer, DateTimeOffset when)
+                                                Identity committer, DateTimeOffset before)
         {
             var reflogEntry = repo.Refs.Log(canonicalName).First();
 
@@ -421,7 +421,7 @@ namespace LibGit2Sharp.Tests.TestHelpers
             Assert.Equal(@from ?? ObjectId.Zero, reflogEntry.From);
 
             Assert.Equal(committer.Email, reflogEntry.Committer.Email);
-            Assert.InRange(reflogEntry.Committer.When, when - TimeSpan.FromSeconds(5), when);
+            Assert.InRange(reflogEntry.Committer.When, before, DateTimeOffset.Now);
         }
 
         protected static void EnableRefLog(IRepository repository, bool enable = true)

--- a/LibGit2Sharp.Tests/TestHelpers/DateTimeOffsetExtensions.cs
+++ b/LibGit2Sharp.Tests/TestHelpers/DateTimeOffsetExtensions.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace LibGit2Sharp.Tests.TestHelpers
+{
+    public static class DateTimeOffsetExtensions
+    {
+        public static DateTimeOffset TruncateMilliseconds(this DateTimeOffset dto)
+        {
+            // From http://stackoverflow.com/a/1005222/335418
+
+            return dto.AddTicks( - (dto.Ticks % TimeSpan.TicksPerSecond));
+        }
+    }
+}


### PR DESCRIPTION
We actually rely on `Assert.InRange` for this and usually ensure the entry has been created within the range of `[DateTimeOffset.Now - 5 seconds, DateTimeOffset.Now]`.

A better alternative (courtesy of @jamill), would be to retrieve the DateTimeOffset.Now before the action generating the reflog entry and ensuring the logged datetime uses this as the lower bound (ie.  `recordedOffset, DateTimeOffset.Now]`).