### PR TITLE
RepositoryInformation.IsEmpty

### DIFF
--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -1219,6 +1219,9 @@ namespace LibGit2Sharp.Core
         internal static extern int git_repository_is_shallow(RepositorySafeHandle repo);
 
         [DllImport(libgit2)]
+        internal static extern int git_repository_is_empty(RepositorySafeHandle repo);
+
+        [DllImport(libgit2)]
         internal static extern int git_repository_state_cleanup(RepositorySafeHandle repo);
 
         internal delegate int git_repository_mergehead_foreach_cb(

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -2137,6 +2137,11 @@ namespace LibGit2Sharp.Core
             return RepositoryStateChecker(repo, NativeMethods.git_repository_is_shallow);
         }
 
+        public static bool git_repository_is_empty(RepositorySafeHandle repo)
+        {
+            return RepositoryStateChecker(repo, NativeMethods.git_repository_is_empty);
+        }
+
         public static void git_repository_state_cleanup(RepositorySafeHandle repo)
         {
             int res = NativeMethods.git_repository_state_cleanup(repo);

--- a/LibGit2Sharp/RepositoryInformation.cs
+++ b/LibGit2Sharp/RepositoryInformation.cs
@@ -26,6 +26,7 @@ namespace LibGit2Sharp
             Path = path.Native;
             WorkingDirectory = workingDirectoryPath == null ? null : workingDirectoryPath.Native;
             IsShallow = Proxy.git_repository_is_shallow(repo.Handle);
+            IsEmpty = Proxy.git_repository_is_empty(repo.Handle);
         }
 
         /// <summary>

--- a/LibGit2Sharp/RepositoryInformation.cs
+++ b/LibGit2Sharp/RepositoryInformation.cs
@@ -26,7 +26,6 @@ namespace LibGit2Sharp
             Path = path.Native;
             WorkingDirectory = workingDirectoryPath == null ? null : workingDirectoryPath.Native;
             IsShallow = Proxy.git_repository_is_shallow(repo.Handle);
-            IsEmpty = Proxy.git_repository_is_empty(repo.Handle);
         }
 
         /// <summary>
@@ -55,7 +54,9 @@ namespace LibGit2Sharp
         /// <summary>
         /// Indicates whether the repository is empty.
         /// </summary>
-        public virtual bool IsEmpty { get; private set; }
+        public virtual bool IsEmpty {
+            get { return Proxy.git_repository_is_empty(repo.Handle); }
+        }
 
         /// <summary>
         /// Indicates whether the Head points to an arbitrary commit instead of the tip of a local branch.

--- a/LibGit2Sharp/RepositoryInformation.cs
+++ b/LibGit2Sharp/RepositoryInformation.cs
@@ -26,6 +26,7 @@ namespace LibGit2Sharp
             Path = path.Native;
             WorkingDirectory = workingDirectoryPath == null ? null : workingDirectoryPath.Native;
             IsShallow = Proxy.git_repository_is_shallow(repo.Handle);
+            isEmpty = new Lazy<bool>(() => Proxy.git_repository_is_empty(repo.Handle));
         }
 
         /// <summary>
@@ -54,9 +55,12 @@ namespace LibGit2Sharp
         /// <summary>
         /// Indicates whether the repository is empty.
         /// </summary>
-        public virtual bool IsEmpty {
-            get { return Proxy.git_repository_is_empty(repo.Handle); }
+        public virtual bool IsEmpty
+        {
+            get { return isEmpty.Value; }
         }
+
+        private readonly Lazy<bool> isEmpty;
 
         /// <summary>
         /// Indicates whether the Head points to an arbitrary commit instead of the tip of a local branch.

--- a/LibGit2Sharp/RepositoryInformation.cs
+++ b/LibGit2Sharp/RepositoryInformation.cs
@@ -54,7 +54,8 @@ namespace LibGit2Sharp
         /// <summary>
         /// Indicates whether the repository is empty.
         /// </summary>
-        public virtual bool IsEmpty {
+        public virtual bool IsEmpty
+        {
             get { return Proxy.git_repository_is_empty(repo.Handle); }
         }
 

--- a/LibGit2Sharp/RepositoryInformation.cs
+++ b/LibGit2Sharp/RepositoryInformation.cs
@@ -52,6 +52,11 @@ namespace LibGit2Sharp
         public virtual bool IsShallow { get; private set; }
 
         /// <summary>
+        /// Indicates whether the repository is empty.
+        /// </summary>
+        public virtual bool IsEmpty { get; private set; }
+
+        /// <summary>
         /// Indicates whether the Head points to an arbitrary commit instead of the tip of a local branch.
         /// </summary>
         public virtual bool IsHeadDetached

--- a/LibGit2Sharp/RepositoryInformation.cs
+++ b/LibGit2Sharp/RepositoryInformation.cs
@@ -26,7 +26,6 @@ namespace LibGit2Sharp
             Path = path.Native;
             WorkingDirectory = workingDirectoryPath == null ? null : workingDirectoryPath.Native;
             IsShallow = Proxy.git_repository_is_shallow(repo.Handle);
-            isEmpty = new Lazy<bool>(() => Proxy.git_repository_is_empty(repo.Handle));
         }
 
         /// <summary>
@@ -55,12 +54,9 @@ namespace LibGit2Sharp
         /// <summary>
         /// Indicates whether the repository is empty.
         /// </summary>
-        public virtual bool IsEmpty
-        {
-            get { return isEmpty.Value; }
+        public virtual bool IsEmpty {
+            get { return Proxy.git_repository_is_empty(repo.Handle); }
         }
-
-        private readonly Lazy<bool> isEmpty;
 
         /// <summary>
         /// Indicates whether the Head points to an arbitrary commit instead of the tip of a local branch.


### PR DESCRIPTION
- [x] Add an `extern` to `NativeMethods`.
- [x] Add a method to `Proxy`.
- [x] Expose `IsEmpty` as a property in `RepositoryInformation`.