### PR TITLE
Fixes `RebaseFixture` tests by adding .gitattributes file to repo

### DIFF
--- a/LibGit2Sharp.Tests/FilterFixture.cs
+++ b/LibGit2Sharp.Tests/FilterFixture.cs
@@ -304,7 +304,6 @@ namespace LibGit2Sharp.Tests
             return true;
         }
 
-
         private FileInfo CheckoutFileForSmudge(string repoPath, string branchName, string content)
         {
             FileInfo expectedPath;
@@ -348,11 +347,6 @@ namespace LibGit2Sharp.Tests
             var repository = new Repository(path, repositoryOptions);
             CreateAttributesFile(repository, "* filter=test");
             return repository;
-        }
-
-        private static void CreateAttributesFile(IRepository repo, string attributeEntry)
-        {
-            Touch(repo.Info.WorkingDirectory, ".gitattributes", attributeEntry);
         }
 
         class EmptyFilter : Filter

--- a/LibGit2Sharp.Tests/RebaseFixture.cs
+++ b/LibGit2Sharp.Tests/RebaseFixture.cs
@@ -62,13 +62,13 @@ namespace LibGit2Sharp.Tests
 
                 RebaseOptions options = new RebaseOptions()
                 {
-                    RebaseStepStarting =  x =>
-                    {
-                        beforeRebaseStepCountCorrect &= beforeStepCallCount == x.StepIndex;
-                        totalStepCountCorrect &= (x.TotalStepCount == stepCount);
-                        beforeStepCallCount++;
-                        PreRebaseCommits.Add(x.StepInfo.Commit);
-                    },
+                    RebaseStepStarting = x =>
+                   {
+                       beforeRebaseStepCountCorrect &= beforeStepCallCount == x.StepIndex;
+                       totalStepCountCorrect &= (x.TotalStepCount == stepCount);
+                       beforeStepCallCount++;
+                       PreRebaseCommits.Add(x.StepInfo.Commit);
+                   },
                     RebaseStepCompleted = x =>
                     {
                         afterRebaseStepCountCorrect &= (afterStepCallCount == x.CompletedStepIndex);
@@ -262,15 +262,15 @@ namespace LibGit2Sharp.Tests
 
                 List<ObjectId> expectedTreeIds = new List<ObjectId>()
                 {
-                    new ObjectId("447bad85bcc1882037848370620a6f88e8ee264e"),
-                    new ObjectId("3b0fc846952496a64b6149064cde21215daca8f8"),
-                    new ObjectId("a2d114246012daf3ef8e7ccbfbe91889a24e1e60"),
+                    new ObjectId("e20530e760c7e3009e2a482d8bcb0cd69f1ffb65"),
+                    new ObjectId("3a3b0dce3266801cf90eaa58f4b5b1f7955a49be"),
+                    new ObjectId("27559b63dd0afcb93c2058b96e91d9266466c3c4"),
                 };
 
                 List<Commit> rebasedCommits = repo.Commits.QueryBy(commitFilter).ToList();
 
                 Assert.Equal(3, rebasedCommits.Count);
-                for(int i = 0; i < 3; i++)
+                for (int i = 0; i < 3; i++)
                 {
                     Assert.Equal(expectedTreeIds[i], rebasedCommits[i].Tree.Id);
                     Assert.Equal(Constants.Signature.Name, rebasedCommits[i].Author.Name);
@@ -602,7 +602,7 @@ namespace LibGit2Sharp.Tests
 
                 repo.Checkout(topicBranch1Name);
 
-                 Branch topicBranch1Prime = repo.CreateBranch(topicBranch1PrimeName, masterBranch1Name);
+                Branch topicBranch1Prime = repo.CreateBranch(topicBranch1PrimeName, masterBranch1Name);
 
                 string newFileRelativePath = "new_file.txt";
                 Touch(repo.Info.WorkingDirectory, newFileRelativePath, "New Content");
@@ -631,7 +631,7 @@ namespace LibGit2Sharp.Tests
                 };
 
                 repo.Rebase.Start(null, upstreamBranch, null, Constants.Identity2, options);
-                ObjectId secondCommitExpectedTreeId = new ObjectId("ac04bf04980c9be72f64ba77fd0d9088a40ed681");
+                ObjectId secondCommitExpectedTreeId = new ObjectId("7845bcdf89faf2b1f992758962b333aff874ce51");
                 Signature secondCommitAuthorSignature = Constants.Signature;
                 Identity secondCommitCommiterIdentity = Constants.Identity2;
 
@@ -699,6 +699,10 @@ namespace LibGit2Sharp.Tests
 
             string workdir = repo.Info.WorkingDirectory;
             Commit commit = null;
+
+            CreateAttributesFile(repo, "* text=auto\n.gitattributes eol=lf");
+            repo.Stage(".gitattributes");
+            commit = repo.Commit("setup", Constants.Signature, Constants.Signature, new CommitOptions());
 
             Touch(workdir, filePathA, fileContentA1);
             repo.Stage(filePathA);

--- a/LibGit2Sharp.Tests/TestHelpers/BaseFixture.cs
+++ b/LibGit2Sharp.Tests/TestHelpers/BaseFixture.cs
@@ -49,7 +49,7 @@ namespace LibGit2Sharp.Tests.TestHelpers
         protected static DateTimeOffset TruncateSubSeconds(DateTimeOffset dto)
         {
             int seconds = dto.ToSecondsSinceEpoch();
-            return Epoch.ToDateTimeOffset(seconds, (int) dto.Offset.TotalMinutes);
+            return Epoch.ToDateTimeOffset(seconds, (int)dto.Offset.TotalMinutes);
         }
 
         private static void SetUpTestEnvironment()
@@ -258,7 +258,7 @@ namespace LibGit2Sharp.Tests.TestHelpers
                 throw new InvalidOperationException("Cannot access Mono.RunTime.GetDisplayName() method.");
             }
 
-            var version = (string) displayName.Invoke(null, null);
+            var version = (string)displayName.Invoke(null, null);
 
             System.Version current;
 
@@ -459,6 +459,11 @@ namespace LibGit2Sharp.Tests.TestHelpers
             where T : IBelongToARepository
         {
             Assert.Same(repo, ((IBelongToARepository)instance).Repository);
+        }
+
+        protected void CreateAttributesFile(IRepository repo, string attributeEntry)
+        {
+            Touch(repo.Info.WorkingDirectory, ".gitattributes", attributeEntry);
         }
     }
 }


### PR DESCRIPTION
Several of the tests in the `RebaseFixture` assume that `core.autocrlf = true` was set. On systems where this wasn't set to true, the tests failed. The correct solution is to not rely on `core.autocrlf` and include a `.gitattributes` file in the test repo.

Fixes #1111 