### PR TITLE
Add support revwalk range

### DIFF
--- a/LibGit2Sharp/CommitFilter.cs
+++ b/LibGit2Sharp/CommitFilter.cs
@@ -108,10 +108,11 @@ namespace LibGit2Sharp
             if (obj is string)
             {
                 list.Add((string)obj);
-                return list;
+            } 
+            else if (obj is IEnumerable)
+            {
+                list.AddRange(((IEnumerable)obj).OfType<string>());
             }
-
-            list.AddRange(((IEnumerable)obj).OfType<string>());
             return list;
         }
     }

--- a/LibGit2Sharp/CommitFilter.cs
+++ b/LibGit2Sharp/CommitFilter.cs
@@ -44,6 +44,17 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
+        /// Gets or sets the range spec from..to or a list of range.
+        /// </summary>
+        /// <value>The range.</value>
+        public object Range { get; set; }
+
+        internal IList<string> RangeList
+        {
+            get { return ToRangeList(Range); }
+        }
+
+        /// <summary>
         /// A pointer to a commit object or a list of pointers which will be excluded (along with ancestors) from the enumeration.
         /// <para>
         ///   Can be either a <see cref="string"/> containing the sha or reference canonical name to use,
@@ -87,6 +98,20 @@ namespace LibGit2Sharp
             }
 
             list.AddRange(((IEnumerable)obj).Cast<object>());
+            return list;
+        }
+
+        private static IList<string> ToRangeList(object obj)
+        {
+            var list = new List<string>();
+
+            if (obj is string)
+            {
+                list.Add((string)obj);
+                return list;
+            }
+
+            list.AddRange(((IEnumerable)obj).OfType<string>());
             return list;
         }
     }

--- a/LibGit2Sharp/CommitLog.cs
+++ b/LibGit2Sharp/CommitLog.cs
@@ -144,6 +144,7 @@ namespace LibGit2Sharp
                 Sort(filter.SortBy);
                 Push(filter.SinceList);
                 Hide(filter.UntilList);
+                PushRange(filter.RangeList);
                 FirstParentOnly(filter.FirstParentOnly);
             }
 
@@ -206,6 +207,14 @@ namespace LibGit2Sharp
             private void Push(IList<object> identifier)
             {
                 InternalHidePush(identifier, Proxy.git_revwalk_push);
+            }
+
+            private void PushRange(IEnumerable<string> ranges)
+            {
+                foreach (var range in ranges)
+                {
+                    Proxy.git_revwalk_push_range(handle, range);
+                }
             }
 
             private void Hide(IList<object> identifier)

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -1399,6 +1399,18 @@ namespace LibGit2Sharp.Core
         internal static extern int git_revwalk_push(RevWalkerSafeHandle walker, ref GitOid id);
 
         [DllImport(libgit2)]
+        internal static extern int git_revwalk_push_range(RevWalkerSafeHandle walker, [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string range);
+
+        [DllImport(libgit2)]
+        internal static extern int git_revwalk_push_ref(RevWalkerSafeHandle walker, [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string refname);
+
+        [DllImport(libgit2)]
+        internal static extern int git_revwalk_push_glob(RevWalkerSafeHandle walker, [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string glob);
+
+        [DllImport(libgit2)]
+        internal static extern int git_revwalk_push_head(RevWalkerSafeHandle walker);
+
+        [DllImport(libgit2)]
         internal static extern void git_revwalk_reset(RevWalkerSafeHandle walker);
 
         [DllImport(libgit2)]

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -2620,6 +2620,24 @@ namespace LibGit2Sharp.Core
             Ensure.ZeroResult(res);
         }
 
+        public static void git_revwalk_push_range(RevWalkerSafeHandle walker, string range)
+        {
+            int res = NativeMethods.git_revwalk_push_range(walker, range);
+            Ensure.ZeroResult(res);
+        }
+
+        public static void git_revwalk_push_ref(RevWalkerSafeHandle walker, string refname)
+        {
+            int res = NativeMethods.git_revwalk_push_ref(walker, refname);
+            Ensure.ZeroResult(res);
+        }
+
+        public static void git_revwalk_push_glob(RevWalkerSafeHandle walker, string glob)
+        {
+            int res = NativeMethods.git_revwalk_push_glob(walker, glob);
+            Ensure.ZeroResult(res);
+        }
+        
         public static void git_revwalk_reset(RevWalkerSafeHandle walker)
         {
             NativeMethods.git_revwalk_reset(walker);


### PR DESCRIPTION
Hi!
I have added support for [git_revwalk_push_range](https://libgit2.github.com/libgit2/#HEAD/group/revwalk/git_revwalk_push_range) on `CommitLog`/`CommitFilter`, as the current API doesn't support the behavior of the push_range (left part is not included, unlike the CommitFilter.Until).

I'm not particulary satisfied with the way the API is designed in CommitFilter. Not sure if we should better match the behavior of the underlying API instead. Maybe adding dedicated Push commands on `CommitFilter` would be more easier to map, but anyway, let me know.

I will add test once we agree on the design.
Thanks!
