### PR TITLE
Let's (try to) make Coverity's job easier

### DIFF
--- a/LibGit2Sharp.Tests/FilterFixture.cs
+++ b/LibGit2Sharp.Tests/FilterFixture.cs
@@ -304,7 +304,7 @@ namespace LibGit2Sharp.Tests
         private static FileInfo CommitFileOnBranch(Repository repo, string branchName, String content)
         {
             var branch = repo.CreateBranch(branchName);
-            repo.Checkout(branch.Name);
+            repo.Checkout(branch.FriendlyName);
 
             FileInfo expectedPath = StageNewFile(repo, content);
             repo.Commit("Commit");

--- a/LibGit2Sharp.Tests/FilterSubstitutionCipherFixture.cs
+++ b/LibGit2Sharp.Tests/FilterSubstitutionCipherFixture.cs
@@ -35,7 +35,7 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(0, filter.SmudgeCalledCount);
 
                 var branch = repo.CreateBranch("delete-files");
-                repo.Checkout(branch.Name);
+                repo.Checkout(branch.FriendlyName);
 
                 DeleteFile(repo, fileName);
 
@@ -75,7 +75,7 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(0, filter.SmudgeCalledCount);
 
                 var branch = repo.CreateBranch("delete-files");
-                repo.Checkout(branch.Name);
+                repo.Checkout(branch.FriendlyName);
 
                 DeleteFile(repo, fileName);
 
@@ -181,7 +181,7 @@ namespace LibGit2Sharp.Tests
                 CommitOnBranchAndReturnDatabaseBlob(repo, fileName, decodedInput);
 
                 var branch = repo.CreateBranch("delete-files");
-                repo.Checkout(branch.Name);
+                repo.Checkout(branch.FriendlyName);
 
                 DeleteFile(repo, fileName);
 

--- a/LibGit2Sharp/Core/Ensure.cs
+++ b/LibGit2Sharp/Core/Ensure.cs
@@ -250,44 +250,21 @@ namespace LibGit2Sharp.Core
         /// <param name="identifier">The <see cref="GitObject"/> identifier to examine.</param>
         public static void GitObjectIsNotNull(GitObject gitObject, string identifier)
         {
-            Func<string, LibGit2SharpException> exceptionBuilder;
-
-            if (string.Equals("HEAD", identifier, StringComparison.Ordinal))
-            {
-                exceptionBuilder = m => new UnbornBranchException(m);
-            }
-            else
-            {
-                exceptionBuilder = m => new NotFoundException(m);
-            }
-
-            GitObjectIsNotNull(gitObject, identifier, exceptionBuilder);
-        }
-
-
-        /// <summary>
-        /// Check that the result of a C call that returns a non-null GitObject
-        /// using the default exception builder.
-        /// <para>
-        ///   The native function is expected to return a valid object value.
-        /// </para>
-        /// </summary>
-        /// <param name="gitObject">The <see cref="GitObject"/> to examine.</param>
-        /// <param name="identifier">The <see cref="GitObject"/> identifier to examine.</param>
-        /// <param name="exceptionBuilder">The builder which constructs an <see cref="LibGit2SharpException"/> from a message.</param>
-        public static void GitObjectIsNotNull(
-            GitObject gitObject,
-            string identifier,
-            Func<string, LibGit2SharpException> exceptionBuilder)
-        {
             if (gitObject != null)
             {
                 return;
             }
 
-            throw exceptionBuilder(string.Format(CultureInfo.InvariantCulture,
-                                                     "No valid git object identified by '{0}' exists in the repository.",
-                                                     identifier));
+            var message = string.Format(CultureInfo.InvariantCulture,
+                "No valid git object identified by '{0}' exists in the repository.",
+                identifier);
+
+            if (string.Equals("HEAD", identifier, StringComparison.Ordinal))
+            {
+                throw new UnbornBranchException(message);
+            }
+
+            throw new NotFoundException(message);
         }
     }
 }

