### PR TITLE
Filter fixes

### DIFF
--- a/LibGit2Sharp.Tests/FilterFixture.cs
+++ b/LibGit2Sharp.Tests/FilterFixture.cs
@@ -219,9 +219,13 @@ namespace LibGit2Sharp.Tests
                 FileInfo contentFile = new FileInfo(filePath);
                 using (var writer = new StreamWriter(contentFile.OpenWrite()) { AutoFlush = true })
                 {
-                    for (int i = 0; i < ContentLength / content.Length; i++)
+                    int remain = ContentLength;
+
+                    while (remain > 0)
                     {
-                        writer.Write(content);
+                        int chunkSize = remain > content.Length ? content.Length : remain;
+                        writer.Write(content, 0, chunkSize);
+                        remain -= chunkSize;
                     }
                 }
 

--- a/LibGit2Sharp.Tests/FilterFixture.cs
+++ b/LibGit2Sharp.Tests/FilterFixture.cs
@@ -69,9 +69,14 @@ namespace LibGit2Sharp.Tests
                                         initializeCallback);
             var registration = GlobalSettings.RegisterFilter(filter);
 
-            Assert.False(called);
-
-            GlobalSettings.DeregisterFilter(registration);
+            try
+            {
+                Assert.False(called);
+            }
+            finally
+            {
+                GlobalSettings.DeregisterFilter(registration);
+            }
         }
 
         [Fact]
@@ -89,16 +94,22 @@ namespace LibGit2Sharp.Tests
                                         successCallback,
                                         initializeCallback);
             var registration = GlobalSettings.RegisterFilter(filter);
-            Assert.False(called);
 
-            string repoPath = InitNewRepository();
-            using (var repo = CreateTestRepository(repoPath))
+            try
             {
-                StageNewFile(repo);
-                Assert.True(called);
-            }
+                Assert.False(called);
 
-            GlobalSettings.DeregisterFilter(registration);
+                string repoPath = InitNewRepository();
+                using (var repo = CreateTestRepository(repoPath))
+                {
+                    StageNewFile(repo);
+                    Assert.True(called);
+                }
+            }
+            finally
+            {
+                GlobalSettings.DeregisterFilter(registration);
+            }
         }
 
         [Fact]
@@ -116,13 +127,18 @@ namespace LibGit2Sharp.Tests
             var filter = new FakeFilter(FilterName, attributes, clean);
             var registration = GlobalSettings.RegisterFilter(filter);
 
-            using (var repo = CreateTestRepository(repoPath))
+            try
             {
-                StageNewFile(repo);
-                Assert.True(called);
+                using (var repo = CreateTestRepository(repoPath))
+                {
+                    StageNewFile(repo);
+                    Assert.True(called);
+                }
             }
-
-            GlobalSettings.DeregisterFilter(registration);
+            finally
+            {
+                GlobalSettings.DeregisterFilter(registration);
+            }
         }
 
         [Fact]
@@ -138,17 +154,22 @@ namespace LibGit2Sharp.Tests
             var filter = new FakeFilter(FilterName, attributes, cleanCallback);
             var registration = GlobalSettings.RegisterFilter(filter);
 
-            using (var repo = CreateTestRepository(repoPath))
+            try
             {
-                FileInfo expectedFile = StageNewFile(repo, decodedInput);
-                var commit = repo.Commit("Clean that file");
-                var blob = (Blob)commit.Tree[expectedFile.Name].Target;
+                using (var repo = CreateTestRepository(repoPath))
+                {
+                    FileInfo expectedFile = StageNewFile(repo, decodedInput);
+                    var commit = repo.Commit("Clean that file");
+                    var blob = (Blob)commit.Tree[expectedFile.Name].Target;
 
-                var textDetected = blob.GetContentText();
-                Assert.Equal(encodedInput, textDetected);
+                    var textDetected = blob.GetContentText();
+                    Assert.Equal(encodedInput, textDetected);
+                }
             }
-
-            GlobalSettings.DeregisterFilter(registration);
+            finally
+            {
+                GlobalSettings.DeregisterFilter(registration);
+            }
         }
 
         [Fact]
