### PR TITLE
Allow libgit2# to redirect the global/system/xdg config search path

### DIFF
--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -581,6 +581,25 @@ namespace LibGit2Sharp.Core
         [DllImport(libgit2)]
         internal static extern int git_libgit2_features();
 
+        #region git_libgit2_opts
+
+        // Bindings for git_libgit2_opts(int option, ...):
+        // Currently only GIT_OPT_GET_SEARCH_PATH and GIT_OPT_SET_SEARCH_PATH are supported,
+        // but other overloads could be added using a similar pattern.
+        // CallingConvention.Cdecl is used to allow binding the the C varargs signature, and each possible call signature must be enumerated.
+        // __argslist was an option, but is an undocumented feature that should likely not be used here.
+
+        // git_libgit2_opts(GIT_OPT_GET_SEARCH_PATH, int level, git_buf *buf)
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int git_libgit2_opts(int option, uint level, GitBuf buf);
+
+        // git_libgit2_opts(GIT_OPT_SET_SEARCH_PATH, int level, const char *path)
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int git_libgit2_opts(int option, uint level,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))]string path);
+
+        #endregion
+
         [DllImport(libgit2)]
         internal static extern int git_graph_ahead_behind(out UIntPtr ahead, out UIntPtr behind, RepositorySafeHandle repo, ref GitOid one, ref GitOid two);
 

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -3193,6 +3193,60 @@ namespace LibGit2Sharp.Core
             return (BuiltInFeatures)NativeMethods.git_libgit2_features();
         }
 
+        // C# equivalent of libgit2's git_libgit2_opt_t
+        private enum LibGitOption
+        {
+            GetMWindowSize,        // GIT_OPT_GET_MWINDOW_SIZE
+            SetMWindowSize,        // GIT_OPT_SET_MWINDOW_SIZE
+            GetMWindowMappedLimit, // GIT_OPT_GET_MWINDOW_MAPPED_LIMIT
+            SetMWindowMappedLimit, // GIT_OPT_SET_MWINDOW_MAPPED_LIMIT
+            GetSearchPath,         // GIT_OPT_GET_SEARCH_PATH
+            SetSearchPath,         // GIT_OPT_SET_SEARCH_PATH
+            SetCacheObjectLimit,   // GIT_OPT_SET_CACHE_OBJECT_LIMIT
+            SetCacheMaxSize,       // GIT_OPT_SET_CACHE_MAX_SIZE
+            EnableCaching,         // GIT_OPT_ENABLE_CACHING
+            GetCachedMemory,       // GIT_OPT_GET_CACHED_MEMORY
+            GetTemplatePath,       // GIT_OPT_GET_TEMPLATE_PATH
+            SetTemplatePath,       // GIT_OPT_SET_TEMPLATE_PATH
+            SetSslCertLocations,   // GIT_OPT_SET_SSL_CERT_LOCATIONS
+        }
+
+        /// <summary>
+        /// Get the paths under which libgit2 searches for the configuration file of a given level.
+        /// </summary>
+        /// <param name="level">The level (global/system/XDG) of the config.</param>
+        /// <returns>
+        ///     The paths delimited by 'GIT_PATH_LIST_SEPARATOR' (<see cref="GlobalSettings.PathListSeparator"/>).
+        /// </returns>
+        public static string git_libgit2_opts_get_search_path(ConfigurationLevel level)
+        {
+            string path;
+
+            using (var buf = new GitBuf())
+            {
+                var res = NativeMethods.git_libgit2_opts((int)LibGitOption.GetSearchPath, (uint)level, buf);
+                Ensure.ZeroResult(res);
+
+                path = LaxUtf8Marshaler.FromNative(buf.ptr) ?? string.Empty;
+            }
+
+            return path;
+        }
+
+        /// <summary>
+        /// Set the path(s) under which libgit2 searches for the configuration file of a given level.
+        /// </summary>
+        /// <param name="level">The level (global/system/XDG) of the config.</param>
+        /// <param name="path">
+        ///     A string of paths delimited by 'GIT_PATH_LIST_SEPARATOR' (<see cref="GlobalSettings.PathListSeparator"/>).
+        ///     Pass null to reset the search path to the default.
+        /// </param>
+        public static void git_libgit2_opts_set_search_path(ConfigurationLevel level, string path)
+        {
+            var res = NativeMethods.git_libgit2_opts((int)LibGitOption.SetSearchPath, (uint)level, path);
+            Ensure.ZeroResult(res);
+        }
+
         #endregion
 
         private static ICollection<TResult> git_foreach<T, TResult>(

--- a/LibGit2Sharp/GlobalSettings.cs
+++ b/LibGit2Sharp/GlobalSettings.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using System.Collections.Generic;
 using LibGit2Sharp.Core;
 
 namespace LibGit2Sharp
@@ -271,6 +272,33 @@ namespace LibGit2Sharp
                 // unregister the filter
                 DeregisterFilter(registration);
             }
