### PR TITLE
[RFC] Certs and Creds from a managed smart subtransport

### DIFF
--- a/LibGit2Sharp/CertificateSsh.cs
+++ b/LibGit2Sharp/CertificateSsh.cs
@@ -1,4 +1,6 @@
 ﻿using LibGit2Sharp.Core;
+using System;
+using System.Runtime.InteropServices;
 
 namespace LibGit2Sharp
 {
@@ -48,6 +50,32 @@ namespace LibGit2Sharp
 
             HashSHA1 = new byte[20];
             cert.HashSHA1.CopyTo(HashSHA1, 0);
+        }
+
+        internal IntPtr ToPointer()
+        {
+            GitCertificateSshType sshCertType = 0;
+            if (HasMD5)
+            {
+                sshCertType |= GitCertificateSshType.MD5;
+            }
+            if (HasSHA1)
+            {
+                sshCertType |= GitCertificateSshType.SHA1;
+            }
+
+            var gitCert = new GitCertificateSsh
+            {
+                cert_type = GitCertificateType.Hostkey,
+                type = sshCertType,
+            };
+            HashMD5.CopyTo(gitCert.HashMD5, 0);
+            HashSHA1.CopyTo(gitCert.HashSHA1, 0);
+
+            var ptr = Marshal.AllocHGlobal(Marshal.SizeOf(gitCert));
+            Marshal.StructureToPtr(gitCert, ptr, false);
+
+            return ptr;
         }
     }
 }

--- a/LibGit2Sharp/CertificateX509.cs
+++ b/LibGit2Sharp/CertificateX509.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.InteropServices;
+﻿using System;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
 using LibGit2Sharp.Core;
 
@@ -27,6 +28,24 @@ namespace LibGit2Sharp
             byte[] data = new byte[len];
             Marshal.Copy(cert.data, data, 0, len);
             Certificate = new X509Certificate(data);
+        }
+
+        internal IntPtr ToPointers(out IntPtr dataPtr)
+        {
+            var certData = Certificate.Export(X509ContentType.Cert);
+            dataPtr = Marshal.AllocHGlobal(certData.Length);
+            Marshal.Copy(certData, 0, dataPtr, certData.Length);
+            var gitCert = new GitCertificateX509()
+            {
+                cert_type = GitCertificateType.X509,
+                data = dataPtr,
+                len = (UIntPtr)certData.LongLength,
+            };
+
+            var ptr = Marshal.AllocHGlobal(Marshal.SizeOf(gitCert));
+            Marshal.StructureToPtr(gitCert, ptr, false);
+
+            return ptr;
         }
     }
 }

--- a/LibGit2Sharp/Core/GitCredential.cs
+++ b/LibGit2Sharp/Core/GitCredential.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace LibGit2Sharp.Core
+{
+    [StructLayout(LayoutKind.Sequential)]
+    internal class GitCredential
+    {
+        public GitCredentialType credtype;
+        public IntPtr free;
+    }
+}
+

--- a/LibGit2Sharp/Core/GitCredentialUserpass.cs
+++ b/LibGit2Sharp/Core/GitCredentialUserpass.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace LibGit2Sharp.Core
+{
+    [StructLayout(LayoutKind.Sequential)]
+    internal class GitCredentialUserpass
+    {
+        public GitCredential parent;
+        public IntPtr username;
+        public IntPtr password;
+    }
+}
+

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -460,6 +460,9 @@ namespace LibGit2Sharp.Core
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string password);
 
         [DllImport(libgit2)]
+        internal static extern void git_cred_free(IntPtr cred);
+
+        [DllImport(libgit2)]
         internal static extern int git_describe_commit(
             out DescribeResultSafeHandle describe,
             GitObjectSafeHandle committish,
@@ -1731,6 +1734,20 @@ namespace LibGit2Sharp.Core
             out IntPtr transport,
             IntPtr remote,
             IntPtr definition);
+
+        [DllImport(libgit2)]
+        internal static extern int git_transport_smart_certificate_check(
+            IntPtr transport,
+            IntPtr cert,
+            int valid,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string hostname);
+
+        [DllImport(libgit2)]
+        internal static extern int git_transport_smart_credentials(
+            out IntPtr cred_out,
+            IntPtr transport,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string user,
+            int methods);
 
         [DllImport(libgit2)]
         internal static extern int git_transport_unregister(

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -628,6 +628,15 @@ namespace LibGit2Sharp.Core
 
         #endregion
 
+        #region git_cred_
+
+        public static void git_cred_free(IntPtr cred)
+        {
+            NativeMethods.git_cred_free(cred);
+        }
+
+        #endregion
+
         #region git_describe_
 
         public static string git_describe_commit(
@@ -3177,6 +3186,15 @@ namespace LibGit2Sharp.Core
             }
 
             Ensure.ZeroResult(res);
+        }
+
+        #endregion
+
+        #region git_transport_smart_
+
+        public static int git_transport_smart_credentials(out IntPtr cred, IntPtr transport, string user, int methods)
+        {
+            return NativeMethods.git_transport_smart_credentials(out cred, transport, user, methods);
         }
 
         #endregion

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -383,6 +383,8 @@
     <Compile Include="Core\GitCertificateSshType.cs" />
     <Compile Include="CertificateSsh.cs" />
     <Compile Include="IDiffResult.cs" />