@@ -165,13 +186,18 @@ namespace LibGit2Sharp.Tests
             var filter = new FakeFilter(FilterName, attributes, null, smudgeCallback);
             var registration = GlobalSettings.RegisterFilter(filter);
 
-            FileInfo expectedFile = CheckoutFileForSmudge(repoPath, branchName, encodedInput);
+            try
+            {
+                FileInfo expectedFile = CheckoutFileForSmudge(repoPath, branchName, encodedInput);
 
-            string combine = Path.Combine(repoPath, "..", expectedFile.Name);
-            string readAllText = File.ReadAllText(combine);
-            Assert.Equal(decodedInput, readAllText);
-
-            GlobalSettings.DeregisterFilter(registration);
+                string combine = Path.Combine(repoPath, "..", expectedFile.Name);
+                string readAllText = File.ReadAllText(combine);
+                Assert.Equal(decodedInput, readAllText);
+            }
+            finally
+            {
+                GlobalSettings.DeregisterFilter(registration);
+            }
         }
 
         [Fact]
@@ -187,51 +213,56 @@ namespace LibGit2Sharp.Tests
             var filter = new FileExportFilter(FilterName, attributes);
             var registration = GlobalSettings.RegisterFilter(filter);
 
-            string filePath = Path.Combine(Directory.GetParent(repoPath).Parent.FullName, Guid.NewGuid().ToString() + ".blob");
-            FileInfo contentFile = new FileInfo(filePath);
-            using (var writer = new StreamWriter(contentFile.OpenWrite()) { AutoFlush = true })
+            try
             {
-                for (int i = 0; i < ContentLength / content.Length; i++)
+                string filePath = Path.Combine(Directory.GetParent(repoPath).Parent.FullName, Guid.NewGuid().ToString() + ".blob");
+                FileInfo contentFile = new FileInfo(filePath);
+                using (var writer = new StreamWriter(contentFile.OpenWrite()) { AutoFlush = true })
                 {
-                    writer.Write(content);
+                    for (int i = 0; i < ContentLength / content.Length; i++)
+                    {
+                        writer.Write(content);
+                    }
                 }
-            }
 
-            string attributesPath = Path.Combine(Directory.GetParent(repoPath).Parent.FullName, ".gitattributes");
-            FileInfo attributesFile = new FileInfo(attributesPath);
+                string attributesPath = Path.Combine(Directory.GetParent(repoPath).Parent.FullName, ".gitattributes");
+                FileInfo attributesFile = new FileInfo(attributesPath);
 
-            string configPath = CreateConfigurationWithDummyUser(Constants.Signature);
-            var repositoryOptions = new RepositoryOptions { GlobalConfigurationLocation = configPath };
+                string configPath = CreateConfigurationWithDummyUser(Constants.Signature);
+                var repositoryOptions = new RepositoryOptions { GlobalConfigurationLocation = configPath };
 
-            using (Repository repo = new Repository(repoPath, repositoryOptions))
-            {
-                File.WriteAllText(attributesPath, "*.blob filter=test");
-                repo.Stage(attributesFile.Name);
-                repo.Stage(contentFile.Name);
-                repo.Commit("test");
+                using (Repository repo = new Repository(repoPath, repositoryOptions))
+                {
+                    File.WriteAllText(attributesPath, "*.blob filter=test");
+                    repo.Stage(attributesFile.Name);
+                    repo.Stage(contentFile.Name);
+                    repo.Commit("test");
+                    contentFile.Delete();
+                    repo.Checkout("HEAD", new CheckoutOptions() { CheckoutModifiers = CheckoutModifiers.Force });
+                }
+
+                contentFile = new FileInfo(filePath);
+                Assert.True(contentFile.Exists, "Contents not restored correctly by forced checkout.");
+                using (StreamReader reader = contentFile.OpenText())
+                {
+                    int totalRead = 0;
+                    char[] block = new char[1024];
+                    int read;
+                    while ((read = reader.Read(block, 0, block.Length)) > 0)
+                    {
+                        Assert.True(CharArrayAreEqual(block, content, read));
+                        totalRead += read;
+                    }
+
+                    Assert.Equal(ContentLength, totalRead);
+                }
+
                 contentFile.Delete();
-                repo.Checkout("HEAD", new CheckoutOptions() { CheckoutModifiers = CheckoutModifiers.Force });
             }
