### PR TITLE
NuGet packages are no longer generated on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,8 +57,8 @@ install:
     Write-Host "Should run Coverity analysis = " -NoNewLine
     Write-Host $Env:SHOULD_RUN_COVERITY_ANALYSIS -ForegroundColor "Green"
 
-    $Env:SHOULD_PACKAGE_NUGET_ARTIFACT = $($Env:APPVEYOR_PULL_REQUEST_NUMBER -eq $null `
-                                               -and $Env:APPVEYOR_SCHEDULED_BUILD -eq $False)
+    $Env:SHOULD_PACKAGE_NUGET_ARTIFACT = $($($Env:APPVEYOR_PULL_REQUEST_NUMBER -eq $null) `
+                                               -and $($Env:APPVEYOR_SCHEDULED_BUILD -eq $False))
     Write-Host "Should package Nuget artifact = " -NoNewLine
     Write-Host $Env:SHOULD_PACKAGE_NUGET_ARTIFACT -ForegroundColor "Green"
 


### PR DESCRIPTION
Latest published package has been successfully performed with https://ci.appveyor.com/project/libgit2/libgit2sharp/build/868

Stopped working with https://ci.appveyor.com/project/libgit2/libgit2sharp/build/890

Which seems to put the issue in https://github.com/libgit2/libgit2sharp/compare/77691c271a87c4493d3e0146dda53ec231797e88...2a283297ee33cfa2e819577146934f483a6c189c