+    <Compile Include="Core\GitCredential.cs" />
+    <Compile Include="Core\GitCredentialUserpass.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="CustomDictionary.xml" />

--- a/LibGit2Sharp/SmartSubtransport.cs
+++ b/LibGit2Sharp/SmartSubtransport.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Runtime.InteropServices;
+using System.Text;
 using LibGit2Sharp.Core;
+using LibGit2Sharp.Core.Handles;
 
 namespace LibGit2Sharp
 {
@@ -47,6 +49,76 @@ namespace LibGit2Sharp
     /// </summary>
     public abstract class SmartSubtransport
     {
+        internal IntPtr Transport { get; set; }
+
+        /// <summary>
+        /// Call the certificate check callback
+        /// </summary>
+        /// <param name="cert">The certificate to send</param>
+        /// <param name="valid">Whether we consider the certificate to be valid</param>
+        /// <param name="hostname">The hostname we connected to</param>
+        public int CertificateCheck(Certificate cert, bool valid, string hostname)
+        {
+            CertificateSsh sshCert = cert as CertificateSsh;
+            CertificateX509 x509Cert = cert as CertificateX509;
+
+            if (sshCert == null && x509Cert == null)
+            {
+                throw new InvalidOperationException("Unsupported certificate type");
+            }
+
+            int ret;
+            if (sshCert != null)
+            {
+                var certPtr = sshCert.ToPointer();
+                ret = NativeMethods.git_transport_smart_certificate_check(Transport, certPtr, valid ? 1 : 0, hostname);
+                Marshal.FreeHGlobal(certPtr);
+            } else {
+                IntPtr certPtr, dataPtr;
+                certPtr = x509Cert.ToPointers(out dataPtr);
+                ret = NativeMethods.git_transport_smart_certificate_check(Transport, certPtr, valid ? 1 : 0, hostname);
+                Marshal.FreeHGlobal(dataPtr);
+                Marshal.FreeHGlobal(certPtr);
+            }
+
+            return ret;
+        }
+
+        public int AcquireCredentials(out Credentials cred, string user, params Type[] methods)
+        {
+            // Convert the user-provided types to libgit2's flags
+            int allowed = 0;
+            foreach (var method in methods)
+            {
+                if (method == typeof(UsernamePasswordCredentials))
+                {
+                    allowed |= (int)GitCredentialType.UserPassPlaintext;
+                }
+                else
+                {
+                    throw new InvalidOperationException("Unknown type passes as allowed credential");
+                }
+            }
+
+            IntPtr credHandle = IntPtr.Zero;
+            int res = Proxy.git_transport_smart_credentials(out credHandle, Transport, user, allowed);
+            if (res != 0)
+            {
+                cred = null;
+                return res;
+            }
+
+            var baseCred = credHandle.MarshalAs<GitCredential>();
+            switch (baseCred.credtype)
+            {
+                case GitCredentialType.UserPassPlaintext:
+                    cred = UsernamePasswordCredentials.FromNative(credHandle.MarshalAs<GitCredentialUserpass>());
+                    return 0;
+                default:
+                    throw new InvalidOperationException("User returned an unkown credential type");
+            }
+        }
+
         /// <summary>
         /// Invoked by libgit2 to create a connection using this subtransport.
         /// </summary>

--- a/LibGit2Sharp/SmartSubtransportRegistration.cs
+++ b/LibGit2Sharp/SmartSubtransportRegistration.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 using LibGit2Sharp.Core;
+using LibGit2Sharp.Core.Handles;
 
 namespace LibGit2Sharp
 {
@@ -75,7 +76,9 @@ namespace LibGit2Sharp
 
                 try
                 {
-                    subtransport = new T().GitSmartSubtransportPointer;
+                    var obj = new T();
+                    obj.Transport = transport;
+                    subtransport = obj.GitSmartSubtransportPointer;
 
                     return 0;
                 }

--- a/LibGit2Sharp/UsernamePasswordCredentials.cs
+++ b/LibGit2Sharp/UsernamePasswordCredentials.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Text;
+using System.Runtime.InteropServices;
 using LibGit2Sharp.Core;
 
 namespace LibGit2Sharp
@@ -21,6 +23,15 @@ namespace LibGit2Sharp
             }
 
             return NativeMethods.git_cred_userpass_plaintext_new(out cred, Username, Password);
+        }
+
+        static internal UsernamePasswordCredentials FromNative(GitCredentialUserpass gitCred)
+        {
+            return new UsernamePasswordCredentials()
+            {
+                Username = LaxUtf8Marshaler.FromNative(gitCred.username),
+                Password = LaxUtf8Marshaler.FromNative(gitCred.password),
+            };
         }
 
         /// <summary>


### PR DESCRIPTION
The current implementation does not ask for credentials or confirm server certs via the libgit2 channel; the implementation we know of wants to bypass libgit2 for these things. Which is fine, but if we want a managed implementation to behave like the built-in ones, we also need to let the subtransport ask for them.

This is an attempt at such an implementation. Basically nothing is final, but I'd like to know what we consider best to deal with return codes coming from the callbacks. We might be able to punt and say that we only support whatever libgit2sharp itself would return, so maybe we don't have to deal with `PASSTHROUGH` if we never generate it.

This depends on updated libgit2 binaries.