### PR TITLE
The case for the removal of overloads which take an identity from the configuration

### DIFF
--- a/LibGit2Sharp.Tests/CommitFixture.cs
+++ b/LibGit2Sharp.Tests/CommitFixture.cs
@@ -560,7 +560,9 @@ namespace LibGit2Sharp.Tests
 
                 Assert.Null(repo.Head[relativeFilepath]);
 
-                Commit commit = repo.Commit("Initial egotistic commit");
+                Signature signature = repo.Config.BuildSignature(DateTimeOffset.Now);
+
+                Commit commit = repo.Commit("Initial egotistic commit", signature, signature);
 
                 AssertBlobContent(repo.Head[relativeFilepath], "nulltoken\n");
                 AssertBlobContent(commit[relativeFilepath], "nulltoken\n");

--- a/LibGit2Sharp.Tests/CommitFixture.cs
+++ b/LibGit2Sharp.Tests/CommitFixture.cs
@@ -563,7 +563,7 @@ namespace LibGit2Sharp.Tests
         public void CanCommitWithSignatureFromConfig()
         {
             string repoPath = InitNewRepository();
-            string configPath = CreateConfigurationWithDummyUser(Constants.Signature);
+            string configPath = CreateConfigurationWithDummyUser(Constants.Identity);
             var options = new RepositoryOptions { GlobalConfigurationLocation = configPath };
 
             using (var repo = new Repository(repoPath, options))
@@ -586,7 +586,7 @@ namespace LibGit2Sharp.Tests
                 AssertBlobContent(repo.Head[relativeFilepath], "nulltoken\n");
                 AssertBlobContent(commit[relativeFilepath], "nulltoken\n");
 
-                AssertCommitSignaturesAre(commit, Constants.Signature);
+                AssertCommitIdentitiesAre(commit, Constants.Identity);
             }
         }
 

--- a/LibGit2Sharp.Tests/CommitFixture.cs
+++ b/LibGit2Sharp.Tests/CommitFixture.cs
@@ -538,27 +538,6 @@ namespace LibGit2Sharp.Tests
             }
         }
 
-        [Theory]
-        [InlineData(null, "x@example.com")]
-        [InlineData("", "x@example.com")]
-        [InlineData("X", null)]
-        [InlineData("X", "")]
-        public void CommitWithInvalidSignatureConfigThrows(string name, string email)
-        {
-            string repoPath = InitNewRepository();
-            string configPath = CreateConfigurationWithDummyUser(name, email);
-            var options = new RepositoryOptions { GlobalConfigurationLocation = configPath };
-
-            using (var repo = new Repository(repoPath, options))
-            {
-                Assert.Equal(name, repo.Config.GetValueOrDefault<string>("user.name"));
-                Assert.Equal(email, repo.Config.GetValueOrDefault<string>("user.email"));
-
-                Assert.Throws<LibGit2SharpException>(
-                    () => repo.Commit("Initial egotistic commit", new CommitOptions { AllowEmptyCommit = true }));
-            }
-        }
-
         [Fact]
         public void CanCommitWithSignatureFromConfig()
         {

--- a/LibGit2Sharp.Tests/ConfigurationFixture.cs
+++ b/LibGit2Sharp.Tests/ConfigurationFixture.cs
@@ -409,5 +409,27 @@ namespace LibGit2Sharp.Tests
             Assert.Throws<FileNotFoundException>(() => Configuration.BuildFrom(
                 Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())));
         }
+
+        [Theory]
+        [InlineData(null, "x@example.com")]
+        [InlineData("", "x@example.com")]
+        [InlineData("X", null)]
+        [InlineData("X", "")]
+        public void CannotBuildAProperSignatureFromConfigWhenFullIdentityCannotBeFoundInTheConfig(string name, string email)
+        {
+            string repoPath = InitNewRepository();
+            string configPath = CreateConfigurationWithDummyUser(name, email);
+            var options = new RepositoryOptions { GlobalConfigurationLocation = configPath };
+
+            using (var repo = new Repository(repoPath, options))
+            {
+                Assert.Equal(name, repo.Config.GetValueOrDefault<string>("user.name"));
+                Assert.Equal(email, repo.Config.GetValueOrDefault<string>("user.email"));
+
+                Signature signature = repo.Config.BuildSignature(DateTimeOffset.Now);
+
+                Assert.Null(signature);
+            }
+        }
     }
 }

