### PR TITLE
Adding support for message formatting in exception c'tors

### DIFF
--- a/LibGit2Sharp/AmbiguousSpecificationException.cs
+++ b/LibGit2Sharp/AmbiguousSpecificationException.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Runtime.Serialization;
 
 namespace LibGit2Sharp
@@ -22,6 +23,17 @@ namespace LibGit2Sharp
         /// <param name="message">A message that describes the error.</param>
         public AmbiguousSpecificationException(string message)
             : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AmbiguousSpecificationException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="cultureInfo">An object that supplies culture-specific formatting information.</param>
+        /// <param name="format">A composite format string for use in <see cref="String.Format(IFormatProvider, string, object[])"/>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        public AmbiguousSpecificationException(CultureInfo cultureInfo, string format, params object[] args)
+            : base(String.Format(cultureInfo, format, args))
         {
         }
 

--- a/LibGit2Sharp/BranchCollection.cs
+++ b/LibGit2Sharp/BranchCollection.cs
@@ -174,9 +174,9 @@ namespace LibGit2Sharp
 
             if (branch.IsRemote)
             {
-                throw new LibGit2SharpException(
-                    string.Format(CultureInfo.InvariantCulture,
-                        "Cannot rename branch '{0}'. It's a remote tracking branch.", branch.FriendlyName));
+                throw new LibGit2SharpException(CultureInfo.InvariantCulture,
+                                                "Cannot rename branch '{0}'. It's a remote tracking branch.",
+                                                branch.FriendlyName);
             }
 
             using (ReferenceSafeHandle referencePtr = repo.Refs.RetrieveReferencePtr(Reference.LocalBranchPrefix + branch.FriendlyName))

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -2334,8 +2334,9 @@ namespace LibGit2Sharp.Core
                     return null;
 
                 case (int)GitErrorCode.Ambiguous:
-                    throw new AmbiguousSpecificationException(string.Format(CultureInfo.InvariantCulture,
-                        "Provided abbreviated ObjectId '{0}' is too short.", objectish));
+                    throw new AmbiguousSpecificationException(CultureInfo.InvariantCulture,
+                                                              "Provided abbreviated ObjectId '{0}' is too short.",
+                                                              objectish);
 
                 default:
                     Ensure.ZeroResult(res);
@@ -2541,10 +2542,10 @@ namespace LibGit2Sharp.Core
                     return FileStatus.Nonexistent;
 
                 case (int)GitErrorCode.Ambiguous:
-                    throw new AmbiguousSpecificationException(string.Format(CultureInfo.InvariantCulture,
-                        "More than one file matches the pathspec '{0}'. " +
-                        "You can either force a literal path evaluation (GIT_STATUS_OPT_DISABLE_PATHSPEC_MATCH), or use git_status_foreach().",
-                        path));
+                    throw new AmbiguousSpecificationException(CultureInfo.InvariantCulture,
+                                                              "More than one file matches the pathspec '{0}'. " +
+                                                              "You can either force a literal path evaluation (GIT_STATUS_OPT_DISABLE_PATHSPEC_MATCH), or use git_status_foreach().",
+                                                              path);
 
                 default:
                     Ensure.ZeroResult(res);

--- a/LibGit2Sharp/Diff.cs
+++ b/LibGit2Sharp/Diff.cs
@@ -212,9 +212,11 @@ namespace LibGit2Sharp
 
             if (!ChangesBuilders.TryGetValue(typeof (T), out builder))
             {
-                throw new LibGit2SharpException(string.Format(CultureInfo.InvariantCulture,
-                    "Unexpected type '{0}' passed to Compare. Supported values are either '{1}' or '{2}'.", typeof (T),
-                    typeof (TreeChanges), typeof (Patch)));
+                throw new LibGit2SharpException(CultureInfo.InvariantCulture,
+                                                "Unexpected type '{0}' passed to Compare. Supported values are either '{1}' or '{2}'.",
+                                                typeof(T),
+                                                typeof(TreeChanges),
+                                                typeof(Patch));
             }
 
             var comparer = TreeToTree(repo);
