### PR TITLE
WriteStream: use libgit2's error when we fail to write to the next stream

### DIFF
--- a/LibGit2Sharp/Core/WriteStream.cs
+++ b/LibGit2Sharp/Core/WriteStream.cs
@@ -49,16 +49,16 @@ namespace LibGit2Sharp.Core
 
         public override void Write(byte[] buffer, int offset, int count)
         {
+            int res;
             unsafe
             {
                 fixed (byte* bufferPtr = &buffer[offset])
                 {
-                    if (nextStream.write(nextPtr, (IntPtr)bufferPtr, (UIntPtr)count) < 0)
-                    {
-                        throw new LibGit2SharpException("failed to write to next buffer");
-                    }
+                    res = nextStream.write(nextPtr, (IntPtr)bufferPtr, (UIntPtr)count);
                 }
             }
+
+            Ensure.Int32Result(res);
         }
     }
 }


### PR DESCRIPTION
This should let us see what libgit2 thinks the problem is when we fail to pass the data forward.

https://github.com/libgit2/libgit2sharp/pull/1030#issuecomment-113449317