### PR TITLE
Add support for git_revparse

### DIFF
--- a/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
+++ b/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
@@ -69,6 +69,7 @@
     <Compile Include="RefSpecFixture.cs" />
     <Compile Include="EqualityFixture.cs" />
     <Compile Include="RevertFixture.cs" />
+    <Compile Include="RevSpecFixture.cs" />
     <Compile Include="SetErrorFixture.cs" />
     <Compile Include="SignatureFixture.cs" />
     <Compile Include="FilterBranchFixture.cs" />

--- a/LibGit2Sharp.Tests/RevSpecFixture.cs
+++ b/LibGit2Sharp.Tests/RevSpecFixture.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using LibGit2Sharp.Tests.TestHelpers;
+using Xunit;
+using Xunit.Extensions;
+
+namespace LibGit2Sharp.Tests
+{
+    public class RevSpecFixture : BaseFixture
+    {
+        private const string FirstCommit = "32eab9cb1f450b5fe7ab663462b77d7f4b703344"; // Add "1.txt" file beside "1" folder
+        private const string PreviousCommit = "592d3c869dbc4127fc57c189cb94f2794fa84e7e"; // add more test files
+        private const string SpecificCommit1 = "4c062a6361ae6959e06292c1fa5e2822d9c96345"; // directory was added
+        private const string SpecificCommit2 = "9fd738e8f7967c078dceed8190330fc8648ee56a"; // a fourth commit
+        private const string SpecificCommit3 = "5b5b025afb0b4c913b4c338a42934a3863bf3644"; // another commit
+        private const string OriginCommit = "580c2111be43802dab11328176d94c391f1deae9"; // Remote-only commit 2
+
+        [Theory]
+        [InlineData(FirstCommit, FirstCommit, null, RevSpecType.Single)]
+        [InlineData(SpecificCommit2 + "..HEAD", SpecificCommit2, FirstCommit, RevSpecType.Range)]
+        [InlineData(SpecificCommit2 + ".." + SpecificCommit1, SpecificCommit2, SpecificCommit1, RevSpecType.Range)]
+        [InlineData("HEAD^1..HEAD", PreviousCommit, FirstCommit, RevSpecType.Range)]
+        [InlineData("HEAD~6..HEAD", SpecificCommit3, FirstCommit, RevSpecType.Range)]
+        [InlineData("origin..HEAD", OriginCommit, FirstCommit, RevSpecType.Range)]
+        public void TestFromPreviousCommit(string spec, string expectedFromSha, string expectedToSha, RevSpecType expectedType)
+        {
+            var path = SandboxStandardTestRepoGitDir();
+            using (var repo = new Repository(path))
+            {
+                var result = RevSpec.Parse(repo, spec);
+                if (expectedFromSha == null)
+                {
+                    Assert.Null(result.From);
+                }
+                else
+                {
+                    Assert.NotNull(result.From);
+                    Assert.IsAssignableFrom<Commit>(result.From);
+                    Assert.Equal(expectedFromSha, result.From.Sha);
+                }
+
+                if (expectedToSha == null)
+                {
+                    Assert.Null(result.To);
+                }
+                else
+                {
+                    Assert.NotNull(result.To);
+                    Assert.IsAssignableFrom<Commit>(result.To);
+                    Assert.Equal(expectedToSha, result.To.Sha);
+                }
+
+                Assert.Equal(expectedType, result.Type);
+            }
+        }
+    }
+}

--- a/LibGit2Sharp/Core/GitRevSpec.cs
+++ b/LibGit2Sharp/Core/GitRevSpec.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using LibGit2Sharp.Core.Handles;
+
+namespace LibGit2Sharp.Core
+{
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct GitRevSpec
+    {
+        public IntPtr From;
+
+        public IntPtr To;
+
+        public RevSpecType Type;
+    }
+}

