### PR TITLE
CommitFilter ahead/behind are confusing...

### DIFF
--- a/LibGit2Sharp.Tests/CommitFixture.cs
+++ b/LibGit2Sharp.Tests/CommitFixture.cs
@@ -92,7 +92,7 @@ namespace LibGit2Sharp.Tests
             string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
-                foreach (Commit commit in repo.Commits.QueryBy(new CommitFilter { Since = "a4a7dce85cf63874e984719f4fdd239f5145052f" }))
+                foreach (Commit commit in repo.Commits.QueryBy(new CommitFilter { IncludeReachableFrom = "a4a7dce85cf63874e984719f4fdd239f5145052f" }))
                 {
                     Assert.NotNull(commit);
                     count++;
@@ -107,9 +107,9 @@ namespace LibGit2Sharp.Tests
             string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
-                Assert.Throws<NotFoundException>(() => repo.Commits.QueryBy(new CommitFilter { Since = Constants.UnknownSha }).Count());
-                Assert.Throws<NotFoundException>(() => repo.Commits.QueryBy(new CommitFilter { Since = "refs/heads/deadbeef" }).Count());
-                Assert.Throws<ArgumentNullException>(() => repo.Commits.QueryBy(new CommitFilter { Since = null }).Count());
+                Assert.Throws<NotFoundException>(() => repo.Commits.QueryBy(new CommitFilter { IncludeReachableFrom = Constants.UnknownSha }).Count());
+                Assert.Throws<NotFoundException>(() => repo.Commits.QueryBy(new CommitFilter { IncludeReachableFrom = "refs/heads/deadbeef" }).Count());
+                Assert.Throws<ArgumentNullException>(() => repo.Commits.QueryBy(new CommitFilter { IncludeReachableFrom = null }).Count());
             }
         }
 
@@ -121,8 +121,8 @@ namespace LibGit2Sharp.Tests
             {
                 CreateCorruptedDeadBeefHead(repo.Info.Path);
 
-                Assert.Throws<NotFoundException>(() => repo.Commits.QueryBy(new CommitFilter { Since = repo.Branches["deadbeef"] }).Count());
-                Assert.Throws<NotFoundException>(() => repo.Commits.QueryBy(new CommitFilter { Since = repo.Refs["refs/heads/deadbeef"] }).Count());
+                Assert.Throws<NotFoundException>(() => repo.Commits.QueryBy(new CommitFilter { IncludeReachableFrom = repo.Branches["deadbeef"] }).Count());
+                Assert.Throws<NotFoundException>(() => repo.Commits.QueryBy(new CommitFilter { IncludeReachableFrom = repo.Refs["refs/heads/deadbeef"] }).Count());
             }
         }
 
@@ -132,8 +132,8 @@ namespace LibGit2Sharp.Tests
             string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
-                Assert.Throws<ArgumentException>(() => repo.Commits.QueryBy(new CommitFilter { Since = string.Empty }));
-                Assert.Throws<ArgumentNullException>(() => repo.Commits.QueryBy(new CommitFilter { Since = null }));
+                Assert.Throws<ArgumentException>(() => repo.Commits.QueryBy(new CommitFilter { IncludeReachableFrom = string.Empty }));
+                Assert.Throws<ArgumentNullException>(() => repo.Commits.QueryBy(new CommitFilter { IncludeReachableFrom = null }));
                 Assert.Throws<ArgumentNullException>(() => repo.Commits.QueryBy(default(CommitFilter)));
             }
         }
