### PR TITLE
Xplat building via cmd line or IDE (Xamarin Studio / MonoDevelop)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ Thumbs.db
 *.obj
 *.exe
 *.pdb
+*.mdb
 *.user
 *.aps
 *.pch

--- a/CI/build.msbuild
+++ b/CI/build.msbuild
@@ -17,6 +17,9 @@
       Overwrite="true" />
 
     <!-- Workaround for xbuild -->
+    <Exec Condition=" ('$(OS)' != 'Windows_NT') " Command=" xbuild ../Lib/CustomBuildTasks/CustomBuildTasksExe/CustomBuildTasksExe.csproj "  />
+    <Exec Condition=" ('$(OS)' != 'Windows_NT') " Command=" cd LibGit2Sharp; mono ../Lib/CustomBuildTasks/CustomBuildTasksExe/CustomBuildTasksExe.exe UniqueIdentifierTask ; cd .. " />
+    <Exec Condition=" ('$(OS)' != 'Windows_NT') " Command=" cd LibGit2Sharp; mono ../Lib/CustomBuildTasks/CustomBuildTasksExe/CustomBuildTasksExe.exe NativeDllNameTask ; cd .. " />
     <Exec Condition=" ('$(OS)' != 'Windows_NT') " Command=" rm -r -f $(DeployFolder) " />
     <Exec Condition=" ('$(OS)' != 'Windows_NT') " Command=" rm -r -f $(TestBuildDir) " />
 

--- a/Lib/CustomBuildTasks/CustomBuildTasks.csproj
+++ b/Lib/CustomBuildTasks/CustomBuildTasks.csproj
@@ -9,9 +9,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CustomBuildTasks</RootNamespace>
     <AssemblyName>CustomBuildTasks</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -33,7 +35,9 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="Microsoft.Build.Framework" />
-    <Reference Include="Microsoft.Build.Utilities" />
+    <Reference Include="Microsoft.Build.Tasks.v4.0" />
+    <Reference Include="Microsoft.Build.Utilities.v4.0" />
+    <Reference Include="Microsoft.Build.Engine" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="GenerateUniqueIdentifierTask.cs" />
@@ -41,3 +45,4 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>
+

--- a/Lib/CustomBuildTasks/CustomBuildTasksExe/CustomBuildTasksExe.csproj
+++ b/Lib/CustomBuildTasks/CustomBuildTasksExe/CustomBuildTasksExe.csproj
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{3A032B41-0FE8-411E-B60B-AD6D22B1BBFE}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>CustomeBuildTasksExe</RootNamespace>
+    <AssemblyName>CustomBuildTasksExe</AssemblyName>
+    <UseMSBuildEngine>False</UseMSBuildEngine>
+    <StartupObject>CustomeBuildTasksExe.MainClass</StartupObject>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>.</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Externalconsole>true</Externalconsole>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>.</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Externalconsole>true</Externalconsole>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="Microsoft.Build.Framework" />
+    <Reference Include="Microsoft.Build.Engine" />
+    <Reference Include="Microsoft.Build" />
+    <Reference Include="Microsoft.Build.Tasks.v4.0" />
+    <Reference Include="Microsoft.Build.Utilities.v4.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <ItemGroup>
+    <ProjectReference Include="..\CustomBuildTasks.csproj">
+      <Project>{B6138573-A4B9-44E7-83C2-8964CAF51EDA}</Project>
+      <Name>CustomBuildTasks</Name>
+    </ProjectReference>
+  </ItemGroup>
+</Project>

--- a/Lib/CustomBuildTasks/CustomBuildTasksExe/Program.cs
+++ b/Lib/CustomBuildTasks/CustomBuildTasksExe/Program.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.IO;
+using Microsoft.Build.Utilities;
+using CustomBuildTasks;
+
+namespace CustomeBuildTasksExe
+{
+    class MainClass
+    {
+        public static void Main(string[] args)
+        {
+            if (args.Length > 0)
+            {
+                if (args[0] == "UniqueIdentifierTask")
+                {
+                    var guidTask = new GenerateUniqueIdentifierTask();
+                    guidTask.OutputFile = args.Length > 1 ? args[1] : Path.Combine(Environment.CurrentDirectory, "Core/UniqueIdentifier.cs");
+                    guidTask.Execute();
+                    Console.WriteLine("Generated: {0}", guidTask.OutputFile);
+                }
+                else if (args[0] == "NativeDllNameTask")
+                {
+                    string fileName;
+                    fileName = args.Length < 2 ? Directory.GetFiles("../packages", "libgit2_hash.txt", SearchOption.AllDirectories)[0] : args[1];
+                    var dllNameTask = new GenerateNativeDllNameTask();
+                    dllNameTask.InputHashFile = new TaskItem(fileName);
+                    dllNameTask.OutputFile = args.Length > 1 ? args[2] : Path.Combine(Environment.CurrentDirectory, "Core/NativeDllName.cs");
+                    dllNameTask.Execute();
+                    Console.WriteLine("Generated: {0}", dllNameTask.OutputFile);
+                    return;
+                }
+                else
+                {
+                    Console.WriteLine("{0}: Unsupported Microsoft.Build.Utilities.Task Id supplied, no task executed.", args[0]);
+                }
+            }
+        }
+    }
+}