--- a/LibGit2Sharp.Tests/ConfigurationFixture.cs
+++ b/LibGit2Sharp.Tests/ConfigurationFixture.cs
@@ -143,7 +143,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanEnumerateGlobalConfig()
         {
-            string configPath = CreateConfigurationWithDummyUser(Constants.Signature);
+            string configPath = CreateConfigurationWithDummyUser(Constants.Identity);
             var options = new RepositoryOptions { GlobalConfigurationLocation = configPath };
 
             var path = SandboxStandardTestRepoGitDir();
@@ -200,7 +200,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanFindInGlobalConfig()
         {
-            string configPath = CreateConfigurationWithDummyUser(Constants.Signature);
+            string configPath = CreateConfigurationWithDummyUser(Constants.Identity);
             var options = new RepositoryOptions { GlobalConfigurationLocation = configPath };
 
             var path = SandboxStandardTestRepoGitDir();
@@ -387,7 +387,7 @@ namespace LibGit2Sharp.Tests
         {
             var path = SandboxStandardTestRepoGitDir();
 
-            string globalConfigPath = CreateConfigurationWithDummyUser(Constants.Signature);
+            string globalConfigPath = CreateConfigurationWithDummyUser(Constants.Identity);
             var options = new RepositoryOptions { GlobalConfigurationLocation = globalConfigPath };
 
             using (var repo = new Repository(path, options))

--- a/LibGit2Sharp.Tests/FilterFixture.cs
+++ b/LibGit2Sharp.Tests/FilterFixture.cs
@@ -159,7 +159,7 @@ namespace LibGit2Sharp.Tests
                 using (var repo = CreateTestRepository(repoPath))
                 {
                     FileInfo expectedFile = StageNewFile(repo, decodedInput);
-                    var commit = repo.Commit("Clean that file");
+                    var commit = repo.Commit("Clean that file", Constants.Signature, Constants.Signature);
                     var blob = (Blob)commit.Tree[expectedFile.Name].Target;
 
                     var textDetected = blob.GetContentText();
@@ -240,7 +240,7 @@ namespace LibGit2Sharp.Tests
                     File.WriteAllText(attributesPath, "*.blob filter=test");
                     repo.Stage(attributesFile.Name);
                     repo.Stage(contentFile.Name);
-                    repo.Commit("test");
+                    repo.Commit("test", Constants.Signature, Constants.Signature);
                     contentFile.Delete();
                     repo.Checkout("HEAD", new CheckoutOptions() { CheckoutModifiers = CheckoutModifiers.Force });
                 }
@@ -346,7 +346,7 @@ namespace LibGit2Sharp.Tests
             {
                 StageNewFile(repo, content);
 
-                repo.Commit("Initial commit");
+                repo.Commit("Initial commit", Constants.Signature, Constants.Signature);
 
                 expectedPath = CommitFileOnBranch(repo, branchName, content);
 
@@ -363,7 +363,7 @@ namespace LibGit2Sharp.Tests
             repo.Checkout(branch.FriendlyName);
 
             FileInfo expectedPath = StageNewFile(repo, content);
-            repo.Commit("Commit");
+            repo.Commit("Commit", Constants.Signature, Constants.Signature);
             return expectedPath;
         }
 

--- a/LibGit2Sharp.Tests/FilterFixture.cs
+++ b/LibGit2Sharp.Tests/FilterFixture.cs
@@ -232,7 +232,7 @@ namespace LibGit2Sharp.Tests
                 string attributesPath = Path.Combine(Directory.GetParent(repoPath).Parent.FullName, ".gitattributes");
                 FileInfo attributesFile = new FileInfo(attributesPath);
 
-                string configPath = CreateConfigurationWithDummyUser(Constants.Signature);
+                string configPath = CreateConfigurationWithDummyUser(Constants.Identity);
                 var repositoryOptions = new RepositoryOptions { GlobalConfigurationLocation = configPath };
 
                 using (Repository repo = new Repository(repoPath, repositoryOptions))
@@ -377,7 +377,7 @@ namespace LibGit2Sharp.Tests
 
         private Repository CreateTestRepository(string path)
         {
-            string configPath = CreateConfigurationWithDummyUser(Constants.Signature);
+            string configPath = CreateConfigurationWithDummyUser(Constants.Identity);
             var repositoryOptions = new RepositoryOptions { GlobalConfigurationLocation = configPath };
             var repository = new Repository(path, repositoryOptions);
             CreateAttributesFile(repository, "* filter=test");

--- a/LibGit2Sharp.Tests/FilterSubstitutionCipherFixture.cs
+++ b/LibGit2Sharp.Tests/FilterSubstitutionCipherFixture.cs
@@ -203,7 +203,7 @@ namespace LibGit2Sharp.Tests
         {
             File.Delete(Path.Combine(repo.Info.WorkingDirectory, fileName));
             repo.Stage(fileName);
-            repo.Commit("remove file");
+            repo.Commit("remove file", Constants.Signature, Constants.Signature);
         }
 
         private static Blob CommitOnBranchAndReturnDatabaseBlob(Repository repo, string fileName, string input)
@@ -211,7 +211,7 @@ namespace LibGit2Sharp.Tests
             Touch(repo.Info.WorkingDirectory, fileName, input);
             repo.Stage(fileName);
 
-            var commit = repo.Commit("new file");
+            var commit = repo.Commit("new file", Constants.Signature, Constants.Signature);
 
             var blob = (Blob)commit.Tree[fileName].Target;
             return blob;

--- a/LibGit2Sharp.Tests/FilterSubstitutionCipherFixture.cs
+++ b/LibGit2Sharp.Tests/FilterSubstitutionCipherFixture.cs
@@ -21,7 +21,7 @@ namespace LibGit2Sharp.Tests
 
             string repoPath = InitNewRepository();
             string fileName = Guid.NewGuid() + ".rot13";
-            string configPath = CreateConfigurationWithDummyUser(Constants.Signature);
+            string configPath = CreateConfigurationWithDummyUser(Constants.Identity);
             var repositoryOptions = new RepositoryOptions { GlobalConfigurationLocation = configPath };
             using (var repo = new Repository(repoPath, repositoryOptions))
             {
@@ -61,7 +61,7 @@ namespace LibGit2Sharp.Tests
 
             string repoPath = InitNewRepository();
             string fileName = Guid.NewGuid() + ".rot13";
-            string configPath = CreateConfigurationWithDummyUser(Constants.Signature);
+            string configPath = CreateConfigurationWithDummyUser(Constants.Identity);
             var repositoryOptions = new RepositoryOptions { GlobalConfigurationLocation = configPath };
             using (var repo = new Repository(repoPath, repositoryOptions))
             {
@@ -106,7 +106,7 @@ namespace LibGit2Sharp.Tests
             string repoPath = InitNewRepository();
             string fileName = Guid.NewGuid() + fileExtension;
 
-            string configPath = CreateConfigurationWithDummyUser(Constants.Signature);
+            string configPath = CreateConfigurationWithDummyUser(Constants.Identity);
             var repositoryOptions = new RepositoryOptions { GlobalConfigurationLocation = configPath };
             using (var repo = new Repository(repoPath, repositoryOptions))
             {
@@ -141,7 +141,7 @@ namespace LibGit2Sharp.Tests
             string repoPath = InitNewRepository();
             string fileName = Guid.NewGuid() + ".txt";
 
-            string configPath = CreateConfigurationWithDummyUser(Constants.Signature);
+            string configPath = CreateConfigurationWithDummyUser(Constants.Identity);
             var repositoryOptions = new RepositoryOptions { GlobalConfigurationLocation = configPath };
             using (var repo = new Repository(repoPath, repositoryOptions))
             {
@@ -172,7 +172,7 @@ namespace LibGit2Sharp.Tests
             string repoPath = InitNewRepository();
             string fileName = Guid.NewGuid() + ".txt";
 
-            string configPath = CreateConfigurationWithDummyUser(Constants.Signature);
+            string configPath = CreateConfigurationWithDummyUser(Constants.Identity);
             var repositoryOptions = new RepositoryOptions { GlobalConfigurationLocation = configPath };
             using (var repo = new Repository(repoPath, repositoryOptions))
             {

--- a/LibGit2Sharp.Tests/NoteFixture.cs
+++ b/LibGit2Sharp.Tests/NoteFixture.cs
@@ -175,7 +175,10 @@ namespace LibGit2Sharp.Tests
             using (var repo = new Repository(path, options))
             {
                 var commit = repo.Lookup<Commit>("9fd738e8f7967c078dceed8190330fc8648ee56a");
-                var note = repo.Notes.Add(commit.Id, "I'm batman!\n", "batmobile");
+
+                Signature signature = repo.Config.BuildSignature(DateTimeOffset.Now);
+
+                var note = repo.Notes.Add(commit.Id, "I'm batman!\n", signature, signature, "batmobile");
 
                 var newNote = commit.Notes.Single();
                 Assert.Equal(note, newNote);

--- a/LibGit2Sharp.Tests/NoteFixture.cs
+++ b/LibGit2Sharp.Tests/NoteFixture.cs
@@ -168,7 +168,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanAddANoteWithSignatureFromConfig()
         {
-            string configPath = CreateConfigurationWithDummyUser(Constants.Signature);
+            string configPath = CreateConfigurationWithDummyUser(Constants.Identity);
             var options = new RepositoryOptions { GlobalConfigurationLocation = configPath };
             string path = SandboxBareTestRepo();
 
@@ -183,7 +183,7 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal("I'm batman!\n", newNote.Message);
                 Assert.Equal("batmobile", newNote.Namespace);
 
-                AssertCommitSignaturesAre(repo.Lookup<Commit>("refs/notes/batmobile"), Constants.Signature);
+                AssertCommitIdentitiesAre(repo.Lookup<Commit>("refs/notes/batmobile"), Constants.Identity);
             }
         }
 
@@ -265,7 +265,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanRemoveANoteWithSignatureFromConfig()
         {
-            string configPath = CreateConfigurationWithDummyUser(Constants.Signature);
+            string configPath = CreateConfigurationWithDummyUser(Constants.Identity);
             RepositoryOptions options = new RepositoryOptions() { GlobalConfigurationLocation = configPath };
             string path = SandboxBareTestRepo();
 
@@ -280,7 +280,7 @@ namespace LibGit2Sharp.Tests
 
                 Assert.Empty(notes);
 
-                AssertCommitSignaturesAre(repo.Lookup<Commit>("refs/notes/" + repo.Notes.DefaultNamespace), Constants.Signature);
+                AssertCommitIdentitiesAre(repo.Lookup<Commit>("refs/notes/" + repo.Notes.DefaultNamespace), Constants.Identity);
             }
         }
 

--- a/LibGit2Sharp.Tests/NoteFixture.cs
+++ b/LibGit2Sharp.Tests/NoteFixture.cs
@@ -279,7 +279,9 @@ namespace LibGit2Sharp.Tests
 
                 Assert.NotEmpty(notes);
 
-                repo.Notes.Remove(commit.Id, repo.Notes.DefaultNamespace);
+                Signature signature = repo.Config.BuildSignature(DateTimeOffset.Now);
+
+                repo.Notes.Remove(commit.Id, signature, signature, repo.Notes.DefaultNamespace);
 
                 Assert.Empty(notes);
 

--- a/LibGit2Sharp.Tests/TestHelpers/BaseFixture.cs
+++ b/LibGit2Sharp.Tests/TestHelpers/BaseFixture.cs
@@ -328,11 +328,11 @@ namespace LibGit2Sharp.Tests.TestHelpers
         /// Creates a configuration file with user.name and user.email set to signature
         /// </summary>
         /// <remarks>The configuration file will be removed automatically when the tests are finished</remarks>
-        /// <param name="signature">The signature to use for user.name and user.email</param>
+        /// <param name="identity">The identity to use for user.name and user.email</param>
         /// <returns>The path to the configuration file</returns>
-        protected string CreateConfigurationWithDummyUser(Signature signature)
+        protected string CreateConfigurationWithDummyUser(Identity identity)
         {
-            return CreateConfigurationWithDummyUser(signature.Name, signature.Email);
+            return CreateConfigurationWithDummyUser(identity.Name, identity.Email);
         }
 
         protected string CreateConfigurationWithDummyUser(string name, string email)
@@ -361,13 +361,13 @@ namespace LibGit2Sharp.Tests.TestHelpers
         /// Asserts that the commit has been authored and committed by the specified signature
         /// </summary>
         /// <param name="commit">The commit</param>
-        /// <param name="signature">The signature to compare author and commiter to</param>
-        protected void AssertCommitSignaturesAre(Commit commit, Signature signature)
+        /// <param name="identity">The identity to compare author and commiter to</param>
+        protected void AssertCommitIdentitiesAre(Commit commit, Identity identity)
         {
-            Assert.Equal(signature.Name, commit.Author.Name);
-            Assert.Equal(signature.Email, commit.Author.Email);
-            Assert.Equal(signature.Name, commit.Committer.Name);
-            Assert.Equal(signature.Email, commit.Committer.Email);
+            Assert.Equal(identity.Name, commit.Author.Name);
+            Assert.Equal(identity.Email, commit.Author.Email);
+            Assert.Equal(identity.Name, commit.Committer.Name);
+            Assert.Equal(identity.Email, commit.Committer.Email);
         }
 
         protected static string Touch(string parent, string file, string content = null, Encoding encoding = null)

--- a/LibGit2Sharp/CheckoutOptions.cs
+++ b/LibGit2Sharp/CheckoutOptions.cs
@@ -34,8 +34,8 @@ namespace LibGit2Sharp
         {
             get
             {
-                return CheckoutModifiers.HasFlag(CheckoutModifiers.Force) 
-                    ? CheckoutStrategy.GIT_CHECKOUT_FORCE 
+                return CheckoutModifiers.HasFlag(CheckoutModifiers.Force)
+                    ? CheckoutStrategy.GIT_CHECKOUT_FORCE
                     : CheckoutStrategy.GIT_CHECKOUT_SAFE;
             }
         }

--- a/LibGit2Sharp/Commit.cs
+++ b/LibGit2Sharp/Commit.cs
@@ -118,8 +118,8 @@ namespace LibGit2Sharp
             get
             {
                 return string.Format(CultureInfo.InvariantCulture,
-                                     "{0} {1}", 
-                                     Id.ToString(7), 
+                                     "{0} {1}",
+                                     Id.ToString(7),
                                      MessageShort);
             }
         }

--- a/LibGit2Sharp/ConflictCollection.cs
+++ b/LibGit2Sharp/ConflictCollection.cs
@@ -104,7 +104,7 @@ namespace LibGit2Sharp
                     default:
                         throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture,
                                                                           "Entry '{0}' bears an unexpected StageLevel '{1}'",
-                                                                          entry.Path, 
+                                                                          entry.Path,
                                                                           entry.StageLevel));
                 }
             }

--- a/LibGit2Sharp/ContentChanges.cs
+++ b/LibGit2Sharp/ContentChanges.cs
@@ -124,7 +124,7 @@ namespace LibGit2Sharp
             {
                 return string.Format(CultureInfo.InvariantCulture,
                                      @"{{+{0}, -{1}}}",
-                                     LinesAdded, 
+                                     LinesAdded,
                                      LinesDeleted);
             }
         }

--- a/LibGit2Sharp/Core/EncodingMarshaler.cs
+++ b/LibGit2Sharp/Core/EncodingMarshaler.cs
@@ -43,8 +43,8 @@ namespace LibGit2Sharp.Core
 
             if (str == null)
             {
-                throw new MarshalDirectiveException(string.Format(CultureInfo.InvariantCulture, 
-                                                                  "{0} must be used on a string.", 
+                throw new MarshalDirectiveException(string.Format(CultureInfo.InvariantCulture,
+                                                                  "{0} must be used on a string.",
                                                                   GetType().Name));
             }
 

--- a/LibGit2Sharp/Core/FilePath.cs
+++ b/LibGit2Sharp/Core/FilePath.cs
@@ -60,8 +60,8 @@ namespace LibGit2Sharp.Core
 
         public bool Equals(FilePath other)
         {
-            return other == null 
-                ? posix == null 
+            return other == null
+                ? posix == null
                 : string.Equals(posix, other.posix, StringComparison.Ordinal);
         }
 

--- a/LibGit2Sharp/Core/FilePathMarshaler.cs
+++ b/LibGit2Sharp/Core/FilePathMarshaler.cs
@@ -68,8 +68,8 @@ namespace LibGit2Sharp.Core
 
             if (null == filePath)
             {
-                throw new MarshalDirectiveException(string.Format(CultureInfo.InvariantCulture, 
-                                                    "{0} must be used on a FilePath.", 
+                throw new MarshalDirectiveException(string.Format(CultureInfo.InvariantCulture,
+                                                    "{0} must be used on a FilePath.",
                                                     GetType().Name));
             }
 

--- a/LibGit2Sharp/Core/GitBlame.cs
+++ b/LibGit2Sharp/Core/GitBlame.cs
@@ -79,8 +79,8 @@ namespace LibGit2Sharp.Core
                     return GitBlameOptionFlags.GIT_BLAME_NORMAL;
 
                 default:
-                    throw new NotSupportedException(string.Format(CultureInfo.InvariantCulture, 
-                                                                  "{0} is not supported at this time", 
+                    throw new NotSupportedException(string.Format(CultureInfo.InvariantCulture,
+                                                                  "{0} is not supported at this time",
                                                                   strategy));
             }
         }

--- a/LibGit2Sharp/Core/GitFilter.cs
+++ b/LibGit2Sharp/Core/GitFilter.cs
@@ -70,9 +70,9 @@ namespace LibGit2Sharp.Core
         /// callback to free the payload.
         /// </summary>
         public delegate int git_filter_check_fn(
-            GitFilter gitFilter, 
-            IntPtr payload, 
-            IntPtr filterSource, 
+            GitFilter gitFilter,
+            IntPtr payload,
+            IntPtr filterSource,
             IntPtr attributeValues);
 
         /// <summary>
@@ -86,17 +86,17 @@ namespace LibGit2Sharp.Core
         /// The `payload` value will refer to any payload that was set by the `check` callback.  It may be read from or written to as needed.
         /// </summary>
         public delegate int git_filter_apply_fn(
-            GitFilter gitFilter, 
-            IntPtr payload, 
-            IntPtr gitBufTo, 
-            IntPtr gitBufFrom, 
+            GitFilter gitFilter,
+            IntPtr payload,
+            IntPtr gitBufTo,
+            IntPtr gitBufFrom,
             IntPtr filterSource);
 
         public delegate int git_filter_stream_fn(
-            out IntPtr git_writestream_out, 
-            GitFilter self, 
-            IntPtr payload, 
-            IntPtr filterSource, 
+            out IntPtr git_writestream_out,
+            GitFilter self,
+            IntPtr payload,
+            IntPtr filterSource,
             IntPtr git_writestream_next);
 
         /// <summary>

--- a/LibGit2Sharp/Core/HistoryRewriter.cs
+++ b/LibGit2Sharp/Core/HistoryRewriter.cs
@@ -302,8 +302,8 @@ namespace LibGit2Sharp.Core
                 newName = options.TagNameRewriter(annotation.Name, true, annotation.Target.Sha);
             }
 
-            var newAnnotation = repo.ObjectDatabase.CreateTagAnnotation(newName, 
-                                                                        newTarget, 
+            var newAnnotation = repo.ObjectDatabase.CreateTagAnnotation(newName,
+                                                                        newTarget,
                                                                         annotation.Tagger,
                                                                         annotation.Message);
             objectMap[annotation] = newAnnotation;

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -702,15 +702,15 @@ namespace LibGit2Sharp.Core
             using (var osw1 = new ObjectSafeWrapper(oldBlob, repo, true))
             using (var osw2 = new ObjectSafeWrapper(newBlob, repo, true))
             {
-                int res = NativeMethods.git_diff_blobs(osw1.ObjectPtr, 
-                                                       null, 
-                                                       osw2.ObjectPtr, 
-                                                       null, 
-                                                       options, 
-                                                       fileCallback, 
-                                                       null, 
-                                                       hunkCallback, 
-                                                       lineCallback, 
+                int res = NativeMethods.git_diff_blobs(osw1.ObjectPtr,
+                                                       null,
+                                                       osw2.ObjectPtr,
+                                                       null,
+                                                       options,
+                                                       fileCallback,
+                                                       null,
+                                                       hunkCallback,
+                                                       lineCallback,
                                                        IntPtr.Zero);
 
                 Ensure.ZeroResult(res);
@@ -2705,8 +2705,8 @@ namespace LibGit2Sharp.Core
         {
             return git_foreach(resultSelector,
                                c => NativeMethods.git_stash_foreach(repo,
-                                                                    (UIntPtr i, IntPtr m, ref GitOid x, IntPtr p) 
-                                                                        => c((int)i, m, x, p), 
+                                                                    (UIntPtr i, IntPtr m, ref GitOid x, IntPtr p)
+                                                                        => c((int)i, m, x, p),
                                                                     IntPtr.Zero),
                                GitErrorCode.NotFound);
         }
@@ -2771,7 +2771,7 @@ namespace LibGit2Sharp.Core
                 case (int)GitErrorCode.Ambiguous:
                     throw new AmbiguousSpecificationException(CultureInfo.InvariantCulture,
                                                               "More than one file matches the pathspec '{0}'. " +
-                                                              "You can either force a literal path evaluation " + 
+                                                              "You can either force a literal path evaluation " +
                                                               "(GIT_STATUS_OPT_DISABLE_PATHSPEC_MATCH), or use git_status_foreach().",
                                                               path);
 

--- a/LibGit2Sharp/Core/TarWriter.cs
+++ b/LibGit2Sharp/Core/TarWriter.cs
@@ -460,9 +460,9 @@ namespace LibGit2Sharp.Core
 
                     return new FileNameExtendedHeader(posixPath,
                                                       string.Empty,
-                                                      string.Format(CultureInfo.InvariantCulture, 
-                                                                    "{0}.data", 
-                                                                    entrySha), 
+                                                      string.Format(CultureInfo.InvariantCulture,
+                                                                    "{0}.data",
+                                                                    entrySha),
                                                       true);
                 }
 

--- a/LibGit2Sharp/Core/Utf8Marshaler.cs
+++ b/LibGit2Sharp/Core/Utf8Marshaler.cs
@@ -105,8 +105,8 @@ namespace LibGit2Sharp.Core
 
         public override IntPtr MarshalManagedToNative(object managedObj)
         {
-            throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, 
-                                                              "{0} cannot be used to pass data to libgit2.", 
+            throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture,
+                                                              "{0} cannot be used to pass data to libgit2.",
                                                               GetType().Name));
         }
 

--- a/LibGit2Sharp/Filter.cs
+++ b/LibGit2Sharp/Filter.cs
@@ -10,7 +10,7 @@ namespace LibGit2Sharp
 {
     /// <summary>
     /// A filter is a way to execute code against a file as it moves to and from the git
-    /// repository and into the working directory. 
+    /// repository and into the working directory.
     /// </summary>
     public abstract class Filter : IEquatable<Filter>
     {
@@ -87,7 +87,7 @@ namespace LibGit2Sharp
 
         /// <summary>
         /// Complete callback on filter
-        /// 
+        ///
         /// This optional callback will be invoked when the upstream filter is
         /// closed. Gives the filter a chance to perform any final actions or
         /// necissary clean up.

--- a/LibGit2Sharp/FilterRegistration.cs
+++ b/LibGit2Sharp/FilterRegistration.cs
@@ -19,7 +19,7 @@ namespace LibGit2Sharp
         public const int FilterPriorityMin = 0;
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="filter"></param>
         /// <param name="priority"></param>

--- a/LibGit2Sharp/GitObjectMetadata.cs
+++ b/LibGit2Sharp/GitObjectMetadata.cs
@@ -10,7 +10,7 @@ namespace LibGit2Sharp
         private readonly GitObjectType type;
 
         /// <summary>
-        /// Size of the Object 
+        /// Size of the Object
         /// </summary>
         public long Size { get; private set; }
 

--- a/LibGit2Sharp/GlobalSettings.cs
+++ b/LibGit2Sharp/GlobalSettings.cs
@@ -200,7 +200,7 @@ namespace LibGit2Sharp
         /// Registers a <see cref="Filter"/> to be invoked when <see cref="Filter.Name"/> matches .gitattributes 'filter=name'
         /// </summary>
         /// <param name="filter">The filter to be invoked at run time.</param>
-        /// <param name="priority">The priroty of the filter to invoked. 
+        /// <param name="priority">The priroty of the filter to invoked.
         /// A value of 0 (<see cref="FilterRegistration.FilterPriorityMin"/>) will be run first on checkout and last on checkin.
         /// A value of 200 (<see cref="FilterRegistration.FilterPriorityMax"/>) will be run last on checkout and first on checkin.
         /// </param>
@@ -222,7 +222,7 @@ namespace LibGit2Sharp
 
             lock (registeredFilters)
             {
-                // if the filter has already been registered 
+                // if the filter has already been registered
                 if (registeredFilters.ContainsKey(filter))
                 {
                     throw new EntryExistsException("The filter has already been registered.", GitErrorCode.Exists, GitErrorCategory.Filter);
@@ -251,7 +251,7 @@ namespace LibGit2Sharp
 
                 // do nothing if the filter isn't registered
                 if (registeredFilters.ContainsKey(filter))
-                {                    
+                {
                     // remove the register from the global tracking list
                     registeredFilters.Remove(filter);
                     // clean up native allocations

--- a/LibGit2Sharp/IndexEntry.cs
+++ b/LibGit2Sharp/IndexEntry.cs
@@ -117,9 +117,9 @@ namespace LibGit2Sharp
             get
             {
                 return string.Format(CultureInfo.InvariantCulture,
-                                     "{0} ({1}) => \"{2}\"", 
-                                     Path, 
-                                     StageLevel, 
+                                     "{0} ({1}) => \"{2}\"",
+                                     Path,
+                                     StageLevel,
                                      Id.ToString(7));
             }
         }

--- a/LibGit2Sharp/IndexNameEntry.cs
+++ b/LibGit2Sharp/IndexNameEntry.cs
@@ -120,9 +120,9 @@ namespace LibGit2Sharp
             get
             {
                 return string.Format(CultureInfo.InvariantCulture,
-                                     "{0} {1} {2}", 
-                                     Ancestor, 
-                                     Ours, 
+                                     "{0} {1} {2}",
+                                     Ancestor,
+                                     Ours,
                                      Theirs);
             }
         }

--- a/LibGit2Sharp/IndexReucEntry.cs
+++ b/LibGit2Sharp/IndexReucEntry.cs
@@ -145,10 +145,10 @@ namespace LibGit2Sharp
             get
             {
                 return string.Format(CultureInfo.InvariantCulture,
-                                     "{0}: {1} {2} {3}", 
-                                     Path, 
-                                     AncestorId, 
-                                     OurId, 
+                                     "{0}: {1} {2} {3}",
+                                     Path,
+                                     AncestorId,
+                                     OurId,
                                      TheirId);
             }
         }

--- a/LibGit2Sharp/Network.cs
+++ b/LibGit2Sharp/Network.cs
@@ -429,10 +429,10 @@ namespace LibGit2Sharp
             Ensure.ArgumentNotNull(objectish, "objectish");
             Ensure.ArgumentNotNullOrEmptyString(destinationSpec, "destinationSpec");
 
-            Push(remote, 
+            Push(remote,
                  string.Format(CultureInfo.InvariantCulture,
-                               "{0}:{1}", 
-                               objectish, 
+                               "{0}:{1}",
+                               objectish,
                                destinationSpec));
         }
 
@@ -452,11 +452,11 @@ namespace LibGit2Sharp
             Ensure.ArgumentNotNull(objectish, "objectish");
             Ensure.ArgumentNotNullOrEmptyString(destinationSpec, "destinationSpec");
 
-            Push(remote, 
+            Push(remote,
                  string.Format(CultureInfo.InvariantCulture,
-                               "{0}:{1}", 
-                               objectish, 
-                               destinationSpec), 
+                               "{0}:{1}",
+                               objectish,
+                               destinationSpec),
                  pushOptions);
         }
 
@@ -570,7 +570,7 @@ namespace LibGit2Sharp
             {
                 int i = 0;
 
-                Func<string, string, GitOid, bool, FetchHead> resultSelector = 
+                Func<string, string, GitOid, bool, FetchHead> resultSelector =
                     (name, url, oid, isMerge) => new FetchHead(repository, name, url, oid, isMerge, i++);
 
                 return Proxy.git_repository_fetchhead_foreach(repository.Handle, resultSelector);

--- a/LibGit2Sharp/Note.cs
+++ b/LibGit2Sharp/Note.cs
@@ -115,8 +115,8 @@ namespace LibGit2Sharp
             {
                 return string.Format(CultureInfo.InvariantCulture,
                                      "Target \"{0}\", Namespace \"{1}\": {2}",
-                                     TargetObjectId.ToString(7), 
-                                     Namespace, 
+                                     TargetObjectId.ToString(7),
+                                     Namespace,
                                      Message);
             }
         }

--- a/LibGit2Sharp/NoteCollection.cs
+++ b/LibGit2Sharp/NoteCollection.cs
@@ -211,6 +211,7 @@ namespace LibGit2Sharp
         /// </summary>
         /// <param name="targetId">The target <see cref="ObjectId"/>, for which the note will be created.</param>
         /// <param name="namespace">The namespace on which the note will be removed. It can be either a canonical namespace or an abbreviated namespace ('refs/notes/myNamespace' or just 'myNamespace').</param>
+        [Obsolete("This method will be removed in the next release. Please use Remove(ObjectId, Signature, Signature, string) instead.")]
         public virtual void Remove(ObjectId targetId, string @namespace)
         {
             Signature author = repo.Config.BuildSignatureOrThrow(DateTimeOffset.Now);

--- a/LibGit2Sharp/NoteCollection.cs
+++ b/LibGit2Sharp/NoteCollection.cs
@@ -171,6 +171,7 @@ namespace LibGit2Sharp
         /// <param name="message">The note message.</param>
         /// <param name="namespace">The namespace on which the note will be created. It can be either a canonical namespace or an abbreviated namespace ('refs/notes/myNamespace' or just 'myNamespace').</param>
         /// <returns>The note which was just saved.</returns>
+        [Obsolete("This method will be removed in the next release. Please use Add(ObjectId, string, Signature, Signature, string) instead.")]
         public virtual Note Add(ObjectId targetId, string message, string @namespace)
         {
             Signature author = repo.Config.BuildSignatureOrThrow(DateTimeOffset.Now);

--- a/LibGit2Sharp/ObjectDatabase.cs
+++ b/LibGit2Sharp/ObjectDatabase.cs
@@ -489,9 +489,9 @@ namespace LibGit2Sharp
 
             if (minLength <= 0 || minLength > ObjectId.HexSize)
             {
-                throw new ArgumentOutOfRangeException("minLength", 
+                throw new ArgumentOutOfRangeException("minLength",
                                                       minLength,
-                                                      string.Format("Expected value should be greater than zero and less than or equal to {0}.", 
+                                                      string.Format("Expected value should be greater than zero and less than or equal to {0}.",
                                                                     ObjectId.HexSize));
             }
 

--- a/LibGit2Sharp/ObjectId.cs
+++ b/LibGit2Sharp/ObjectId.cs
@@ -297,9 +297,9 @@ namespace LibGit2Sharp
                     return false;
                 }
 
-                throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, 
-                                                          "'{0}' is not a valid object identifier. Its length should be {1}.", 
-                                                          objectId, 
+                throw new ArgumentException(string.Format(CultureInfo.InvariantCulture,
+                                                          "'{0}' is not a valid object identifier. Its length should be {1}.",
+                                                          objectId,
                                                           HexSize),
                                             "objectId");
             }

--- a/LibGit2Sharp/OdbBackend.cs
+++ b/LibGit2Sharp/OdbBackend.cs
@@ -637,7 +637,7 @@ namespace LibGit2Sharp
             {
                 throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture,
                                                                   "Provided length ({0}) exceeds long.MaxValue ({1}).",
-                                                                  len.ToUInt64(), 
+                                                                  len.ToUInt64(),
                                                                   long.MaxValue));
             }
 

--- a/LibGit2Sharp/Rebase.cs
+++ b/LibGit2Sharp/Rebase.cs
@@ -91,7 +91,7 @@ namespace LibGit2Sharp
                     this.repository.Refs.RetrieveReferencePtr(b.CanonicalName);
             };
 
-            Func<ReferenceSafeHandle, GitAnnotatedCommitHandle> AnnotatedCommitHandleFromRefHandle = 
+            Func<ReferenceSafeHandle, GitAnnotatedCommitHandle> AnnotatedCommitHandleFromRefHandle =
                 (ReferenceSafeHandle refHandle) =>
             {
                 return (refHandle == null) ?
@@ -273,7 +273,7 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <returns></returns>
         public virtual long GetCurrentStepIndex()
@@ -290,7 +290,7 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <returns></returns>
         public virtual long GetTotalStepCount()

--- a/LibGit2Sharp/RebaseOperationImpl.cs
+++ b/LibGit2Sharp/RebaseOperationImpl.cs
@@ -237,7 +237,7 @@ namespace LibGit2Sharp
                 current = stepToApplyIndex,
                 total = totalStepCount,
             };
-            
+
             return progress;
         }
 

--- a/LibGit2Sharp/RebaseResult.cs
+++ b/LibGit2Sharp/RebaseResult.cs
@@ -26,7 +26,7 @@ namespace LibGit2Sharp
         /// </summary>
         Stop,
     };
-    
+
     /// <summary>
     /// Information on a rebase operation.
     /// </summary>

--- a/LibGit2Sharp/Reference.cs
+++ b/LibGit2Sharp/Reference.cs
@@ -231,8 +231,8 @@ namespace LibGit2Sharp
             get
             {
                 return string.Format(CultureInfo.InvariantCulture,
-                                     "{0} => \"{1}\"", 
-                                     CanonicalName, 
+                                     "{0} => \"{1}\"",
+                                     CanonicalName,
                                      TargetIdentifier);
             }
         }

--- a/LibGit2Sharp/ReferenceWrapper.cs
+++ b/LibGit2Sharp/ReferenceWrapper.cs
@@ -166,8 +166,8 @@ namespace LibGit2Sharp
             {
                 return string.Format(CultureInfo.InvariantCulture,
                                      "{0} => \"{1}\"", CanonicalName,
-                                     (TargetObject != null) 
-                                        ? TargetObject.Id.ToString(7) 
+                                     (TargetObject != null)
+                                        ? TargetObject.Id.ToString(7)
                                         : "?");
             }
         }

--- a/LibGit2Sharp/RemoteCallbacks.cs
+++ b/LibGit2Sharp/RemoteCallbacks.cs
@@ -59,7 +59,7 @@ namespace LibGit2Sharp
         private readonly UpdateTipsHandler UpdateTips;
 
         /// <summary>
-        /// PushStatusError callback. It will be called when the libgit2 push_update_reference returns a non null status message, 
+        /// PushStatusError callback. It will be called when the libgit2 push_update_reference returns a non null status message,
         /// which means that the update was rejected by the remote server.
         /// </summary>
         private readonly PushStatusErrorHandler PushStatusError;
@@ -266,10 +266,10 @@ namespace LibGit2Sharp
         }
 
         private int GitCredentialHandler(
-            out IntPtr ptr, 
-            IntPtr cUrl, 
-            IntPtr usernameFromUrl, 
-            GitCredentialType credTypes, 
+            out IntPtr ptr,
+            IntPtr cUrl,
+            IntPtr usernameFromUrl,
+            GitCredentialType credTypes,
             IntPtr payload)
         {
             string url = LaxUtf8Marshaler.FromNative(cUrl);

--- a/LibGit2Sharp/RepositoryExtensions.cs
+++ b/LibGit2Sharp/RepositoryExtensions.cs
@@ -219,6 +219,7 @@ namespace LibGit2Sharp
         /// <param name="repository">The <see cref="Repository"/> being worked with.</param>
         /// <param name="message">The description of why a change was made to the repository.</param>
         /// <returns>The generated <see cref="LibGit2Sharp.Commit"/>.</returns>
+        [Obsolete("This method will be removed in the next release. Please use Commit(string, Signature, Signature) instead.")]
         public static Commit Commit(this IRepository repository, string message)
         {
             return repository.Commit(message, (CommitOptions)null);
@@ -234,6 +235,7 @@ namespace LibGit2Sharp
         /// <param name="message">The description of why a change was made to the repository.</param>
         /// <param name="options">The <see cref="CommitOptions"/> that specify the commit behavior.</param>
         /// <returns>The generated <see cref="LibGit2Sharp.Commit"/>.</returns>
+        [Obsolete("This method will be removed in the next release. Please use Commit(string, Signature, Signature, CommitOptions) instead.")]
         public static Commit Commit(this IRepository repository, string message, CommitOptions options)
         {
             Signature author = repository.Config.BuildSignatureOrThrow(DateTimeOffset.Now);
@@ -251,6 +253,7 @@ namespace LibGit2Sharp
         /// <param name="author">The <see cref="Signature"/> of who made the change.</param>
         /// <param name="message">The description of why a change was made to the repository.</param>
         /// <returns>The generated <see cref="LibGit2Sharp.Commit"/>.</returns>
+        [Obsolete("This method will be removed in the next release. Please use Commit(string, Signature, Signature) instead.")]
         public static Commit Commit(this IRepository repository, string message, Signature author)
         {
             return repository.Commit(message, author, (CommitOptions)null);
@@ -267,11 +270,27 @@ namespace LibGit2Sharp
         /// <param name="message">The description of why a change was made to the repository.</param>
         /// <param name="options">The <see cref="CommitOptions"/> that specify the commit behavior.</param>
         /// <returns>The generated <see cref="LibGit2Sharp.Commit"/>.</returns>
+        [Obsolete("This method will be removed in the next release. Please use Commit(string, Signature, Signature, CommitOptions) instead.")]
         public static Commit Commit(this IRepository repository, string message, Signature author, CommitOptions options)
         {
             Signature committer = repository.Config.BuildSignatureOrThrow(DateTimeOffset.Now);
 
             return repository.Commit(message, author, committer, options);
+        }
+
+        /// <summary>
+        /// Stores the content of the <see cref="Repository.Index"/> as a new <see cref="LibGit2Sharp.Commit"/> into the repository.
+        /// The tip of the <see cref="Repository.Head"/> will be used as the parent of this new Commit.
+        /// Once the commit is created, the <see cref="Repository.Head"/> will move forward to point at it.
+        /// </summary>
+        /// <param name="repository">The <see cref="IRepository"/> being worked with.</param>
+        /// <param name="message">The description of why a change was made to the repository.</param>
+        /// <param name="author">The <see cref="Signature"/> of who made the change.</param>
+        /// <param name="committer">The <see cref="Signature"/> of who added the change to the repository.</param>
+        /// <returns>The generated <see cref="LibGit2Sharp.Commit"/>.</returns>
+        public static Commit Commit(this IRepository repository, string message, Signature author, Signature committer)
+        {
+            return repository.Commit(message, author, committer, default(CommitOptions));
         }
 
         /// <summary>
@@ -599,21 +618,6 @@ namespace LibGit2Sharp
         public static void Reset(this IRepository repository, Commit commit)
         {
             repository.Index.Replace(commit, null, null);
-        }
-
-        /// <summary>
-        /// Stores the content of the <see cref="Repository.Index"/> as a new <see cref="LibGit2Sharp.Commit"/> into the repository.
-        /// The tip of the <see cref="Repository.Head"/> will be used as the parent of this new Commit.
-        /// Once the commit is created, the <see cref="Repository.Head"/> will move forward to point at it.
-        /// </summary>
-        /// <param name="repository">The <see cref="IRepository"/> being worked with.</param>
-        /// <param name="message">The description of why a change was made to the repository.</param>
-        /// <param name="author">The <see cref="Signature"/> of who made the change.</param>
-        /// <param name="committer">The <see cref="Signature"/> of who added the change to the repository.</param>
-        /// <returns>The generated <see cref="LibGit2Sharp.Commit"/>.</returns>
-        public static Commit Commit(this IRepository repository, string message, Signature author, Signature committer)
-        {
-            return repository.Commit(message, author, committer, null);
         }
 
         /// <summary>

--- a/LibGit2Sharp/RepositoryExtensions.cs
+++ b/LibGit2Sharp/RepositoryExtensions.cs
@@ -256,7 +256,6 @@ namespace LibGit2Sharp
             return repository.Commit(message, author, (CommitOptions)null);
         }
 
-
         /// <summary>
         /// Stores the content of the <see cref="Repository.Index"/> as a new <see cref="LibGit2Sharp.Commit"/> into the repository.
         /// The tip of the <see cref="Repository.Head"/> will be used as the parent of this new Commit.
@@ -357,7 +356,7 @@ namespace LibGit2Sharp
             {
                 throw new ArgumentException(string.Format(CultureInfo.InvariantCulture,
                                                           "Unable to process file '{0}'. This file is not located under the working directory of the repository ('{1}').",
-                                                          normalizedPath, 
+                                                          normalizedPath,
                                                           repo.Info.WorkingDirectory));
             }
 

--- a/LibGit2Sharp/SymbolicReference.cs
+++ b/LibGit2Sharp/SymbolicReference.cs
@@ -46,10 +46,10 @@ namespace LibGit2Sharp
             {
                 return string.Format(CultureInfo.InvariantCulture,
                                      "{0} => {1} => \"{2}\"",
-                                     CanonicalName, 
+                                     CanonicalName,
                                      TargetIdentifier,
-                                     (Target != null) 
-                                         ? Target.TargetIdentifier 
+                                     (Target != null)
+                                         ? Target.TargetIdentifier
                                          : "?");
             }
         }

--- a/LibGit2Sharp/TagAnnotation.cs
+++ b/LibGit2Sharp/TagAnnotation.cs
@@ -23,11 +23,11 @@ namespace LibGit2Sharp
             : base(repo, id)
         {
             lazyName = GitObjectLazyGroup.Singleton(repo, id, Proxy.git_tag_name);
-            lazyTarget = GitObjectLazyGroup.Singleton(repo, 
+            lazyTarget = GitObjectLazyGroup.Singleton(repo,
                                                       id,
-                                                      obj => BuildFrom(repo, 
-                                                                       Proxy.git_tag_target_id(obj), 
-                                                                       Proxy.git_tag_target_type(obj), 
+                                                      obj => BuildFrom(repo,
+                                                                       Proxy.git_tag_target_id(obj),
+                                                                       Proxy.git_tag_target_type(obj),
                                                                        null));
 
             group = new GitObjectLazyGroup(repo, id);

--- a/LibGit2Sharp/TarArchiver.cs
+++ b/LibGit2Sharp/TarArchiver.cs
@@ -100,9 +100,9 @@ namespace LibGit2Sharp
                     }
                     break;
                 default:
-                    throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, 
-                                                                      "Unsupported file mode: {0} (sha1: {1}).", 
-                                                                      entry.Mode, 
+                    throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture,
+                                                                      "Unsupported file mode: {0} (sha1: {1}).",
+                                                                      entry.Mode,
                                                                       entry.TargetId.Sha));
             }
         }
@@ -111,20 +111,20 @@ namespace LibGit2Sharp
         {
             using (Stream contentStream = streamer())
             {
-                writer.Write(path, 
-                             contentStream, 
+                writer.Write(path,
+                             contentStream,
                              modificationTime,
-                             (entry.Mode == Mode.ExecutableFile) 
-                                 ? "775".OctalToInt32() 
+                             (entry.Mode == Mode.ExecutableFile)
+                                 ? "775".OctalToInt32()
                                  : "664".OctalToInt32(),
-                             "0", 
-                             "0", 
-                             '0', 
-                             "root", 
-                             "root", 
-                             "0", 
-                             "0", 
-                             entry.TargetId.Sha, 
+                             "0",
+                             "0",
+                             '0',
+                             "root",
+                             "root",
+                             "0",
+                             "0",
+                             entry.TargetId.Sha,
                              false);
             }
         }

--- a/LibGit2Sharp/Tree.cs
+++ b/LibGit2Sharp/Tree.cs
@@ -107,8 +107,8 @@ namespace LibGit2Sharp
             get
             {
                 return string.Format(CultureInfo.InvariantCulture,
-                                     "{0}, Count = {1}", 
-                                     Id.ToString(7), 
+                                     "{0}, Count = {1}",
+                                     Id.ToString(7),
                                      Count);
             }
         }

--- a/LibGit2Sharp/TreeChanges.cs
+++ b/LibGit2Sharp/TreeChanges.cs
@@ -162,11 +162,11 @@ namespace LibGit2Sharp
             {
                 return string.Format(CultureInfo.InvariantCulture,
                                      "+{0} ~{1} -{2} \u00B1{3} R{4} C{5}",
-                                     Added.Count(), 
-                                     Modified.Count(), 
+                                     Added.Count(),
+                                     Modified.Count(),
                                      Deleted.Count(),
-                                     TypeChanged.Count(), 
-                                     Renamed.Count(), 
+                                     TypeChanged.Count(),
+                                     Renamed.Count(),
                                      Copied.Count());
             }
         }

