### PR TITLE
Include nuget.config for custom native nupkg

### DIFF
--- a/CI/travis.osx.install.deps.sh
+++ b/CI/travis.osx.install.deps.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ev
 
-MONO_VER=3.6.0
+MONO_VER=4.0.3
 
 brew update
 which cmake || brew install cmake

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="LibGit2Sharp Internal" value="Lib\NativeBinaries" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
Allow consumers to include a custom nuget package inside the LibGit2Sharp repository (`Lib/NativeBinaries`), which may be useful for people who fork this repository and want to use a custom libgit2, but one that is not generally available on some Nuget server.

This is something that we do in our workflow with the new-style LibGit2Sharp.NativeBinaries package.  While checking this file into this repo isn't strictly necessary, it would help us avoid recreating this each time.
