### PR TITLE
Certificate validation callback

### DIFF
--- a/LibGit2Sharp.Tests/CloneFixture.cs
+++ b/LibGit2Sharp.Tests/CloneFixture.cs
@@ -237,6 +237,66 @@ namespace LibGit2Sharp.Tests
             }
         }
 
+        [SkippableTheory]
+        [InlineData("https://github.com/libgit2/TestGitRepository.git", "github.com", typeof(CertificateX509))]
+        [InlineData("git@github.com:libgit2/TestGitRepository.git", "github.com", typeof(CertificateSsh))]
+        public void CanInspectCertificateOnClone(string url, string hostname, Type certType)
+        {
+            var scd = BuildSelfCleaningDirectory();
+
+            InconclusiveIf(
+                () =>
+                    certType == typeof (CertificateSsh) && !GlobalSettings.Version.Features.HasFlag(BuiltInFeatures.Ssh),
+                "SSH not supported");
+
+            bool wasCalled = false;
+            bool checksHappy = false;
+
+            var options = new CloneOptions {
+                CertificateCheck = (cert, valid, host) => {
+                    wasCalled = true;
+
+                    Assert.Equal(hostname, host);
+                    Assert.Equal(certType, cert.GetType());
+
+                    if (certType == typeof(CertificateX509)) {
+                        Assert.True(valid);
+                        var x509 = ((CertificateX509)cert).Certificate;
+                        // we get a string with the different fields instead of a structure, so...
+                        Assert.True(x509.Subject.Contains("CN=github.com,"));
+                        checksHappy = true;
+                        return false;
+                    }
+
+                    if (certType == typeof(CertificateSsh)) {
+                        var hostkey = (CertificateSsh)cert;
+                        Assert.True(hostkey.HasMD5);
+                        /*
+                         * Once you've connected and thus your ssh has stored the hostkey,
+                         * you can get the hostkey for a host with
+                         *
+                         *     ssh-keygen -F github.com -l | tail -n 1 | cut -d ' ' -f 2 | tr -d ':'
+                         *
+                         * though GitHub's hostkey won't change anytime soon.
+                         */
+                        Assert.Equal("1627aca576282d36631b564debdfa648",
+                            BitConverter.ToString(hostkey.HashMD5).ToLower().Replace("-", ""));
+                        checksHappy = true;
+                        return false;
+                    }
+
+                    return false;
+                },
+            };
+
+            Assert.Throws<UserCancelledException>(() =>
+                Repository.Clone(url, scd.DirectoryPath, options)
+            );
+
+            Assert.True(wasCalled);
+            Assert.True(checksHappy);
+        }
+
         [Fact]
         public void CloningAnUrlWithoutPathThrows()
         {

--- a/LibGit2Sharp/Certificate.cs
+++ b/LibGit2Sharp/Certificate.cs
@@ -1,0 +1,9 @@
+﻿namespace LibGit2Sharp
+{
+    /// <summary>
+    /// Top-level certificate type. The usable certificates inherit from this class.
+    /// </summary>
+    public abstract class Certificate
+    {
+    }
+}

--- a/LibGit2Sharp/CertificateSsh.cs
+++ b/LibGit2Sharp/CertificateSsh.cs
@@ -1,0 +1,53 @@
+﻿using LibGit2Sharp.Core;
+
+namespace LibGit2Sharp
+{
+    /// <summary>
+    /// This class represents the hostkey which is avaiable when connecting to a SSH host.
+    /// </summary>
+    public class CertificateSsh : Certificate
+    {
+        /// <summary>
+        /// For mocking purposes
+        /// </summary>
+        protected CertificateSsh()
+        { }
+
+        /// <summary>
+        /// The MD5 hash of the host. Meaningful if <see cref="HasMD5"/> is true
+        /// </summary>
+        public readonly byte[] HashMD5;
+
+        /// <summary>
+        /// The SHA1 hash of the host. Meaningful if <see cref="HasSHA1"/> is true
+        /// </summary>
+        public readonly byte[] HashSHA1;
+
+        /// <summary>
+        /// True if we have the MD5 hostkey hash from the server
+        /// </summary>
+        public readonly bool HasMD5;
+
+        /// <summary>
+        /// True if we have the SHA1 hostkey hash from the server
+        /// </summary>
+        public readonly bool HasSHA1;
+
+        /// <summary>
+        /// True if we have the SHA1 hostkey hash from the server
+        /// </summary>public readonly bool HasSHA1;
+
+        internal CertificateSsh(GitCertificateSsh cert)
+        {
+
+            HasMD5  = cert.type.HasFlag(GitCertificateSshType.MD5);
+            HasSHA1 = cert.type.HasFlag(GitCertificateSshType.SHA1);
+
+            HashMD5 = new byte[16];
+            cert.HashMD5.CopyTo(HashMD5, 0);
+
+            HashSHA1 = new byte[20];
+            cert.HashSHA1.CopyTo(HashSHA1, 0);
+        }
+    }
+}

--- a/LibGit2Sharp/CertificateX509.cs
+++ b/LibGit2Sharp/CertificateX509.cs
@@ -1,0 +1,32 @@
+﻿using System.Runtime.InteropServices;
+using System.Security.Cryptography.X509Certificates;
+using LibGit2Sharp.Core;
+
+namespace LibGit2Sharp
+{
+    /// <summary>
+    /// Conains a X509 certificate
+    /// </summary>
+    public class CertificateX509 : Certificate
+    {
+
+        /// <summary>
+        /// For mocking purposes
+        /// </summary>
+        protected CertificateX509()
+        { }
+
+        /// <summary>
+        /// The certificate.
+        /// </summary>
+        public virtual X509Certificate Certificate { get; private set; }
+
+        internal CertificateX509(GitCertificateX509 cert)
+        {
+            int len = checked((int) cert.len.ToUInt32());
+            byte[] data = new byte[len];
+            Marshal.Copy(cert.data, data, 0, len);
+            Certificate = new X509Certificate(data);
+        }
+    }
+}

--- a/LibGit2Sharp/Core/GitCertificate.cs
+++ b/LibGit2Sharp/Core/GitCertificate.cs
@@ -1,0 +1,10 @@
+﻿using System.Runtime.InteropServices;
+
+namespace LibGit2Sharp.Core
+{
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct GitCertificate
+    {
+        public GitCertificateType type;
+    }
+}

--- a/LibGit2Sharp/Core/GitCertificateSsh.cs
+++ b/LibGit2Sharp/Core/GitCertificateSsh.cs
@@ -1,0 +1,23 @@
+﻿using System.Runtime.InteropServices;
+
+namespace LibGit2Sharp.Core
+{
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct GitCertificateSsh
+    {
+        public GitCertificateType cert_type;
+        public GitCertificateSshType type;
+
+        /// <summary>
+        /// The MD5 hash (if appropriate)
+        /// </summary>
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
+        public byte[] HashMD5;
+
+        /// <summary>
+        /// The MD5 hash (if appropriate)
+        /// </summary>
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 20)]
+        public byte[] HashSHA1;
+    }
+}