@@ -323,9 +325,11 @@ namespace LibGit2Sharp
 
             if (!ChangesBuilders.TryGetValue(typeof (T), out builder))
             {
-                throw new LibGit2SharpException(string.Format(CultureInfo.InvariantCulture,
-                    "Unexpected type '{0}' passed to Compare. Supported values are either '{1}' or '{2}'.", typeof (T),
-                    typeof (TreeChanges), typeof (Patch)));
+                throw new LibGit2SharpException(CultureInfo.InvariantCulture,
+                                                "Unexpected type '{0}' passed to Compare. Supported values are either '{1}' or '{2}'.",
+                                                typeof(T),
+                                                typeof(TreeChanges),
+                                                typeof(Patch));
             }
 
             var comparer = HandleRetrieverDispatcher[diffTargets](repo);
@@ -453,9 +457,11 @@ namespace LibGit2Sharp
 
             if (!ChangesBuilders.TryGetValue(typeof (T), out builder))
             {
-                throw new LibGit2SharpException(string.Format(CultureInfo.InvariantCulture,
-                    "Unexpected type '{0}' passed to Compare. Supported values are either '{1}' or '{2}'.", typeof (T),
-                    typeof (TreeChanges), typeof (Patch)));
+                throw new LibGit2SharpException(CultureInfo.InvariantCulture,
+                                                "Unexpected type '{0}' passed to Compare. Supported values are either '{1}' or '{2}'.",
+                                                typeof(T),
+                                                typeof(TreeChanges),
+                                                typeof(Patch));
             }
 
             var comparer = WorkdirToIndex(repo);

--- a/LibGit2Sharp/GitObject.cs
+++ b/LibGit2Sharp/GitObject.cs
@@ -73,7 +73,10 @@ namespace LibGit2Sharp
                 case GitObjectType.Blob:
                     return new Blob(repo, id);
                 default:
-                    throw new LibGit2SharpException(string.Format(CultureInfo.InvariantCulture, "Unexpected type '{0}' for object '{1}'.", type, id));
+                    throw new LibGit2SharpException(CultureInfo.InvariantCulture,
+                                                    "Unexpected type '{0}' for object '{1}'.",
+                                                    type,
+                                                    id);
             }
         }
 

--- a/LibGit2Sharp/LibGit2SharpException.cs
+++ b/LibGit2Sharp/LibGit2SharpException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Runtime.Serialization;
 using LibGit2Sharp.Core;
 
@@ -33,6 +34,17 @@ namespace LibGit2Sharp
         /// <param name="innerException">The exception that is the cause of the current exception. If the <paramref name="innerException"/> parameter is not a null reference, the current exception is raised in a catch block that handles the inner exception.</param>
         public LibGit2SharpException(string message, Exception innerException)
             : base(message, innerException)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LibGit2SharpException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
+        /// </summary>
+        /// <param name="cultureInfo">An object that supplies culture-specific formatting information.</param>
+        /// <param name="format">A composite format string for use in <see cref="String.Format(IFormatProvider, string, object[])"/>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        public LibGit2SharpException(CultureInfo cultureInfo, string format, params object[] args)
+            : base(String.Format(cultureInfo, format, args))
         {
         }
 

--- a/LibGit2Sharp/Reference.cs
+++ b/LibGit2Sharp/Reference.cs
@@ -59,7 +59,7 @@ namespace LibGit2Sharp
                     break;
 
                 default:
-                    throw new LibGit2SharpException(String.Format(CultureInfo.InvariantCulture, "Unable to build a new reference from a type '{0}'.", type));
+                    throw new LibGit2SharpException(CultureInfo.InvariantCulture, "Unable to build a new reference from a type '{0}'.", type);
             }
 
             return reference as T;

--- a/LibGit2Sharp/ReferenceCollectionExtensions.cs
+++ b/LibGit2Sharp/ReferenceCollectionExtensions.cs
@@ -256,7 +256,10 @@ namespace LibGit2Sharp
                 return refsColl.UpdateTarget(symbolicReference, targetRef, logMessage);
             }
 
-            throw new LibGit2SharpException(string.Format(CultureInfo.InvariantCulture, "Reference '{0}' has an unexpected type ('{1}').", name, reference.GetType()));
+            throw new LibGit2SharpException(CultureInfo.InvariantCulture,
+                                            "Reference '{0}' has an unexpected type ('{1}').",
+                                            name,
+                                            reference.GetType());
         }
 
         /// <summary>

--- a/LibGit2Sharp/RemoveFromIndexException.cs
+++ b/LibGit2Sharp/RemoveFromIndexException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Runtime.Serialization;
 
 namespace LibGit2Sharp
@@ -22,6 +23,17 @@ namespace LibGit2Sharp
         /// <param name="message">A message that describes the error.</param>
         public RemoveFromIndexException(string message)
             : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LibGit2SharpException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
