### PR TITLE
Enable Mono 4.0.1+ build / xUnit testing 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ Thumbs.db
 *.obj
 *.exe
 *.pdb
+*.mdb
 *.user
 *.aps
 *.pch

--- a/CI/build.msbuild
+++ b/CI/build.msbuild
@@ -20,6 +20,9 @@
     <Exec Condition=" ('$(OS)' != 'Windows_NT') " Command=" rm -r -f $(DeployFolder) " />
     <Exec Condition=" ('$(OS)' != 'Windows_NT') " Command=" rm -r -f $(TestBuildDir) " />
 
+    <Exec Condition=" ('$(OS)' == 'Unix') " Command=" xbuild ../Lib/CustomBuildTasks/CustomBuildTasksExe/CustomBuildTasksExe.sln "  />
+    <Exec Condition=" ('$(OS)' == 'Unix') " Command=" cd ../LibGit2Sharp; mono ../Lib/CustomBuildTasks/CustomBuildTasksExe/CustomBuildTasksExe.exe UniqueIdentifierTask ; cd .. " />
+    <Exec Condition=" ('$(OS)' == 'Unix') " Command=" cd ../LibGit2Sharp; mono ../Lib/CustomBuildTasks/CustomBuildTasksExe/CustomBuildTasksExe.exe NativeDllNameTask ; cd .. " />
     <RemoveDir Directories="$(DeployFolder)" Condition="Exists('$(DeployFolder)')" />
     <RemoveDir Directories="$(TestBuildDir)" Condition="Exists('$(TestBuildDir)')" />
   </Target>
@@ -37,7 +40,9 @@
   </Target>
 
   <Target Name="Test" DependsOnTargets="Build">
-    <xunit Assembly="$(TestBuildDir)/LibGit2Sharp.Tests.dll" ShadowCopy="false" Xml="$(DeployFolder)/Test-result.xml" />
+    <xunit Condition=" ('$(OS)' == 'Windows_NT') " Assembly="$(TestBuildDir)/LibGit2Sharp.Tests.dll" ShadowCopy="false" Xml="$(DeployFolder)/Test-result.xml" />
+    <Exec Condition=" ('$(OS)' == 'Unix') " Command=" cd $(TestBuildDir); LD_LIBRARY_PATH=. mono ../../../packages/xunit.runners.1.9.2/tools/xunit.console.exe LibGit2Sharp.Tests.dll /xml Test-result.xml " />
+    <Exec Condition=" ('$(OS)' == 'Unix') " Command=" cp $(TestBuildDir)/Test-result.xml $(DeployFolder) " />
   </Target>
 
   <Target Name="Deploy" DependsOnTargets="Test">

--- a/CI/travis.linux.install.deps.sh
+++ b/CI/travis.linux.install.deps.sh
@@ -3,7 +3,7 @@ set -ev
 
 sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 
-echo "deb http://download.mono-project.com/repo/debian wheezy/snapshots/3.12.0 main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list
+echo "deb http://download.mono-project.com/repo/debian wheezy main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list
 echo "deb http://download.mono-project.com/repo/debian wheezy-libtiff-compat main" | sudo tee -a /etc/apt/sources.list.d/mono-xamarin.list
 
 sudo apt-get update

--- a/CI/travis.osx.install.deps.sh
+++ b/CI/travis.osx.install.deps.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ev
 
-MONO_VER=3.6.0
+MONO_VER=4.0.2
 
 brew update
 which cmake || brew install cmake

--- a/Lib/CustomBuildTasks/CustomBuildTasks.csproj
+++ b/Lib/CustomBuildTasks/CustomBuildTasks.csproj
@@ -9,9 +9,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CustomBuildTasks</RootNamespace>
     <AssemblyName>CustomBuildTasks</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -33,7 +35,11 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="Microsoft.Build.Framework" />
-    <Reference Include="Microsoft.Build.Utilities" />
+    <Reference Include="Microsoft.Build" />
+    <Reference Include="Microsoft.Build.Engine" />
+    <Reference Include="Microsoft.Build.Tasks.v4.0" />
+    <Reference Include="Microsoft.Build.Utilities.v4.0" />
+    <Reference Include="Microsoft.Build.Engine" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="GenerateUniqueIdentifierTask.cs" />