--- a/LibGit2Sharp/Core/GitCertificateSshType.cs
+++ b/LibGit2Sharp/Core/GitCertificateSshType.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace LibGit2Sharp.Core
+{
+    [Flags]
+    internal enum GitCertificateSshType
+    {
+        MD5  = (1 << 0),
+        SHA1 = (1 << 1),
+    }
+}

--- a/LibGit2Sharp/Core/GitCertificateType.cs
+++ b/LibGit2Sharp/Core/GitCertificateType.cs
@@ -1,0 +1,29 @@
+﻿namespace LibGit2Sharp.Core
+{
+    /// <summary>
+    /// Git certificate types to present to the user
+    /// </summary>
+    internal enum GitCertificateType
+    {
+        /// <summary>
+        /// No information about the certificate is available.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// The certificate is a x509 certificate
+        /// </summary>
+        X509 = 1,
+
+        /// <summary>
+        /// The "certificate" is in fact a hostkey identification for ssh.
+        /// </summary>
+        Hostkey = 2,
+
+        /// <summary>
+        /// The "certificate" is in fact a collection of `name:content` strings
+        /// containing information about the certificate.
+        /// </summary>
+        StrArray = 3,
+    }
+}

--- a/LibGit2Sharp/Core/GitCertificateX509.cs
+++ b/LibGit2Sharp/Core/GitCertificateX509.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace LibGit2Sharp.Core
+{
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct GitCertificateX509
+    {
+        /// <summary>
+        /// Type of the certificate, in this case, GitCertificateType.X509
+        /// </summary>
+        public GitCertificateType cert_type;
+        /// <summary>
+        /// Pointer to the X509 certificate data
+        /// </summary>
+        public IntPtr data;
+        /// <summary>
+        ///  The size of the certificate data
+        /// </summary>
+        public UIntPtr len;
+    }
+}

