### PR TITLE
Fixes `RebaseFixture` tests by adding .gitattributes file to repo 

### DIFF
--- a/LibGit2Sharp.Tests/FilterFixture.cs
+++ b/LibGit2Sharp.Tests/FilterFixture.cs
@@ -304,7 +304,6 @@ namespace LibGit2Sharp.Tests
             return true;
         }
 
-
         private FileInfo CheckoutFileForSmudge(string repoPath, string branchName, string content)
         {
             FileInfo expectedPath;
@@ -348,11 +347,6 @@ namespace LibGit2Sharp.Tests
             var repository = new Repository(path, repositoryOptions);
             CreateAttributesFile(repository, "* filter=test");
             return repository;
-        }
-
-        private static void CreateAttributesFile(IRepository repo, string attributeEntry)
-        {
-            Touch(repo.Info.WorkingDirectory, ".gitattributes", attributeEntry);
         }
 
         class EmptyFilter : Filter

--- a/LibGit2Sharp.Tests/FilterSubstitutionCipherFixture.cs
+++ b/LibGit2Sharp.Tests/FilterSubstitutionCipherFixture.cs
@@ -216,10 +216,5 @@ namespace LibGit2Sharp.Tests
             var blob = (Blob)commit.Tree[fileName].Target;
             return blob;
         }
-
-        private static void CreateAttributesFile(IRepository repo, string attributeEntry)
-        {
-            Touch(repo.Info.WorkingDirectory, ".gitattributes", attributeEntry);
-        }
     }
 }

--- a/LibGit2Sharp.Tests/TestHelpers/BaseFixture.cs
+++ b/LibGit2Sharp.Tests/TestHelpers/BaseFixture.cs
@@ -49,7 +49,7 @@ namespace LibGit2Sharp.Tests.TestHelpers
         protected static DateTimeOffset TruncateSubSeconds(DateTimeOffset dto)
         {
             int seconds = dto.ToSecondsSinceEpoch();
-            return Epoch.ToDateTimeOffset(seconds, (int) dto.Offset.TotalMinutes);
+            return Epoch.ToDateTimeOffset(seconds, (int)dto.Offset.TotalMinutes);
         }
 
         private static void SetUpTestEnvironment()
@@ -258,7 +258,7 @@ namespace LibGit2Sharp.Tests.TestHelpers
                 throw new InvalidOperationException("Cannot access Mono.RunTime.GetDisplayName() method.");
             }
 
-            var version = (string) displayName.Invoke(null, null);
+            var version = (string)displayName.Invoke(null, null);
 
             System.Version current;
 
@@ -459,6 +459,11 @@ namespace LibGit2Sharp.Tests.TestHelpers
             where T : IBelongToARepository
         {
             Assert.Same(repo, ((IBelongToARepository)instance).Repository);
+        }
+
+        protected void CreateAttributesFile(IRepository repo, string attributeEntry)
+        {
+            Touch(repo.Info.WorkingDirectory, ".gitattributes", attributeEntry);
         }
     }
 }


### PR DESCRIPTION
Several of the tests in the `RebaseFixture` assume that `core.autocrlf = true` was set. On systems where this wasn't set to true, the tests failed. The correct solution is to not rely on `core.autocrlf` and include a `.gitattributes` file in the test repo.

Fixes #1111 

Supersedes #1136 