@@ -150,7 +150,7 @@ namespace LibGit2Sharp.Tests
             {
                 foreach (Commit commit in repo.Commits.QueryBy(new CommitFilter
                                                                     {
-                                                                        Since = "a4a7dce85cf63874e984719f4fdd239f5145052f",
+                                                                        IncludeReachableFrom = "a4a7dce85cf63874e984719f4fdd239f5145052f",
                                                                         SortBy = CommitSortStrategies.Time | CommitSortStrategies.Reverse
                                                                     }))
                 {
@@ -170,7 +170,7 @@ namespace LibGit2Sharp.Tests
             {
                 List<Commit> commits = repo.Commits.QueryBy(new CommitFilter
                                                                 {
-                                                                    Since = "a4a7dce85cf63874e984719f4fdd239f5145052f",
+                                                                    IncludeReachableFrom = "a4a7dce85cf63874e984719f4fdd239f5145052f",
                                                                     SortBy = CommitSortStrategies.Time | CommitSortStrategies.Reverse
                                                                 }).ToList();
                 foreach (Commit commit in commits)
@@ -189,7 +189,7 @@ namespace LibGit2Sharp.Tests
         public void CanSimplifyByFirstParent()
         {
             AssertEnumerationOfCommits(
-                repo => new CommitFilter { Since = repo.Head, FirstParentOnly = true },
+                repo => new CommitFilter { IncludeReachableFrom = repo.Head, FirstParentOnly = true },
             new[]
             {
                 "4c062a6", "be3563a", "9fd738e",
@@ -216,7 +216,7 @@ namespace LibGit2Sharp.Tests
             {
                 foreach (Commit commit in repo.Commits.QueryBy(new CommitFilter
                                                                     {
-                                                                        Since = "a4a7dce85cf63874e984719f4fdd239f5145052f",
+                                                                        IncludeReachableFrom = "a4a7dce85cf63874e984719f4fdd239f5145052f",
                                                                         SortBy = CommitSortStrategies.Time
                                                                     }))
                 {
@@ -236,7 +236,7 @@ namespace LibGit2Sharp.Tests
             {
                 List<Commit> commits = repo.Commits.QueryBy(new CommitFilter
                                                                 {
-                                                                    Since = "a4a7dce85cf63874e984719f4fdd239f5145052f",
+                                                                    IncludeReachableFrom = "a4a7dce85cf63874e984719f4fdd239f5145052f",
                                                                     SortBy = CommitSortStrategies.Topological
                                                                 }).ToList();
                 foreach (Commit commit in commits)
@@ -255,7 +255,7 @@ namespace LibGit2Sharp.Tests
         public void CanEnumerateFromHead()
         {
             AssertEnumerationOfCommits(
-                repo => new CommitFilter { Since = repo.Head },
+                repo => new CommitFilter { IncludeReachableFrom = repo.Head },
                 new[]
                     {
                         "4c062a6", "be3563a", "c47800c", "9fd738e",
@@ -277,7 +277,7 @@ namespace LibGit2Sharp.Tests
                 repoClone.Checkout(headSha);
 
                 AssertEnumerationOfCommitsInRepo(repoClone,
-                    repo => new CommitFilter { Since = repo.Head },
+                    repo => new CommitFilter { IncludeReachableFrom = repo.Head },
                     new[]
                         {
                             "32eab9c", "592d3c8", "4c062a6",
@@ -291,7 +291,7 @@ namespace LibGit2Sharp.Tests
         public void CanEnumerateUsingTwoHeadsAsBoundaries()
         {
             AssertEnumerationOfCommits(
-                repo => new CommitFilter { Since = "HEAD", Until = "refs/heads/br2" },
+                repo => new CommitFilter { IncludeReachableFrom = "HEAD", ExcludeReachableFrom = "refs/heads/br2" },
                 new[] { "4c062a6", "be3563a" }
                 );
         }
@@ -300,7 +300,7 @@ namespace LibGit2Sharp.Tests
         public void CanEnumerateUsingImplicitHeadAsSinceBoundary()
         {
             AssertEnumerationOfCommits(
-                repo => new CommitFilter { Until = "refs/heads/br2" },
+                repo => new CommitFilter { ExcludeReachableFrom = "refs/heads/br2" },
                 new[] { "4c062a6", "be3563a" }
                 );
         }
@@ -309,7 +309,7 @@ namespace LibGit2Sharp.Tests
         public void CanEnumerateUsingTwoAbbreviatedShasAsBoundaries()
         {
             AssertEnumerationOfCommits(
-                repo => new CommitFilter { Since = "a4a7dce", Until = "4a202b3" },
+                repo => new CommitFilter { IncludeReachableFrom = "a4a7dce", ExcludeReachableFrom = "4a202b3" },
                 new[] { "a4a7dce", "c47800c", "9fd738e" }
                 );
         }
@@ -318,7 +318,7 @@ namespace LibGit2Sharp.Tests
         public void CanEnumerateCommitsFromTwoHeads()
         {
             AssertEnumerationOfCommits(
-                repo => new CommitFilter { Since = new[] { "refs/heads/br2", "refs/heads/master" } },
+                repo => new CommitFilter { IncludeReachableFrom = new[] { "refs/heads/br2", "refs/heads/master" } },
                 new[]
                     {
                         "4c062a6", "a4a7dce", "be3563a", "c47800c",
@@ -330,7 +330,7 @@ namespace LibGit2Sharp.Tests
         public void CanEnumerateCommitsFromMixedStartingPoints()
         {
             AssertEnumerationOfCommits(
-                repo => new CommitFilter { Since = new object[] { repo.Branches["br2"],
+                repo => new CommitFilter { IncludeReachableFrom = new object[] { repo.Branches["br2"],
                                                             "refs/heads/master",
                                                             new ObjectId("e90810b8df3e80c413d903f631643c716887138d") } },
                 new[]
@@ -345,7 +345,7 @@ namespace LibGit2Sharp.Tests
         public void CanEnumerateCommitsUsingGlob()
         {
             AssertEnumerationOfCommits(
-                repo => new CommitFilter { Since = repo.Refs.FromGlob("refs/heads/*") },
+                repo => new CommitFilter { IncludeReachableFrom = repo.Refs.FromGlob("refs/heads/*") },
                 new[]
                    {
                        "4c062a6", "e90810b", "6dcf9bf", "a4a7dce", "be3563a", "c47800c", "9fd738e", "4a202b3", "41bc8c6", "5001298", "5b5b025", "8496071"
@@ -356,7 +356,7 @@ namespace LibGit2Sharp.Tests
         public void CanHideCommitsUsingGlob()
         {
             AssertEnumerationOfCommits(
-                repo => new CommitFilter { Since = "refs/heads/packed-test", Until = repo.Refs.FromGlob("*/packed") },
+                repo => new CommitFilter { IncludeReachableFrom = "refs/heads/packed-test", ExcludeReachableFrom = repo.Refs.FromGlob("*/packed") },
                 new[]
                    {
                        "4a202b3", "5b5b025", "8496071"
@@ -378,7 +378,7 @@ namespace LibGit2Sharp.Tests
         private void CanEnumerateCommitsFromATag(Func<Tag, object> transformer)
         {
             AssertEnumerationOfCommits(
-                repo => new CommitFilter { Since = transformer(repo.Tags["test"]) },
+                repo => new CommitFilter { IncludeReachableFrom = transformer(repo.Tags["test"]) },
                 new[] { "e90810b", "6dcf9bf", }
                 );
         }
@@ -389,7 +389,7 @@ namespace LibGit2Sharp.Tests
             AssertEnumerationOfCommits(
                 repo => new CommitFilter
                     {
-                        Since = repo.Refs.OrderBy(r => r.CanonicalName, StringComparer.Ordinal),
+                        IncludeReachableFrom = repo.Refs.OrderBy(r => r.CanonicalName, StringComparer.Ordinal),
                     },
                 new[]
                     {
@@ -404,7 +404,7 @@ namespace LibGit2Sharp.Tests
         public void CanEnumerateCommitsFromATagWhichPointsToABlob()
         {
             AssertEnumerationOfCommits(
-                repo => new CommitFilter { Since = repo.Tags["point_to_blob"] },
+                repo => new CommitFilter { IncludeReachableFrom = repo.Tags["point_to_blob"] },
                 new string[] { });
         }
 
@@ -419,7 +419,7 @@ namespace LibGit2Sharp.Tests
                 Tag tag = repo.ApplyTag("point_to_tree", headTreeSha);
 
                 AssertEnumerationOfCommitsInRepo(repo,
-                    r => new CommitFilter { Since = tag },
+                    r => new CommitFilter { IncludeReachableFrom = tag },
                     new string[] { });
             }
         }
@@ -880,10 +880,10 @@ namespace LibGit2Sharp.Tests
                 var filter = new CommitFilter
                                  {
                                      /* Revwalk from all the refs (git log --all) ... */
-                                     Since = repo.Refs,
+                                     IncludeReachableFrom = repo.Refs,
 
                                      /* ... and stop when the parent is reached */
-                                     Until = parentSha
+                                     ExcludeReachableFrom = parentSha
                                  };
 
                 var commits = repo.Commits.QueryBy(filter);

--- a/LibGit2Sharp.Tests/FilterBranchFixture.cs
+++ b/LibGit2Sharp.Tests/FilterBranchFixture.cs
@@ -29,7 +29,7 @@ namespace LibGit2Sharp.Tests
         public void CanRewriteHistoryWithoutChangingCommitMetadata()
         {
             var originalRefs = repo.Refs.ToList().OrderBy(r => r.CanonicalName);
-            var commits = repo.Commits.QueryBy(new CommitFilter { Since = repo.Refs }).ToArray();
+            var commits = repo.Commits.QueryBy(new CommitFilter { IncludeReachableFrom = repo.Refs }).ToArray();
 
             // Noop header rewriter
             repo.Refs.RewriteHistory(new RewriteHistoryOptions
@@ -42,14 +42,14 @@ namespace LibGit2Sharp.Tests
             AssertSucceedingButNotError();
 
             Assert.Equal(originalRefs, repo.Refs.ToList().OrderBy(r => r.CanonicalName));
-            Assert.Equal(commits, repo.Commits.QueryBy(new CommitFilter { Since = repo.Refs }).ToArray());
+            Assert.Equal(commits, repo.Commits.QueryBy(new CommitFilter { IncludeReachableFrom = repo.Refs }).ToArray());
         }
 
         [Fact]
         public void CanRewriteHistoryWithoutChangingTrees()
         {
             var originalRefs = repo.Refs.ToList().OrderBy(r => r.CanonicalName);
-            var commits = repo.Commits.QueryBy(new CommitFilter { Since = repo.Refs }).ToArray();
+            var commits = repo.Commits.QueryBy(new CommitFilter { IncludeReachableFrom = repo.Refs }).ToArray();
 
             // Noop tree rewriter
             repo.Refs.RewriteHistory(new RewriteHistoryOptions
@@ -62,14 +62,14 @@ namespace LibGit2Sharp.Tests
             AssertSucceedingButNotError();
 
             Assert.Equal(originalRefs, repo.Refs.ToList().OrderBy(r => r.CanonicalName));
-            Assert.Equal(commits, repo.Commits.QueryBy(new CommitFilter { Since = repo.Refs }).ToArray());
+            Assert.Equal(commits, repo.Commits.QueryBy(new CommitFilter { IncludeReachableFrom = repo.Refs }).ToArray());
         }
 
         [Fact]
         public void CanRollbackRewriteByThrowingInOnCompleting()
         {
             var originalRefs = repo.Refs.ToList().OrderBy(r => r.CanonicalName);
-            var commits = repo.Commits.QueryBy(new CommitFilter { Since = repo.Refs }).ToArray();
+            var commits = repo.Commits.QueryBy(new CommitFilter { IncludeReachableFrom = repo.Refs }).ToArray();
 
             Assert.Throws<Exception>(
                 () =>
@@ -90,14 +90,14 @@ namespace LibGit2Sharp.Tests
             AssertSucceedingButNotError();
 
             Assert.Equal(originalRefs, repo.Refs.ToList().OrderBy(r => r.CanonicalName));
-            Assert.Equal(commits, repo.Commits.QueryBy(new CommitFilter { Since = repo.Refs }).ToArray());
+            Assert.Equal(commits, repo.Commits.QueryBy(new CommitFilter { IncludeReachableFrom = repo.Refs }).ToArray());
         }
 
         [Fact]
         public void ErrorThrownInOnErrorTakesPrecedenceOverErrorDuringCommitHeaderRewriter()
         {
             var originalRefs = repo.Refs.ToList().OrderBy(r => r.CanonicalName);
-            var commits = repo.Commits.QueryBy(new CommitFilter { Since = repo.Refs }).ToArray();
+            var commits = repo.Commits.QueryBy(new CommitFilter { IncludeReachableFrom = repo.Refs }).ToArray();
 
             var thrown = Assert.Throws<Exception>(
                 () =>
@@ -117,14 +117,14 @@ namespace LibGit2Sharp.Tests
             Assert.Equal("From CommitHeaderRewriter", thrown.InnerException.Message);
 
             Assert.Equal(originalRefs, repo.Refs.ToList().OrderBy(r => r.CanonicalName));
-            Assert.Equal(commits, repo.Commits.QueryBy(new CommitFilter { Since = repo.Refs }).ToArray());
+            Assert.Equal(commits, repo.Commits.QueryBy(new CommitFilter { IncludeReachableFrom = repo.Refs }).ToArray());
         }
 
         [Fact]
         public void ErrorThrownInOnErrorTakesPrecedenceOverErrorDuringCommitTreeRewriter()
         {
             var originalRefs = repo.Refs.ToList().OrderBy(r => r.CanonicalName);
-            var commits = repo.Commits.QueryBy(new CommitFilter { Since = repo.Refs }).ToArray();
+            var commits = repo.Commits.QueryBy(new CommitFilter { IncludeReachableFrom = repo.Refs }).ToArray();
 
             var thrown = Assert.Throws<Exception>(
                 () =>
@@ -144,13 +144,13 @@ namespace LibGit2Sharp.Tests
             Assert.Equal("From CommitTreeRewriter", thrown.InnerException.Message);
 
             Assert.Equal(originalRefs, repo.Refs.ToList().OrderBy(r => r.CanonicalName));
-            Assert.Equal(commits, repo.Commits.QueryBy(new CommitFilter { Since = repo.Refs }).ToArray());
+            Assert.Equal(commits, repo.Commits.QueryBy(new CommitFilter { IncludeReachableFrom = repo.Refs }).ToArray());
         }
 
         [Fact]
         public void CanRewriteAuthorOfCommits()
         {
-            var commits = repo.Commits.QueryBy(new CommitFilter { Since = repo.Refs }).ToArray();
+            var commits = repo.Commits.QueryBy(new CommitFilter { IncludeReachableFrom = repo.Refs }).ToArray();
             repo.Refs.RewriteHistory(new RewriteHistoryOptions
             {
                 OnError = OnError,
@@ -164,7 +164,7 @@ namespace LibGit2Sharp.Tests
 
             var nonBackedUpRefs = repo.Refs.Where(
                 x => !x.CanonicalName.StartsWith("refs/original/") && !x.CanonicalName.StartsWith("refs/notes/"));
-            Assert.Empty(repo.Commits.QueryBy(new CommitFilter { Since = nonBackedUpRefs })
+            Assert.Empty(repo.Commits.QueryBy(new CommitFilter { IncludeReachableFrom = nonBackedUpRefs })
                              .Where(c => c.Author.Name != "Ben Straub"));
         }
 
@@ -217,7 +217,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanRewriteTreesByInjectingTreeEntry()
         {
-            var commits = repo.Commits.QueryBy(new CommitFilter { Since = repo.Branches }).ToArray();
+            var commits = repo.Commits.QueryBy(new CommitFilter { IncludeReachableFrom = repo.Branches }).ToArray();
 
             var currentReadme = repo.Head["README"];
 
@@ -236,7 +236,7 @@ namespace LibGit2Sharp.Tests
 
             Assert.Equal(new Commit[0],
                          repo.Commits
-                             .QueryBy(new CommitFilter {Since = repo.Branches})
+                             .QueryBy(new CommitFilter {IncludeReachableFrom = repo.Branches})
                              .Where(c => c["README"] != null
                                          && c["README"].Target.Id != currentReadme.Target.Id)
                              .ToArray());
@@ -541,7 +541,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanNotOverWriteAnExistingReference()
         {
-            var commits = repo.Commits.QueryBy(new CommitFilter { Since = repo.Refs }).ToArray();
+            var commits = repo.Commits.QueryBy(new CommitFilter { IncludeReachableFrom = repo.Refs }).ToArray();
 
             var ex = Assert.Throws<NameConflictException>(
                 () =>
@@ -700,7 +700,7 @@ namespace LibGit2Sharp.Tests
                 CommitHeaderRewriter =
                     c => CommitRewriteInfo.From(c, message: ""),
                 TagNameRewriter = TagNameRewriter,
-            }, repo.Commits.QueryBy(new CommitFilter { Since = repo.Refs["refs/heads/test"] }));
+            }, repo.Commits.QueryBy(new CommitFilter { IncludeReachableFrom = repo.Refs["refs/heads/test"] }));
 
             AssertSucceedingButNotError();
 
@@ -807,7 +807,7 @@ namespace LibGit2Sharp.Tests
         {
             var notesRefsRetriever = new Func<IEnumerable<Reference>>(() => repo.Refs.Where(r => r.CanonicalName.StartsWith("refs/notes/")));
             var originalNotesRefs = notesRefsRetriever().ToList();
-            var commits = repo.Commits.QueryBy(new CommitFilter { Since = originalNotesRefs }).ToArray();
+            var commits = repo.Commits.QueryBy(new CommitFilter { IncludeReachableFrom = originalNotesRefs }).ToArray();
 
             repo.Refs.RewriteHistory(new RewriteHistoryOptions
             {

--- a/LibGit2Sharp.Tests/RebaseFixture.cs
+++ b/LibGit2Sharp.Tests/RebaseFixture.cs
@@ -97,8 +97,8 @@ namespace LibGit2Sharp.Tests
                 // Verify the chain of source commits that were rebased.
                 CommitFilter sourceCommitFilter = new CommitFilter()
                 {
-                    Since = expectedSinceCommit,
-                    Until = expectedUntilCommit,
+                    IncludeReachableFrom = expectedSinceCommit,
+                    ExcludeReachableFrom = expectedUntilCommit,
                     SortBy = CommitSortStrategies.Reverse | CommitSortStrategies.Topological,
                 };
                 Assert.Equal(repo.Commits.QueryBy(sourceCommitFilter), PreRebaseCommits);
@@ -261,8 +261,8 @@ namespace LibGit2Sharp.Tests
                 // Verify the chain of resultant rebased commits.
                 CommitFilter commitFilter = new CommitFilter()
                 {
-                    Since = repo.Head.Tip,
-                    Until = upstreamBranch.Tip,
+                    IncludeReachableFrom = repo.Head.Tip,
+                    ExcludeReachableFrom = upstreamBranch.Tip,
                     SortBy = CommitSortStrategies.Reverse | CommitSortStrategies.Topological,
                 };
 

--- a/LibGit2Sharp.Tests/RepositoryFixture.cs
+++ b/LibGit2Sharp.Tests/RepositoryFixture.cs
@@ -264,10 +264,10 @@ namespace LibGit2Sharp.Tests
 
             Assert.Equal(0, repo.Commits.Count());
             Assert.Equal(0, repo.Commits.QueryBy(new CommitFilter()).Count());
-            Assert.Equal(0, repo.Commits.QueryBy(new CommitFilter { Since = repo.Refs.Head }).Count());
-            Assert.Equal(0, repo.Commits.QueryBy(new CommitFilter { Since = repo.Head }).Count());
-            Assert.Equal(0, repo.Commits.QueryBy(new CommitFilter { Since = "HEAD" }).Count());
-            Assert.Equal(0, repo.Commits.QueryBy(new CommitFilter { Since = expectedHeadTargetIdentifier }).Count());
+            Assert.Equal(0, repo.Commits.QueryBy(new CommitFilter { IncludeReachableFrom = repo.Refs.Head }).Count());
+            Assert.Equal(0, repo.Commits.QueryBy(new CommitFilter { IncludeReachableFrom = repo.Head }).Count());
+            Assert.Equal(0, repo.Commits.QueryBy(new CommitFilter { IncludeReachableFrom = "HEAD" }).Count());
+            Assert.Equal(0, repo.Commits.QueryBy(new CommitFilter { IncludeReachableFrom = expectedHeadTargetIdentifier }).Count());
 
             Assert.Null(repo.Head["subdir/I-do-not-exist"]);
 

--- a/LibGit2Sharp/Branch.cs
+++ b/LibGit2Sharp/Branch.cs
@@ -122,7 +122,7 @@ namespace LibGit2Sharp
         /// </summary>
         public virtual ICommitLog Commits
         {
-            get { return repo.Commits.QueryBy(new CommitFilter { Since = this }); }
+            get { return repo.Commits.QueryBy(new CommitFilter { IncludeReachableFrom = this }); }
         }
 
         /// <summary>

--- a/LibGit2Sharp/CommitFilter.cs
+++ b/LibGit2Sharp/CommitFilter.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -15,7 +16,7 @@ namespace LibGit2Sharp
         public CommitFilter()
         {
             SortBy = CommitSortStrategies.Time;
-            Since = "HEAD";
+            IncludeReachableFrom = "HEAD";
             FirstParentOnly = false;
         }
 
@@ -36,7 +37,23 @@ namespace LibGit2Sharp
         ///   By default, the <see cref="Repository.Head"/> will be used as boundary.
         /// </para>
         /// </summary>
-        public object Since { get; set; }
+        [Obsolete("This property will be removed in the next release. Please use IncludeReachableFrom instead.")]
+        public object Since
+        {
+            get { return IncludeReachableFrom; }
+            set { IncludeReachableFrom = value; }
+        }
+
+        /// <summary>
+        /// A pointer to a commit object or a list of pointers to consider as starting points.
+        /// <para>
+        ///   Can be either a <see cref="string"/> containing the sha or reference canonical name to use,
+        ///   a <see cref="Branch"/>, a <see cref="Reference"/>, a <see cref="Commit"/>, a <see cref="Tag"/>,
+        ///   a <see cref="TagAnnotation"/>, an <see cref="ObjectId"/> or even a mixed collection of all of the above.
+        ///   By default, the <see cref="Repository.Head"/> will be used as boundary.
+        /// </para>
+        /// </summary>
+        public object IncludeReachableFrom { get; set; }
 
         internal IList<object> SinceList
         {
@@ -51,7 +68,22 @@ namespace LibGit2Sharp
         ///   a <see cref="TagAnnotation"/>, an <see cref="ObjectId"/> or even a mixed collection of all of the above.
         /// </para>
         /// </summary>
-        public object Until { get; set; }
+        [Obsolete("This property will be removed in the next release. Please use ExcludeReachableFrom instead.")]
+        public object Until
+        {
+            get { return ExcludeReachableFrom; }
+            set { ExcludeReachableFrom = value; }
+        }
+
+        /// <summary>
+        /// A pointer to a commit object or a list of pointers which will be excluded (along with ancestors) from the enumeration.
+        /// <para>
+        ///   Can be either a <see cref="string"/> containing the sha or reference canonical name to use,
+        ///   a <see cref="Branch"/>, a <see cref="Reference"/>, a <see cref="Commit"/>, a <see cref="Tag"/>,
+        ///   a <see cref="TagAnnotation"/>, an <see cref="ObjectId"/> or even a mixed collection of all of the above.
+        /// </para>
+        /// </summary>
+        public object ExcludeReachableFrom { get; set; }
 
         internal IList<object> UntilList
         {

--- a/LibGit2Sharp/Core/HistoryRewriter.cs
+++ b/LibGit2Sharp/Core/HistoryRewriter.cs
@@ -45,7 +45,7 @@ namespace LibGit2Sharp.Core
 
                 var filter = new CommitFilter
                 {
-                    Since = refsToRewrite,
+                    IncludeReachableFrom = refsToRewrite,
                     SortBy = CommitSortStrategies.Reverse | CommitSortStrategies.Topological
                 };
 


### PR DESCRIPTION
I’m using libgit2sharp to emulate this:  “git log HEAD~2..HEAD”

This fails to find any commits:
```
var filter = new CommitFilter { FirstParentOnly = true, Since = "HEAD~2", Until = "HEAD" };
var commits = Repo.Commits.QueryBy(filter);
```

This successfully finds both commits:
```
var filter = new CommitFilter { FirstParentOnly = true, Since = "HEAD", Until = "HEAD~2" };
var commits = Repo.Commits.QueryBy(filter);
```

This makes sense only if you consider that internally, the walk is starting at HEAD and going backwards to HEAD~2.  However, this is grammatically confusing because I'm really intending to get the commits *starting* at HEAD and *ending* at HEAD~2.  The fact that it walks backwards feels like an implementation detail; it really isn't what I'm trying to express.  This is especially true when compared to the git command line which grammatically reads left (start) to right (end).

You can see the very natural confusion in the sample:
  https://github.com/libgit2/libgit2sharp/wiki/git-log
```
$ git log master..development
LibGit2Sharp
using (var repo = new Repository("path/to/your/repo"))
{
  var filter = new CommitFilter { Since = repo.Branches["master"], Until = repo.Branches["development"] };
```

Note that this is only a problem because the choice in words in the structure don't meet the natural expectation.  Humans (even developers) just don't naturally think backwards; time (and relationships) moves "Since" something in the past "Until" something in the future.

It's too late to change the behavior but two new properties that are effectively the same (aliases) could be added.  IMHO, going with the Git "revrange" documentation of "Rev1" and "Rev2" is best since it doesn't rely on natural grammatical terms which might have naturally different implication.

Dave