--- a/Lib/CustomBuildTasks/CustomBuildTasksExe/CustomBuildTasksExe.csproj
+++ b/Lib/CustomBuildTasks/CustomBuildTasksExe/CustomBuildTasksExe.csproj
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{3A032B41-0FE8-411E-B60B-AD6D22B1BBFE}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>CustomeBuildTasksExe</RootNamespace>
+    <AssemblyName>CustomBuildTasksExe</AssemblyName>
+    <UseMSBuildEngine>False</UseMSBuildEngine>
+    <StartupObject>CustomeBuildTasksExe.MainClass</StartupObject>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>.</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Externalconsole>true</Externalconsole>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>.</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Externalconsole>true</Externalconsole>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="Microsoft.Build.Framework" />
+    <Reference Include="Microsoft.Build.Engine" />
+    <Reference Include="Microsoft.Build" />
+    <Reference Include="Microsoft.Build.Tasks.v4.0" />
+    <Reference Include="Microsoft.Build.Utilities.v4.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <ItemGroup>
+    <ProjectReference Include="..\CustomBuildTasks.csproj">
+      <Project>{B6138573-A4B9-44E7-83C2-8964CAF51EDA}</Project>
+      <Name>CustomBuildTasks</Name>
+    </ProjectReference>
+  </ItemGroup>
+</Project>