--- a/LibGit2Sharp/Core/GitRemoteCallbacks.cs
+++ b/LibGit2Sharp/Core/GitRemoteCallbacks.cs
@@ -17,7 +17,7 @@ namespace LibGit2Sharp.Core
 
         internal NativeMethods.git_cred_acquire_cb acquire_credentials;
 
-        internal IntPtr certificate_check;
+        internal NativeMethods.git_transport_certificate_check_cb certificate_check;
 
         internal NativeMethods.git_transfer_progress_callback download_progress;
 

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -1653,6 +1653,8 @@ namespace LibGit2Sharp.Core
 
         internal delegate int git_transport_cb(out IntPtr transport, IntPtr remote, IntPtr payload);
 
+        internal delegate int git_transport_certificate_check_cb(IntPtr cert, int valid, IntPtr hostname, IntPtr payload);
+
         [DllImport(libgit2)]
         internal static extern int git_transport_register(
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string prefix,

--- a/LibGit2Sharp/FetchOptionsBase.cs
+++ b/LibGit2Sharp/FetchOptionsBase.cs
@@ -34,6 +34,12 @@ namespace LibGit2Sharp
         public CredentialsHandler CredentialsProvider { get; set; }
 
         /// <summary>
+        /// This hanlder will be called to let the user make a decision on whether to allow
+        /// the connection to preoceed based on the certificate presented by the server.
+        /// </summary>
+        public CertificateCheckHandler CertificateCheck { get; set; }
+
+        /// <summary>
         /// Starting to operate on a new repository.
         /// </summary>
         public RepositoryOperationStarting RepositoryOperationStarting { get; set; }

--- a/LibGit2Sharp/Handlers.cs
+++ b/LibGit2Sharp/Handlers.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Security.Cryptography.X509Certificates;
 
 namespace LibGit2Sharp.Handlers
 {
@@ -31,6 +32,15 @@ namespace LibGit2Sharp.Handlers
     /// <param name="usernameFromUrl">Username which was extracted from the url, if any</param>
     /// <param name="types">Credential types which the server accepts</param>
     public delegate Credentials CredentialsHandler(string url, string usernameFromUrl, SupportedCredentialTypes types);
+
+    /// <summary>
+    /// Delegate definition for the certificate validation
+    /// </summary>
+    /// <param name="certificate">The certificate which the server sent</param>
+    /// <param name="host">The hostname which we tried to connect to</param>
+    /// <param name="valid">Whether libgit2 thinks this certificate is valid</param>
+    /// <returns>True to continue, false to cancel</returns>
+    public delegate bool CertificateCheckHandler(Certificate certificate, bool valid, string host);
 
     /// <summary>
     /// Delegate definition for transfer progress callback.

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -372,6 +372,14 @@
     <Compile Include="StashApplyOptions.cs" />
     <Compile Include="StashApplyStatus.cs" />
     <Compile Include="Core\GitStashApplyOpts.cs" />
+    <Compile Include="Core\GitCertificateType.cs" />
+    <Compile Include="Core\GitCertificate.cs" />
+    <Compile Include="Core\GitCertificateX509.cs" />
+    <Compile Include="Certificate.cs" />
+    <Compile Include="CertificateX509.cs" />
+    <Compile Include="Core\GitCertificateSsh.cs" />
+    <Compile Include="Core\GitCertificateSshType.cs" />
+    <Compile Include="CertificateSsh.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="CustomDictionary.xml" />

--- a/LibGit2Sharp/PushOptions.cs
+++ b/LibGit2Sharp/PushOptions.cs
@@ -13,6 +13,12 @@ namespace LibGit2Sharp
         public CredentialsHandler CredentialsProvider { get; set; }
 
         /// <summary>
+        /// This hanlder will be called to let the user make a decision on whether to allow
+        /// the connection to preoceed based on the certificate presented by the server.
+        /// </summary>
+        public CertificateCheckHandler CertificateCheck { get; set; }
+
+        /// <summary>
         /// If the transport being used to push to the remote requires the creation
         /// of a pack file, this controls the number of worker threads used by
         /// the packbuilder when creating that pack file to be sent to the remote.


### PR DESCRIPTION
The first commit is just so I can run it on my machines, the others will get squashed.

I'm not sure how deeply to specify types for the certs. ~~~Maybe it'd be fine to expose the cert like in C where the same class may contain MD5 or SHA1 hashes.~~~ It looks like I forgot that it's theoretically possible to have both hostkey hashes at once, so it should be just the one.

I don't quite expect this to actually work yet, but the types and the structs should at least be correct.

- [x] Test an X.509 certificate
- [x] Test a ssh certificate