-
-            contentFile = new FileInfo(filePath);
-            Assert.True(contentFile.Exists, "Contents not restored correctly by forced checkout.");
-            using (StreamReader reader = contentFile.OpenText())
+            finally
             {
-                int totalRead = 0;
-                char[] block = new char[1024];
-                int read;
-                while ((read = reader.Read(block, 0, block.Length)) > 0)
-                {
-                    Assert.True(CharArrayAreEqual(block, content, read));
-                    totalRead += read;
-                }
-
-                Assert.Equal(ContentLength, totalRead);
+                GlobalSettings.DeregisterFilter(registration);
             }
-
-            contentFile.Delete();
-
-            GlobalSettings.DeregisterFilter(registration);
         }
 
         [Fact]

--- a/LibGit2Sharp.Tests/TestHelpers/FileExportFilter.cs
+++ b/LibGit2Sharp.Tests/TestHelpers/FileExportFilter.cs
@@ -19,6 +19,20 @@ namespace LibGit2Sharp.Tests.TestHelpers
             FilesFiltered = new HashSet<string>();
         }
 
+        protected override void Create(string path, string root, FilterMode mode)
+        {
+            if (mode == FilterMode.Clean)
+            {
+                string filename = Path.GetFileName(path);
+                string cachePath = Path.Combine(root, ".git", filename);
+
+                if (File.Exists(cachePath))
+                {
+                    File.Delete(cachePath);
+                }
+            }
+        }
+
         protected override void Clean(string path, string root, Stream input, Stream output)
         {
             CleanCalledCount++;

--- a/LibGit2Sharp/Filter.cs
+++ b/LibGit2Sharp/Filter.cs
@@ -113,6 +113,16 @@ namespace LibGit2Sharp
         { }
 
         /// <summary>
+        /// Indicates that a filter is going to be applied for the given file for
+        /// the given mode.
+        /// </summary>
+        /// <param name="path">The path of the file being filtered</param>
+        /// <param name="root">The path of the working directory for the owning repository</param>
+        /// <param name="mode">The filter mode</param>
+        protected virtual void Create(string path, string root, FilterMode mode)
+        { }
+
+        /// <summary>
         /// Clean the input stream and write to the output stream.
         /// </summary>
         /// <param name="path">The path of the file being filtered</param>
@@ -234,6 +244,8 @@ namespace LibGit2Sharp
                 Marshal.PtrToStructure(nextPtr, nextStream);
                 filterSource = FilterSource.FromNativePtr(filterSourcePtr);
                 output = new WriteStream(nextStream, nextPtr);
+
+                Create(filterSource.Path, filterSource.Root, filterSource.SourceMode);
             }
             catch (Exception exception)
             {

--- a/LibGit2Sharp/Filter.cs
+++ b/LibGit2Sharp/Filter.cs
@@ -320,7 +320,6 @@ namespace LibGit2Sharp
                 Ensure.ArgumentNotZeroIntPtr(buffer, "buffer");
                 Ensure.ArgumentIsExpectedIntPtr(stream, thisPtr, "stream");
 
-                string tempFileName = Path.GetTempFileName();
                 using (UnmanagedMemoryStream input = new UnmanagedMemoryStream((byte*)buffer.ToPointer(), (long)len))
                 using (BufferedStream outputBuffer = new BufferedStream(output, BufferSize))
                 {
@@ -339,9 +338,6 @@ namespace LibGit2Sharp
                             return (int)GitErrorCode.Ambiguous;
                     }
                 }
-
-                // clean up after outselves
-                File.Delete(tempFileName);
             }
             catch (Exception exception)
             {


### PR DESCRIPTION
Some fixes around custom filters.

Primarily, this provides a new Create() method that filters can override, which will indicate to them when a new file is being filtered.

In our test, this allows us to delete any file that may have existed.  The problem here is that with the new racy-git handling, we re-run the filter.  This caused us to continue to append the workdir data, as if we had never seen the EOF.

Other filters, though, will likely want to know when they start filtering a file.