--- a/LibGit2Sharp/Core/Handles/GitObjectSafeHandle.cs
+++ b/LibGit2Sharp/Core/Handles/GitObjectSafeHandle.cs
@@ -1,7 +1,15 @@
-﻿namespace LibGit2Sharp.Core.Handles
+﻿using System;
+
+namespace LibGit2Sharp.Core.Handles
 {
     internal class GitObjectSafeHandle : SafeHandleBase
     {
+        public GitObjectSafeHandle()
+        { }
+
+        public GitObjectSafeHandle(IntPtr invalidHandleValue) : base(invalidHandleValue)
+        { }
+
         protected override bool ReleaseHandleImpl()
         {
             Proxy.git_object_free(handle);

--- a/LibGit2Sharp/Core/Handles/SafeHandleBase.cs
+++ b/LibGit2Sharp/Core/Handles/SafeHandleBase.cs
@@ -98,7 +98,11 @@ namespace LibGit2Sharp.Core.Handles
         private int registered;
 
         protected SafeHandleBase()
-            : base(IntPtr.Zero, true)
+            : this(IntPtr.Zero)
+        {
+        }
+
+        protected SafeHandleBase(IntPtr invalidHandleValue) : base(invalidHandleValue, true)
         {
             NativeMethods.AddHandle();
             registered = 1;

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -1384,6 +1384,12 @@ namespace LibGit2Sharp.Core
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string spec);
 
         [DllImport(libgit2)]
+        internal static extern int git_revparse_single(out GitObjectSafeHandle objectHandle, RepositorySafeHandle repo, [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string spec);
+
+        [DllImport(libgit2)]
+        internal static extern int git_revparse(out GitRevSpec revspec, RepositorySafeHandle repo, [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string spec);
+
+        [DllImport(libgit2)]
         internal static extern void git_revwalk_free(IntPtr walker);
 
         [DllImport(libgit2)]

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -27,6 +27,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>bin\Debug\LibGit2Sharp.xml</DocumentationFile>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -38,6 +39,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <DocumentationFile>bin\Release\LibGit2Sharp.xml</DocumentationFile>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -72,6 +74,7 @@
     <Compile Include="Core\FileHistory.cs" />
     <Compile Include="Core\GitFetchOptions.cs" />
     <Compile Include="Core\GitPushUpdate.cs" />
+    <Compile Include="Core\GitRevSpec.cs" />
     <Compile Include="Core\GitSubmoduleIgnore.cs" />
     <Compile Include="Core\Platform.cs" />
     <Compile Include="Core\Handles\ConflictIteratorSafeHandle.cs" />
@@ -166,6 +169,8 @@
     <Compile Include="RenameDetails.cs" />
     <Compile Include="RevertResult.cs" />
     <Compile Include="RevertOptions.cs" />
+    <Compile Include="RevSpecType.cs" />
+    <Compile Include="RevSpec.cs" />
     <Compile Include="SecureUsernamePasswordCredentials.cs" />
     <Compile Include="StageOptions.cs" />
     <Compile Include="StatusOptions.cs" />

--- a/LibGit2Sharp/RevSpec.cs
+++ b/LibGit2Sharp/RevSpec.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using LibGit2Sharp.Core;
+using LibGit2Sharp.Core.Handles;
+
+namespace LibGit2Sharp
+{
+    /// <summary>
+    /// Defines a Git Revision Spec returned by <see cref="RevSpec.Parse"/>.
+    /// </summary>
+    public sealed class RevSpec
+    {
+        private RevSpec()
+        {
+        }
+
+        /// <summary>
+        /// Gets the left element of the revspec
+        /// </summary>
+        /// <value>The left element of the revspec.</value>
+        public GitObject From { get; private set; }
+
+        /// <summary>
+        /// Gets the right element of the revspec.
+        /// </summary>
+        /// <value>The right element of the revspec.</value>
+        public GitObject To { get; private set; }
+
+        /// <summary>
+        /// Gets the intent of the revspec .
+        /// </summary>
+        /// <value>The intent of the revspec .</value>
+        public RevSpecType Type { get; private set; }
+
+        /// <summary>
+        /// Parse a revision string for `from`, `to`, and intent.
+        /// </summary>
+        /// <param name="repo">The repository to search in.</param>
+        /// <param name="spec">The rev-parse spec to parse.</param>
+        /// <returns>The result of rev-parse.</returns>
+        /// <exception cref="System.ArgumentNullException">
+        /// repo
+        /// or
+        /// spec
+        /// </exception>
+        public static RevSpec Parse(Repository repo, string spec)
+        {
+            if (repo == null)
+            {
+                throw new ArgumentNullException("repo");
+            }
+            if (spec == null)
+            {
+                throw new ArgumentNullException("spec");
+            }
+
+            GitRevSpec gitRevSpec;
+
+            var result = NativeMethods.git_revparse(out gitRevSpec, repo.Handle, spec);
+            Ensure.Int32Result(result);
+
+            var revSpec = new RevSpec();
+
+            if (gitRevSpec.From != IntPtr.Zero)
+            {
+                using (var sh = new GitObjectSafeHandle(gitRevSpec.From))
+                {
+                    var objType = Proxy.git_object_type(sh);
+                    revSpec.From = GitObject.BuildFrom(repo, Proxy.git_object_id(sh), objType, null);
+                }
+            }
+
+            if (gitRevSpec.To != IntPtr.Zero)
+            {
+                using (var sh = new GitObjectSafeHandle(gitRevSpec.To))
+                {
+                    var objType = Proxy.git_object_type(sh);
+                    revSpec.To = GitObject.BuildFrom(repo, Proxy.git_object_id(sh), objType, null);
+                }
+            }
+
+            revSpec.Type = gitRevSpec.Type;
+
+            return revSpec;
+        }
+    }
+}

--- a/LibGit2Sharp/RevSpecType.cs
+++ b/LibGit2Sharp/RevSpecType.cs
@@ -1,0 +1,23 @@
+namespace LibGit2Sharp
+{
+    /// <summary>
+    /// These indicate the intended behavior of the spec passed to git_revparse.
+    /// </summary>
+    public enum RevSpecType
+    {
+        /// <summary>
+        /// The spec targeted a single object. 
+        /// </summary>
+        Single = 1 << 0,
+
+        /// <summary>
+        /// The spec targeted a range of commits. 
+        /// </summary>
+        Range = 1 << 1,
+
+        /// <summary>
+        /// The spec used the '...' operator, which invokes special semantics. 
+        /// </summary>
+        MergeBase = 1 << 2,
+    }
+}


### PR DESCRIPTION
Hi there!
I have added a basic support to [git_revparse](https://libgit2.github.com/libgit2/#HEAD/group/revparse/git_revparse)
As I was not sure how this kind of API is exposed, I have added a static method on the new `RevSpec` instead of polluting the `Repository` class.
Let me know if this is ok.
Thanks!