--- a/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
+++ b/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
@@ -12,6 +12,13 @@
     <RootNamespace>LibGit2Sharp.Tests</RootNamespace>
     <AssemblyName>LibGit2Sharp.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <CustomCommands>
+      <CustomCommands>
+        <Command type="BeforeBuild" command="xbuild Lib/CustomBuildTasks/CustomBuildTasksExe/CustomBuildTasksExe.csproj" workingdir="${SolutionDir}" Condition=" '$(OS)' != 'Windows_NT' "/>
+        <Command type="BeforeBuild" command="mono ../Lib/CustomBuildTasks/CustomBuildTasksExe/CustomBuildTasksExe.exe UniqueIdentifierTask" workingdir="${ProjectDir}" Condition=" '$(OS)' != 'Windows_NT' " />
+        <Command type="BeforeBuild" command="mono ../Lib/CustomBuildTasks/CustomBuildTasksExe/CustomBuildTasksExe.exe NativeDllNameTask" workingdir="${ProjectDir}" Condition=" '$(OS)' != 'Windows_NT' " />
+      </CustomCommands>
+    </CustomCommands>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -24,6 +31,13 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CustomCommands>
+      <CustomCommands>
+        <Command type="BeforeBuild" command="xbuild Lib/CustomBuildTasks/CustomBuildTasksExe/CustomBuildTasksExe.csproj" workingdir="${SolutionDir}" Condition=" '$(OS)' != 'Windows_NT' "/>
+        <Command type="BeforeBuild" command="mono ../Lib/CustomBuildTasks/CustomBuildTasksExe/CustomBuildTasksExe.exe UniqueIdentifierTask" workingdir="${ProjectDir}" Condition=" '$(OS)' != 'Windows_NT' " />
+        <Command type="BeforeBuild" command="mono ../Lib/CustomBuildTasks/CustomBuildTasksExe/CustomBuildTasksExe.exe NativeDllNameTask" workingdir="${ProjectDir}" Condition=" '$(OS)' != 'Windows_NT' " />
+      </CustomCommands>
+    </CustomCommands>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -33,6 +47,13 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CustomCommands>
+      <CustomCommands>
+        <Command type="BeforeBuild" command="xbuild Lib/CustomBuildTasks/CustomBuildTasksExe/CustomBuildTasksExe.csproj" workingdir="${SolutionDir}" Condition=" '$(OS)' != 'Windows_NT' "/>
+        <Command type="BeforeBuild" command="mono ../Lib/CustomBuildTasks/CustomBuildTasksExe/CustomBuildTasksExe.exe UniqueIdentifierTask" workingdir="${ProjectDir}" Condition=" '$(OS)' != 'Windows_NT' " />
+        <Command type="BeforeBuild" command="mono ../Lib/CustomBuildTasks/CustomBuildTasksExe/CustomBuildTasksExe.exe NativeDllNameTask" workingdir="${ProjectDir}" Condition=" '$(OS)' != 'Windows_NT' " />
+      </CustomCommands>
+    </CustomCommands>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Moq, Version=4.2.1409.1722, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -4,8 +4,6 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{EE6ED99F-CB12-4683-B055-D28FC7357A34}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
@@ -14,6 +12,8 @@
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -23,10 +23,16 @@
     <DefineConstants>TRACE;DEBUG;NET40</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>bin\Debug\LibGit2Sharp.xml</DocumentationFile>