+        }
+
+        /// <summary>
+        /// Get the paths under which libgit2 searches for the configuration file of a given level.
+        /// </summary>
+        /// <param name="level">The level (global/system/XDG) of the config.</param>
+        /// <returns>The paths that are searched</returns>
+        public static IEnumerable<string> GetConfigSearchPaths(ConfigurationLevel level)
+        {
+            return Proxy.git_libgit2_opts_get_search_path(level).Split(Path.PathSeparator);
+        }
+
+        /// <summary>
+        /// Set the paths under which libgit2 searches for the configuration file of a given level.
+        ///
+        /// <seealso cref="RepositoryOptions"/>.
+        /// </summary>
+        /// <param name="level">The level (global/system/XDG) of the config.</param>
+        /// <param name="paths">
+        ///     The new search paths to set.
+        ///     Pass null to reset to the default.
+        ///     The special string "$PATH" will be substituted with the current search path.
+        /// </param>
+        public static void SetConfigSearchPaths(ConfigurationLevel level, params string[] paths)
+        {
+            var pathString = (paths == null) ? null : string.Join(Path.PathSeparator.ToString(), paths);
+            Proxy.git_libgit2_opts_set_search_path(level, pathString);
         }
     }
 }

--- a/LibGit2Sharp/RepositoryOptions.cs
+++ b/LibGit2Sharp/RepositoryOptions.cs
@@ -32,6 +32,7 @@
         ///   The path has either to lead to an existing valid configuration file,
         ///   or to a non existent configuration file which will be eventually created.
         /// </para>
+        /// <seealso cref="GlobalSettings.SetConfigSearchPaths"/>.
         /// </summary>
         public string GlobalConfigurationLocation { get; set; }
 
@@ -41,6 +42,7 @@
         ///   The path has either to lead to an existing valid configuration file,
         ///   or to a non existent configuration file which will be eventually created.
         /// </para>
+        /// <seealso cref="GlobalSettings.SetConfigSearchPaths"/>.
         /// </summary>
         public string XdgConfigurationLocation { get; set; }
 
@@ -50,6 +52,7 @@
         ///   The path has to lead to an existing valid configuration file,
         ///   or to a non existent configuration file which will be eventually created.
         /// </para>
+        /// <seealso cref="GlobalSettings.SetConfigSearchPaths"/>.
         /// </summary>
         public string SystemConfigurationLocation { get; set; }
 


### PR DESCRIPTION
This provides an interface for libgit2# to redirect config file lookups via libgit2's `git_libgit2_opt`.

This is useful for unit-testing methods that hit the global, system, or xdg config files.

It is currently possible to redirect config access using `RepositoryOptions`, but this only works if the functions you are testing take a `Repository` as an argument. This isn't much of a problem for libgit2#, but other frameworks may not want to pass a `Repository` all the way through their call stack to support testing with a faked config. This provides a more foolproof way to sandbox your tests as it guarantees that all config access is redirected (libgit2 [uses this for testing](https://github.com/libgit2/libgit2/blob/c7f94123569e8fe00ffb3a35e6a12b6ebe9320ec/tests/config/global.c#L5)).

The first commit adds the actual functionality. `git_libgit2_opts` has a number of other options -- I only added bindings for search path redirection, but this sets the stage for binding other libgit2 settings if they are needed.

The second commit shows how this could be used within libgit2# tests. The current redirection scheme can be flaky -- I noticed some tests failing because they [only redirected system config access](https://github.com/libgit2/libgit2sharp/blob/vNext/LibGit2Sharp.Tests/DiffTreeToTreeFixture.cs#L1049), and my personal global config was interfering.
The test could be fixed without this, of course, but I think this will help prevent mistakes in the long run.

[EDIT]
I've removed the second commit for now -- my partial fixup of the test fixtures was causing problems in as many tests as it fixed.

This PR just allows libgit2# consumers to redirect config access, I can work on a second PR to use this in the lg2# test fixtures if it seems like a good idea (started [here](https://github.com/rcorre/libgit2sharp/commit/f5002458f9e8a8867a86c89e5c297678c084d650)).