--- a/Lib/CustomBuildTasks/CustomBuildTasksExe/CustomBuildTasksExe.sln
+++ b/Lib/CustomBuildTasks/CustomBuildTasksExe/CustomBuildTasksExe.sln
@@ -1,0 +1,23 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2010
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CustomBuildTasksExe", "CustomBuildTasksExe.csproj", "{3A032B41-0FE8-411E-B60B-AD6D22B1BBFE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CustomBuildTasks", "..\CustomBuildTasks.csproj", "{B6138573-A4B9-44E7-83C2-8964CAF51EDA}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{3A032B41-0FE8-411E-B60B-AD6D22B1BBFE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3A032B41-0FE8-411E-B60B-AD6D22B1BBFE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3A032B41-0FE8-411E-B60B-AD6D22B1BBFE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3A032B41-0FE8-411E-B60B-AD6D22B1BBFE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B6138573-A4B9-44E7-83C2-8964CAF51EDA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B6138573-A4B9-44E7-83C2-8964CAF51EDA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B6138573-A4B9-44E7-83C2-8964CAF51EDA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B6138573-A4B9-44E7-83C2-8964CAF51EDA}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/Lib/CustomBuildTasks/CustomBuildTasksExe/Program.cs
+++ b/Lib/CustomBuildTasks/CustomBuildTasksExe/Program.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.IO;
+using Microsoft.Build.Utilities;
+using CustomBuildTasks;
+
+namespace CustomeBuildTasksExe
+{
+    class MainClass
+    {
+        public static void Main(string[] args)
+        {
+            if (args.Length > 0)
+            {
+                if (args[0] == "UniqueIdentifierTask")
+                {
+                    var guidTask = new GenerateUniqueIdentifierTask();
+                    guidTask.OutputFile = args.Length > 1 ? args[1] : Path.Combine(Environment.CurrentDirectory, "Core/UniqueIdentifier.cs");
+                    guidTask.Execute();
+                    Console.WriteLine("Generated: {0}", guidTask.OutputFile);
+                }
+                else if (args[0] == "NativeDllNameTask")
+                {
+                    string fileName;
+                    fileName = args.Length < 2 ? Directory.GetFiles("../packages", "libgit2_hash.txt", SearchOption.AllDirectories)[0] : args[1];
+                    var dllNameTask = new GenerateNativeDllNameTask();
+                    dllNameTask.InputHashFile = new TaskItem(fileName);
+                    dllNameTask.OutputFile = args.Length > 1 ? args[2] : Path.Combine(Environment.CurrentDirectory, "Core/NativeDllName.cs");
+                    dllNameTask.Execute();
+                    Console.WriteLine("Generated: {0}", dllNameTask.OutputFile);
+                    return;
+                }
+                else
+                {
+                    Console.WriteLine("{0}: Unsupported Microsoft.Build.Utilities.Task Id supplied, no task executed.", args[0]);
+                }
+            }
+        }
+    }
+}

--- a/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
+++ b/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
@@ -35,19 +35,17 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Moq, Version=4.2.1409.1722, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Moq.4.2.1409.1722\lib\net40\Moq.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
-    <Reference Include="xunit, Version=1.9.2.1705, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
-    </Reference>
     <Reference Include="xunit.extensions">
       <HintPath>..\packages\xunit.extensions.1.9.2\lib\net20\xunit.extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Moq">
+      <HintPath>..\packages\Moq.4.2.1409.1722\lib\net40\Moq.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit">
+      <HintPath>..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -4,8 +4,6 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{EE6ED99F-CB12-4683-B055-D28FC7357A34}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
@@ -14,6 +12,8 @@
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -23,10 +23,16 @@
     <DefineConstants>TRACE;DEBUG;NET40</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>bin\Debug\LibGit2Sharp.xml</DocumentationFile>
+    <CustomCommands>
+      <CustomCommands>
+        <Command type="BeforeBuild" command="xbuild Lib/CustomBuildTasks/CustomBuildTasksExe/CustomBuildTasksExe.sln" workingdir="${SolutionDir}" Condition=" '$(OS)' == 'Unix' " />
+        <Command type="BeforeBuild" command="mono Lib/CustomBuildTasks/CustomBuildTasksExe/CustomBuildTasksExe.exe UniqueIdentifierTask" workingdir="${SolutionDir}" Condition=" '$(OS)' == 'Unix' " />
+        <Command type="BeforeBuild" command="mono Lib/CustomBuildTasks/CustomBuildTasksExe/CustomBuildTasksExe.exe NativeDllNameTask" workingdir="${SolutionDir}" Condition=" '$(OS)' == 'Unix' " />
+      </CustomCommands>
+    </CustomCommands>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -36,7 +42,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <DocumentationFile>bin\Release\LibGit2Sharp.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
@@ -382,8 +387,8 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="UniqueIdentifier.targets" />
-  <Import Project="NativeDllName.targets" />
+  <Import Project="UniqueIdentifier.targets" Condition=" '$(OS)' == 'Windows_NT' " />
+  <Import Project="NativeDllName.targets" Condition=" '$(OS)' == 'Windows_NT' " />
   <Import Project="ExtraDefine.targets" />
   <PropertyGroup>
     <PreBuildEvent>

--- a/build.libgit2sharp.sh
+++ b/build.libgit2sharp.sh
@@ -10,7 +10,7 @@ EXTRADEFINE="$1"
 export LD_LIBRARY_PATH=.
 
 # Required for NuGet package restore to run.
-mozroots --import --sync
+#mozroots --import --sync
 
 mono Lib/NuGet/NuGet.exe restore LibGit2Sharp.sln
 xbuild CI/build.msbuild /target:Deploy /property:ExtraDefine="$EXTRADEFINE"


### PR DESCRIPTION
Note: This is for getting libgit2sharp building and running the xUnit test suite on mono 4.0.x+. I am using only mono 4.0.1+ and needed to do this for my own projects, but if there are is no current need, or a different roadmap is in place for vetting mono 4+, you can close it. Thanks.

Note: Githib auto-closed the last pull-request as I bumped the wrong branch from my private repo.

### Bump CI build requirements:

* OS-X : 4.0.2 (latest public MDK package)
* Linux: 4.0.1 (latest in debian main, non-pinned version)

### Added exe wrapper for CustomBuildTasks.dll to allow travis project building/running using xunit runner console with the following:

* Xamarian Studio v5.9.x+ / MonoDevelop v5.9.x+
* mdtool (matching version from above's IDE installation)
* xbuild (from mono 4.0.1+ installation)
	
### xplat building via cmd line or IDE (Xamarin Studio / MonoDevelop)

### Build the wrapper for project's custom build tasks:

    xbuild Lib/CustomBuildTasks/CustomBuildTasksExe/CustomBuildTasksExe.csproj

### Build LibGit2Sharp.dll:

    xbuild LibGit2Sharp.Tests/LibGit2Sharp.Tests.cspro

### Build and Run xUnit tests:

    xbuild LibGit2Sharp/LibGit2Sharp.csproj
    cd LibGit2Sharp.Tests/bin/Debug
    mono ../../../packages/xunit.runners.1.9.2/tools/xunit.console.exe LibGit2Sharp.Tests.dll