+    <CustomCommands>
+      <CustomCommands>
+        <Command type="BeforeBuild" command="xbuild Lib/CustomBuildTasks/CustomBuildTasksExe/CustomBuildTasksExe.csproj" workingdir="${SolutionDir}" Condition=" '$(OS)' != 'Windows_NT' "/>
+        <Command type="BeforeBuild" command="mono ../Lib/CustomBuildTasks/CustomBuildTasksExe/CustomBuildTasksExe.exe UniqueIdentifierTask" workingdir="${ProjectDir}" Condition=" '$(OS)' != 'Windows_NT' " />
+        <Command type="BeforeBuild" command="mono ../Lib/CustomBuildTasks/CustomBuildTasksExe/CustomBuildTasksExe.exe NativeDllNameTask" workingdir="${ProjectDir}" Condition=" '$(OS)' != 'Windows_NT' " />
+      </CustomCommands>
+    </CustomCommands>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -36,8 +42,14 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <DocumentationFile>bin\Release\LibGit2Sharp.xml</DocumentationFile>
+    <CustomCommands>
+      <CustomCommands>
+        <Command type="BeforeBuild" command="xbuild Lib/CustomBuildTasks/CustomBuildTasksExe/CustomBuildTasksExe.csproj" workingdir="${SolutionDir}" Condition=" '$(OS)' != 'Windows_NT' "/>
+        <Command type="BeforeBuild" command="mono ../Lib/CustomBuildTasks/CustomBuildTasksExe/CustomBuildTasksExe.exe UniqueIdentifierTask" workingdir="${ProjectDir}" Condition=" '$(OS)' != 'Windows_NT' " />
+        <Command type="BeforeBuild" command="mono ../Lib/CustomBuildTasks/CustomBuildTasksExe/CustomBuildTasksExe.exe NativeDllNameTask" workingdir="${ProjectDir}" Condition=" '$(OS)' != 'Windows_NT' " />
+      </CustomCommands>
+    </CustomCommands>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -382,8 +394,8 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="UniqueIdentifier.targets" />
-  <Import Project="NativeDllName.targets" />
+  <Import Project="UniqueIdentifier.targets" Condition=" '$(OS)' == 'Windows_NT' " />
+  <Import Project="NativeDllName.targets" Condition=" '$(OS)' == 'Windows_NT' " />
   <Import Project="ExtraDefine.targets" />
   <PropertyGroup>
     <PreBuildEvent>


### PR DESCRIPTION
Note: I have not 're-confirmed' xUnit tests on *nix, VM access unavailable at the moment

   Added exe wrapper for CustomBuildTasks.dll to allow xplat project building with the following:
    * Xamarian Studio v5.9.x+ / MonoDevelop v5.9.x+
    * mdtool (matching version from above's IDE installation)
    * xbuild (from mono 4.0.2+ installation)

## Xplat building via cmd line or IDE (Xamarin Studio / MonoDevelop)

## From repo's root directory, perform the following:

### Build the wrapper for project's custom build tasks:

    xbuild Lib/CustomBuildTasks/CustomBuildTasksExe/CustomBuildTasksExe.csproj

### Build LibGit2Sharp.dll:

    xbuild LibGit2Sharp/LibGit2Sharp.csproj

### Build and Run xUnit tests:

    xbuild LibGit2Sharp.Tests/LibGit2Sharp.Tests.csprol
    # Tests have to be run from output dir to prevent a test failure:
    #  * LibGit2Sharp.Tests.CleanFixture.CannotCleanABareRepository [FAIL]
    #  * System.IO.DirectoryNotFoundException : Directory '/xxx/Resources/testrepo.git' not found.
    cd LibGit2Sharp.Tests/bin/Debug
    mono ../../../packages/xunit.runners.1.9.2/tools/xunit.console.exe LibGit2Sharp.Tests.dll


## Results:

### OS-X 10.10.3

### Mono 4.0.2 32-bit (latest public MDK release):

    mono --version
    Mono JIT compiler version 4.0.2 ((detached/c99aa0c Thu Jun 11 18:53:01 EDT 2015)

#### xUnit Test Output:

    Using default runtime: v4.0.30319
    xUnit.net console test runner (32-bit .NET 4.0.30319.17020)
    Copyright (C) 2013 Outercurve Foundation.
    xunit.dll:     Version 1.9.2.1705
    ...
    1291 total, 0 failed, 8 skipped, took 182.804 seconds
    
### Mono 4.3.0 64-bit (master - bleeding edge):

    mono --version
    Mono JIT compiler version 4.3.0 (master/e02e386 Sun Jun 28 22:03:31 PDT 2015)

#### xUnit Test Output:

    Using default runtime: v4.0.30319
    xUnit.net console test runner (64-bit .NET 4.0.30319.17020)
    Copyright (C) 2013 Outercurve Foundation.
    xunit.dll:     Version 1.9.2.1705
    ....
    1291 total, 0 failed, 8 skipped, took 147.674 seconds
