### PR TITLE
Explicitly set xUnit MSBuild WorkingFolder property

### DIFF
--- a/CI/build.msbuild
+++ b/CI/build.msbuild
@@ -37,7 +37,7 @@
   </Target>
 
   <Target Name="Test" DependsOnTargets="Build">
-    <xunit Assemblies="$(TestBuildDir)/LibGit2Sharp.Tests.dll" ShadowCopy="false" Xml="$(DeployFolder)/Test-result.xml" />
+    <xunit Assemblies="$(TestBuildDir)/LibGit2Sharp.Tests.dll" ShadowCopy="false" WorkingFolder="$(TestBuildDir)" Xml="$(DeployFolder)/Test-result.xml" />
   </Target>
 
   <Target Name="Deploy" DependsOnTargets="Test">


### PR DESCRIPTION
Looking at the Travis failure @nulltoken pointed out in #1138, I noticed that when it fails, it was looking for
`/home/travis/build/libgit2/Resources/testrepo.git`

which is not even in the same folder as the source code! It should be looking for

`/home/travis/build/libgit2/libgit2sharp/LibGit2Sharp.Tests/Resources/testrepo.git`

All of the test repo paths are build like this: `../../Resources/testrepo.git` so looks like xUnit is sometimes changing its working folder in the middle of testing?

I could reproduce this on my local ubuntu VM, which is running mono 3.12.1, same as Travis.
However, on my mac, I have mono 4.0.2 and it ran perfectly. Same for Windows.

I have another VM running CentOS and mono 4.0.2, and after getting the tests running there... it also ran without errors!

It seems that the xUnit.net 2.0 MSBuild test runner does not play nicely with mono 3.12.1, which is being used on the linux Travis CI builds.

Looking through the xUnit docs, I saw that there is a WorkingFolder property that can be set explicitly instead of relying on the default value. After setting that value, the failures on mono 3.12.1 seem to have vanished.