+        /// </summary>
+        /// <param name="cultureInfo">An object that supplies culture-specific formatting information.</param>
+        /// <param name="format">A composite format string for use in <see cref="String.Format(IFormatProvider, string, object[])"/>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        public RemoveFromIndexException(CultureInfo cultureInfo, string format, params object[] args)
+            : base(cultureInfo, format, args)
         {
         }
 

--- a/LibGit2Sharp/Repository.cs
+++ b/LibGit2Sharp/Repository.cs
@@ -889,9 +889,7 @@ namespace LibGit2Sharp
             // Make sure this is not an unborn branch.
             if (branch.Tip == null)
             {
-                throw new UnbornBranchException(
-                    string.Format(CultureInfo.InvariantCulture,
-                    "The tip of branch '{0}' is null. There's nothing to checkout.", branch.FriendlyName));
+                throw new UnbornBranchException(CultureInfo.InvariantCulture, "The tip of branch '{0}' is null. There's nothing to checkout.", branch.FriendlyName);
             }
 
             if (!branch.IsRemote && !(branch is DetachedHead) &&
@@ -1550,7 +1548,7 @@ namespace LibGit2Sharp
                     Version = 1,
                     MergeFileFavorFlags = options.MergeFileFavor,
                     MergeTreeFlags = options.FindRenames ? GitMergeTreeFlags.GIT_MERGE_TREE_FIND_RENAMES :
-                                                           GitMergeTreeFlags.GIT_MERGE_TREE_NORMAL,
+                                                               GitMergeTreeFlags.GIT_MERGE_TREE_NORMAL,
                     RenameThreshold = (uint) options.RenameThreshold,
                     TargetLimit = (uint) options.TargetLimit,
                 };
@@ -1848,7 +1846,10 @@ namespace LibGit2Sharp
                 FileStatus sourceStatus = keyValuePair.Key.Item2;
                 if (sourceStatus.HasAny(new Enum[] { FileStatus.Nonexistent, FileStatus.DeletedFromIndex, FileStatus.NewInWorkdir, FileStatus.DeletedFromWorkdir }))
                 {
-                    throw new LibGit2SharpException(string.Format(CultureInfo.InvariantCulture, "Unable to move file '{0}'. Its current status is '{1}'.", sourcePath, sourceStatus));
+                    throw new LibGit2SharpException(CultureInfo.InvariantCulture,
+                                                    "Unable to move file '{0}'. Its current status is '{1}'.",
+                                                    sourcePath,
+                                                    sourceStatus);
                 }
 
                 FileStatus desStatus = keyValuePair.Value.Item2;
@@ -1857,7 +1858,10 @@ namespace LibGit2Sharp
                     continue;
                 }
 
-                throw new LibGit2SharpException(string.Format(CultureInfo.InvariantCulture, "Unable to overwrite file '{0}'. Its current status is '{1}'.", destPath, desStatus));
+                throw new LibGit2SharpException(CultureInfo.InvariantCulture,
+                                                "Unable to overwrite file '{0}'. Its current status is '{1}'.",
+                                                destPath,
+                                                desStatus);
             }
 
             string wd = Info.WorkingDirectory;
@@ -2090,8 +2094,9 @@ namespace LibGit2Sharp
                             status.HasFlag(FileStatus.ModifiedInIndex) ||
                             status.HasFlag(FileStatus.NewInIndex) ))
                         {
-                            throw new RemoveFromIndexException(string.Format(CultureInfo.InvariantCulture, "Unable to remove file '{0}', as it has changes staged in the index. You can call the Remove() method with removeFromWorkingDirectory=false if you want to remove it from the index only.",
-                                treeEntryChanges.Path));
+                            throw new RemoveFromIndexException(CultureInfo.InvariantCulture,
+                                                               "Unable to remove file '{0}', as it has changes staged in the index. You can call the Remove() method with removeFromWorkingDirectory=false if you want to remove it from the index only.",
+                                                               treeEntryChanges.Path);
                         }
                         removed.Add(RemoveFromIndex(treeEntryChanges.Path));
                         continue;
