### PR TITLE
Added coveralls.io status and supporting text

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
  [tracker]: https://github.com/libgit2/libgit2sharp/issues
  [twitter]: http://twitter.com/libgit2sharp
 
-## Current project build status
+## Current project status
 
 The CI builds are generously hosted and run on the [Travis][travis] and [AppVeyor][appveyor] infrastructures.
 
@@ -36,16 +36,17 @@ The CI builds are generously hosted and run on the [Travis][travis] and [AppVeyo
 | **master** | [![master win][master-win-badge]][master-win] | [![master nix][master-nix-badge]][master-nix] |
 | **vNext** | [![vNext win][vNext-win-badge]][vNext-win] | [![vNext nix][vNext-nix-badge]][vNext-nix] |
 
-The security oriented static code analysis is kindly run through the [Coverity][coverity] service.
+The security-oriented static code analysis is kindly run through the [Coverity][coverity] service. Code coverage is kindly run through [Coveralls.io][coveralls].
 
-|       | Analysis result |
-|-------|-----------------|
-| **vNext** |  [![coverity][coverity-badge]][coverity-project] |
+|       | Static Analysis | Code Coverage |
+|-------|-----------------|---------------|
+| **vNext** | [![coverity][coverity-badge]][coverity-project] | [![coveralls][coveralls-badge]][coveralls-project] |
 
 
  [travis]: https://travis-ci.org/
  [appveyor]: http://appveyor.com/
  [coverity]: https://scan.coverity.com/
+ [coveralls]: https://coveralls.io/
 
  [master-win-badge]: https://ci.appveyor.com/api/projects/status/8qxcoqdo9kp7x2w9/branch/master?svg=true
  [master-win]: https://ci.appveyor.com/project/libgit2/libgit2sharp/branch/master
@@ -58,6 +59,9 @@ The security oriented static code analysis is kindly run through the [Coverity][
 
  [coverity-project]: https://scan.coverity.com/projects/2088
  [coverity-badge]: https://scan.coverity.com/projects/2088/badge.svg
+
+ [coveralls-project]: https://coveralls.io/r/libgit2/libgit2sharp?branch=vNext
+ [coveralls-badge]: https://coveralls.io/repos/libgit2/libgit2sharp/badge.svg?branch=vNext
 
 ## Quick contributing guide
 


### PR DESCRIPTION
As per #1109, I have added a badge for Coveralls.io and modified the preceding text and column headers to indicate the use of Coveralls and to separate the Coverity static analysis from the Coveralls code coverage.

First commit, just wanted to help out.