### PR TITLE
Resolve FilterFixture NRE

### DIFF
--- a/LibGit2Sharp/Core/EncodingMarshaler.cs
+++ b/LibGit2Sharp/Core/EncodingMarshaler.cs
@@ -59,7 +59,7 @@ namespace LibGit2Sharp.Core
 
         public static unsafe IntPtr FromManaged(Encoding encoding, String value)
         {
-            if (value == null)
+            if (encoding == null || value == null)
             {
                 return IntPtr.Zero;
             }

--- a/LibGit2Sharp/Core/Ensure.cs
+++ b/LibGit2Sharp/Core/Ensure.cs
@@ -133,7 +133,13 @@ namespace LibGit2Sharp.Core
         private static void HandleError(int result)
         {
             string errorMessage;
-            GitError error = NativeMethods.giterr_last().MarshalAsGitError();
+            GitError error = null;
+            var errHandle = NativeMethods.giterr_last();
+
+            if (errHandle != null && !errHandle.IsInvalid)
+            {
+                error = errHandle.MarshalAsGitError();
+            }
 
             if (error == null)
             {

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -809,12 +809,12 @@ namespace LibGit2Sharp.Core
 
         #region git_filter_
 
-        public static void git_filter_register(string name, FilterRegistration filterRegistration, int priority)
+        public static void git_filter_register(string name, IntPtr filterPtr, int priority)
         {
-            int res = NativeMethods.git_filter_register(name, filterRegistration.FilterPointer, priority);
+            int res = NativeMethods.git_filter_register(name, filterPtr, priority);
             if (res == (int)GitErrorCode.Exists)
             {
-                var message = string.Format("A filter with the name '{0}' is already registered", name);
+                var message = String.Format("A filter with the name '{0}' is already registered", name);
                 throw new EntryExistsException(message);
             }
             Ensure.ZeroResult(res);

--- a/LibGit2Sharp/Filter.cs
+++ b/LibGit2Sharp/Filter.cs
@@ -15,14 +15,9 @@ namespace LibGit2Sharp
     public abstract class Filter : IEquatable<Filter>
     {
         private static readonly LambdaEqualityHelper<Filter> equalityHelper =
-        new LambdaEqualityHelper<Filter>(x => x.Name, x => x.Attributes);
+            new LambdaEqualityHelper<Filter>(x => x.Name, x => x.Attributes);
         // 64K is optimal buffer size per https://technet.microsoft.com/en-us/library/cc938632.aspx
         private const int BufferSize = 64 * 1024;
-
-        private readonly string name;
-        private readonly IEnumerable<FilterAttributeEntry> attributes;
-
-        private readonly GitFilter gitFilter;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Filter"/> class.
@@ -46,6 +41,18 @@ namespace LibGit2Sharp
                 stream = StreamCreateCallback,
             };
         }
+        /// <summary>
+        /// Finalizer called by the <see cref="GC"/>, deregisters and frees native memory associated with the registered filter in libgit2.
+        /// </summary>
+        ~Filter()
+        {
+            GlobalSettings.DeregisterFilter(this);
+        }
+
+        private readonly string name;
+        private readonly IEnumerable<FilterAttributeEntry> attributes;
+        private readonly GitFilter gitFilter;
+        private readonly object @lock = new object();
 
         private GitWriteStream thisStream;
         private GitWriteStream nextStream;

--- a/LibGit2Sharp/FilterRegistration.cs
+++ b/LibGit2Sharp/FilterRegistration.cs
@@ -9,26 +9,78 @@ namespace LibGit2Sharp
     /// </summary>
     public sealed class FilterRegistration
     {
-        internal FilterRegistration(Filter filter)
-        {
-            Ensure.ArgumentNotNull(filter, "filter");
-            Name = filter.Name;
+        /// <summary>
+        /// Maximum priority value a filter can have. A value of 200 will be run last on checkout and first on checkin.
+        /// </summary>
+        public const int FilterPriorityMax = 200;
+        /// <summary>
+        /// Minimum priority value a filter can have. A value of 0 will be run first on checkout and last on checkin.
+        /// </summary>
+        public const int FilterPriorityMin = 0;
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="filter"></param>
+        /// <param name="priority"></param>
+        internal FilterRegistration(Filter filter, int priority)
+        {
+            System.Diagnostics.Debug.Assert(filter != null);
+            System.Diagnostics.Debug.Assert(priority >= FilterPriorityMin && priority <= FilterPriorityMax);
+
+            Filter = filter;
+            Priority = priority;
+
+            // marshal the git_filter strucutre into native memory
             FilterPointer = Marshal.AllocHGlobal(Marshal.SizeOf(filter.GitFilter));
             Marshal.StructureToPtr(filter.GitFilter, FilterPointer, false);
+
+            // register the filter with the native libary
+            Proxy.git_filter_register(filter.Name, FilterPointer, priority);
+        }
+        /// <summary>
+        /// Finalizer called by the <see cref="GC"/>, deregisters and frees native memory associated with the registered filter in libgit2.
+        /// </summary>
+        ~FilterRegistration()
+        {
+            // deregister the filter
+            GlobalSettings.DeregisterFilter(this);
+            // clean up native allocations
+            Free();
         }
 
         /// <summary>
+        /// Gets if the registration and underlying filter are valid.
+        /// </summary>
+        public bool IsValid { get { return !freed; } }
+        /// <summary>
+        /// The registerd filters
+        /// </summary>
+        public readonly Filter Filter;
+        /// <summary>
         /// The name of the filter in the libgit2 registry
         /// </summary>
-        public string Name { get; private set; }
+        public string Name { get { return Filter.Name; } }
+        /// <summary>
+        /// The priority of the registered filter
+        /// </summary>
+        public readonly int Priority;
 
-        internal IntPtr FilterPointer { get; private set; }
+        private readonly IntPtr FilterPointer;
+
+        private bool freed;
 
         internal void Free()
         {
-            Marshal.FreeHGlobal(FilterPointer);
-            FilterPointer = IntPtr.Zero;
+            if (!freed)
+            {
+                // unregister the filter with the native libary
+                Proxy.git_filter_unregister(Filter.Name);
+                // release native memory
+                Marshal.FreeHGlobal(FilterPointer);
+                // remember to not do this twice
+                freed = true;
+            }
         }
     }
 }


### PR DESCRIPTION
Resolve racy NRE via re-architect of filter logic.

Moves all filter logic into the `Filter` class. Made `Filter` into `IDisposable`.

Seperates registration logic into the `FilterRegistration` class. Made `FilterRegistration` into `IDisposable`.

Moves core registration logic into `FilterRegistration` while leaving legacy methods in `GlobalSettings`. Methods in `GlobalSettings` now forward to methods in `FilterRegistration`.

Retains handles on all filter and registration values in static `FilterRegistration` class to prevent native code calling disposed managed objects resulting in NRE. Manages register, deregister, and dispose logic coherently.

Added a new test to verify improved features and Survivability.

Fixes a few other areas where NRE happened after GC collection vs. native utilization race occurred.

Fixes #1091