--- a/LibGit2Sharp/Repository.cs
+++ b/LibGit2Sharp/Repository.cs
@@ -1006,14 +1006,17 @@ namespace LibGit2Sharp
             Ensure.ArgumentNotNullOrEmptyString(committishOrBranchSpec, "committishOrBranchSpec");
             Ensure.ArgumentNotNull(paths, "paths");
 
+            var listOfPaths = paths.ToList();
+
             // If there are no paths, then there is nothing to do.
-            if (!paths.Any())
+            if (listOfPaths.Count == 0)
             {
                 return;
             }
 
             Commit commit = LookupCommit(committishOrBranchSpec);
-            CheckoutTree(commit.Tree, paths.ToList(), checkoutOptions ?? new CheckoutOptions());
+
+            CheckoutTree(commit.Tree, listOfPaths, checkoutOptions ?? new CheckoutOptions());
         }
 
         /// <summary>

--- a/LibGit2Sharp/RepositoryExtensions.cs
+++ b/LibGit2Sharp/RepositoryExtensions.cs
@@ -98,7 +98,7 @@ namespace LibGit2Sharp
         {
             Commit commit = repository.Head.Tip;
 
-            Ensure.GitObjectIsNotNull(commit, "HEAD", m => new UnbornBranchException(m));
+            Ensure.GitObjectIsNotNull(commit, "HEAD");
 
             return commit;
         }

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
  [twitter]: http://twitter.com/libgit2sharp
 
 ## Current project build status
+
 The CI builds are generously hosted and run on the [Travis][travis] and [AppVeyor][appveyor] infrastructures.
 
 |  | Windows (x86/amd64) | Linux/Mac OS X |
@@ -35,9 +36,17 @@ The CI builds are generously hosted and run on the [Travis][travis] and [AppVeyo
 | **master** | [![master win][master-win-badge]][master-win] | [![master nix][master-nix-badge]][master-nix] |
 | **vNext** | [![vNext win][vNext-win-badge]][vNext-win] | [![vNext nix][vNext-nix-badge]][vNext-nix] |
 
+The security oriented static code analysis is kindly run through the [Coverity][coverity] service.
 
- [travis]: http://travis-ci.org/
+|       | Analysis result |
+|-------|-----------------|
+| **vNext** |  [![coverity][coverity-badge]][coverity-project] |
+
+
+ [travis]: https://travis-ci.org/
  [appveyor]: http://appveyor.com/
+ [coverity]: https://scan.coverity.com/
+
  [master-win-badge]: https://ci.appveyor.com/api/projects/status/8qxcoqdo9kp7x2w9/branch/master?svg=true
  [master-win]: https://ci.appveyor.com/project/libgit2/libgit2sharp/branch/master
  [master-nix-badge]: https://travis-ci.org/libgit2/libgit2sharp.svg?branch=master
@@ -46,6 +55,9 @@ The CI builds are generously hosted and run on the [Travis][travis] and [AppVeyo
  [vNext-win]: https://ci.appveyor.com/project/libgit2/libgit2sharp/branch/vNext
  [vNext-nix-badge]: https://travis-ci.org/libgit2/libgit2sharp.svg?branch=vNext
  [vNext-nix]: https://travis-ci.org/libgit2/libgit2sharp/branches
+
+ [coverity-project]: https://scan.coverity.com/projects/2088
+ [coverity-badge]: https://scan.coverity.com/projects/2088/badge.svg
 
 ## Quick contributing guide
 


### PR DESCRIPTION
I've started to review Coverity findings. Some on them were raised because Coverity was unable to properly decipher `Ensure.GitObjectIsNotNull()` logic.

I've started to manually triage them as mark as False Positives.

Then, I eventually rollbacked my work and decided to simplify the code flow. 

This PR also contains some minor fixes that I discovered while working on this.