@@ -2099,20 +2104,24 @@ namespace LibGit2Sharp
                     case ChangeKind.Modified:
                         if (status.HasFlag(FileStatus.ModifiedInWorkdir) && status.HasFlag(FileStatus.ModifiedInIndex))
                         {
-                            throw new RemoveFromIndexException(string.Format(CultureInfo.InvariantCulture, "Unable to remove file '{0}', as it has staged content different from both the working directory and the HEAD.",
-                                treeEntryChanges.Path));
+                            throw new RemoveFromIndexException(CultureInfo.InvariantCulture,
+                                                               "Unable to remove file '{0}', as it has staged content different from both the working directory and the HEAD.",
+                                                               treeEntryChanges.Path);
                         }
                         if (removeFromWorkingDirectory)
                         {
-                            throw new RemoveFromIndexException(string.Format(CultureInfo.InvariantCulture, "Unable to remove file '{0}', as it has local modifications. You can call the Remove() method with removeFromWorkingDirectory=false if you want to remove it from the index only.",
-                                treeEntryChanges.Path));
+                            throw new RemoveFromIndexException(CultureInfo.InvariantCulture,
+                                                               "Unable to remove file '{0}', as it has local modifications. You can call the Remove() method with removeFromWorkingDirectory=false if you want to remove it from the index only.",
+                                                               treeEntryChanges.Path);
                         }
                         removed.Add(RemoveFromIndex(treeEntryChanges.Path));
                         continue;
 
                     default:
-                        throw new RemoveFromIndexException(string.Format(CultureInfo.InvariantCulture, "Unable to remove file '{0}'. Its current status is '{1}'.",
-                            treeEntryChanges.Path, treeEntryChanges.Status));
+                        throw new RemoveFromIndexException(CultureInfo.InvariantCulture,
+                                                           "Unable to remove file '{0}'. Its current status is '{1}'.",
+                                                           treeEntryChanges.Path,
+                                                           treeEntryChanges.Status);
                 }
             }
 
@@ -2148,9 +2157,9 @@ namespace LibGit2Sharp
             get
             {
                 return string.Format(CultureInfo.InvariantCulture,
-                    "{0} = \"{1}\"",
-                    Info.IsBare ? "Gitdir" : "Workdir",
-                    Info.IsBare ? Info.Path : Info.WorkingDirectory);
+                                     "{0} = \"{1}\"",
+                                     Info.IsBare ? "Gitdir" : "Workdir",
+                                     Info.IsBare ? Info.Path : Info.WorkingDirectory);
             }
         }
     }

--- a/LibGit2Sharp/RepositoryExtensions.cs
+++ b/LibGit2Sharp/RepositoryExtensions.cs
@@ -466,7 +466,7 @@ namespace LibGit2Sharp
 
             if (throwIfNotFound)
             {
-                throw new LibGit2SharpException(string.Format(CultureInfo.InvariantCulture, "Unexpected kind of identifier '{0}'.", identifier));
+                throw new LibGit2SharpException(CultureInfo.InvariantCulture, "Unexpected kind of identifier '{0}'.", identifier);
             }
 
             yield return null;

--- a/LibGit2Sharp/SubmoduleCollection.cs
+++ b/LibGit2Sharp/SubmoduleCollection.cs
@@ -160,9 +160,7 @@ namespace LibGit2Sharp
 
                 if (throwIfNotFound)
                 {
-                    throw new LibGit2SharpException(string.Format(
-                        CultureInfo.InvariantCulture,
-                        "Submodule lookup failed for '{0}'.", name));
+                    throw new LibGit2SharpException(CultureInfo.InvariantCulture, "Submodule lookup failed for '{0}'.", name);
                 }
 
                 return default(T);

--- a/LibGit2Sharp/UnbornBranchException.cs
+++ b/LibGit2Sharp/UnbornBranchException.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Runtime.Serialization;
 
 namespace LibGit2Sharp
@@ -23,6 +24,17 @@ namespace LibGit2Sharp
         /// <param name="message">A message that describes the error.</param>
         public UnbornBranchException(string message)
             : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnbornBranchException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="cultureInfo">An object that supplies culture-specific formatting information.</param>
+        /// <param name="format">A composite format string for use in <see cref="String.Format(IFormatProvider, string, object[])"/>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        public UnbornBranchException(CultureInfo cultureInfo, string format, params object[] args)
+            : base(String.Format(cultureInfo, format, args))
         {
         }
 


### PR DESCRIPTION
Just simplifies the code. There's not a great reason to continually use `string.Format(...)` constantly.

Was limited to using the `public LibGit2SharpException(CultureInfo cultureInfo, string format, params object[] args)` to avoid a conflict with the `public LibGit2SharpException(string message, Exception innerException)` if I used `public LibGit2SharpException(string format, params object[] args)`.