--- a/LibGit2Sharp/TreeEntryChanges.cs
+++ b/LibGit2Sharp/TreeEntryChanges.cs
@@ -95,9 +95,9 @@ namespace LibGit2Sharp
             {
                 return string.Format(CultureInfo.InvariantCulture,
                                      "Path = {0}, File {1}",
-                                     !string.IsNullOrEmpty(Path) 
-                                         ? Path 
-                                         : OldPath, 
+                                     !string.IsNullOrEmpty(Path)
+                                         ? Path
+                                         : OldPath,
                                      Status);
             }
         }

--- a/LibGit2Sharp/TreeEntryTargetType.cs
+++ b/LibGit2Sharp/TreeEntryTargetType.cs
@@ -38,8 +38,8 @@ namespace LibGit2Sharp
                     return GitObjectType.Blob;
 
                 default:
-                    throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, 
-                                                                      "Cannot map {0} to a GitObjectType.", 
+                    throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture,
+                                                                      "Cannot map {0} to a GitObjectType.",
                                                                       type));
             }
         }


### PR DESCRIPTION
These are meant to make it convenient to use the configured signature when the programmer wants to take it from the configuration.

But this makes these overloads very dependent on the configuration, something which is almost guaranteed to change between the developer's machine and the production (or even test) usage.

This causes code which was seemingly working fine to stop working once deployed (and this kind of environment dependence has bit us in libgit2sharp's tests as well) and it's letting the programmer assume that the environment is set up correctly instead of letting them make sure that it is or take steps to set it up correctly. This is not helped by `BuildSignature()` returning a fake signature if none is available in the configuration.

#1171 attempts to mitigate this problem by removing the fake signature. A programmer can now figure out whether the environment is set up correctly and set it up if that's the way they want to go (or conditionally provide their own signature). But it still lets the programmer make assumptions about the environment in which they are operating which can be confusing.

/cc @ckuhn203