### PR TITLE
Don't build a fake signature

### DIFF
--- a/LibGit2Sharp/NoteCollection.cs
+++ b/LibGit2Sharp/NoteCollection.cs
@@ -173,7 +173,7 @@ namespace LibGit2Sharp
         /// <returns>The note which was just saved.</returns>
         public virtual Note Add(ObjectId targetId, string message, string @namespace)
         {
-            Signature author = repo.Config.BuildSignature(DateTimeOffset.Now, true);
+            Signature author = repo.Config.BuildSignatureOrThrow(DateTimeOffset.Now);
 
             return Add(targetId, message, author, author, @namespace);
         }
@@ -212,7 +212,7 @@ namespace LibGit2Sharp
         /// <param name="namespace">The namespace on which the note will be removed. It can be either a canonical namespace or an abbreviated namespace ('refs/notes/myNamespace' or just 'myNamespace').</param>
         public virtual void Remove(ObjectId targetId, string @namespace)
         {
-            Signature author = repo.Config.BuildSignature(DateTimeOffset.Now, true);
+            Signature author = repo.Config.BuildSignatureOrThrow(DateTimeOffset.Now);
 
             Remove(targetId, author, author, @namespace);
         }

--- a/LibGit2Sharp/RepositoryExtensions.cs
+++ b/LibGit2Sharp/RepositoryExtensions.cs
@@ -236,7 +236,7 @@ namespace LibGit2Sharp
         /// <returns>The generated <see cref="LibGit2Sharp.Commit"/>.</returns>
         public static Commit Commit(this IRepository repository, string message, CommitOptions options)
         {
-            Signature author = repository.Config.BuildSignature(DateTimeOffset.Now, true);
+            Signature author = repository.Config.BuildSignatureOrThrow(DateTimeOffset.Now);
 
             return repository.Commit(message, author, options);
         }
@@ -270,7 +270,7 @@ namespace LibGit2Sharp
         /// <returns>The generated <see cref="LibGit2Sharp.Commit"/>.</returns>
         public static Commit Commit(this IRepository repository, string message, Signature author, CommitOptions options)
         {
-            Signature committer = repository.Config.BuildSignature(DateTimeOffset.Now, true);
+            Signature committer = repository.Config.BuildSignatureOrThrow(DateTimeOffset.Now);
 
             return repository.Commit(message, author, committer, options);
         }


### PR DESCRIPTION
When there is no user information in the configuration files, BuildSignature() sets
"unkown" as the name and uses the environment variables to create the
e-mail. This seems peculiar, since it means a consumer of the library
cannot use this method to figure out if this configuration does exist
but has to do it themselves.

As far as I can tell, this started as a way to provide something to the
reflog when the user has not set up the information as it's more
transient data and progress matters more than accuracy in that
case. This is now handled by libgit2 itself, so there is no need for
this behaviour inside the library.

This leaves us with the curious case of this fake signature only being
provided to a consumer of the library when this behaviour was due to
some internal users. It also makes it harder than it needs to be to know
if the signature the library provided is accurate.

Resolve this situation by returning null when there is no signature
configured. The internal users can then move to use a method which
throws a message mentioning the lack of a necessary signature.

---

I'm not sold on the name of the new method or the exception message, but returning a fake signature to the user is IMO the least useful thing we could do here.