### PR TITLE
History rewriting and documentaton

### DIFF
--- a/LibGit2Sharp.Tests/FilterBranchFixture.cs
+++ b/LibGit2Sharp.Tests/FilterBranchFixture.cs
@@ -191,10 +191,10 @@ namespace LibGit2Sharp.Tests
             AssertSucceedingButNotError();
 
             var lightweightTag = repo.Tags["so-lonely"];
-            Assert.Equal("Bam!\n", ((Commit)lightweightTag.Target).Message);
+            Assert.Equal("Bam!", ((Commit)lightweightTag.Target).Message);
 
             var annotatedTag = repo.Tags["so-lonely-but-annotated"];
-            Assert.Equal("Bam!\n", ((Commit)annotatedTag.Target).Message);
+            Assert.Equal("Bam!", ((Commit)annotatedTag.Target).Message);
         }
 
         [Fact]
@@ -495,7 +495,7 @@ namespace LibGit2Sharp.Tests
             var parents = repo.Branches["br2"].Tip.Parents.ToList();
             Assert.Equal(2, parents.Count());
             Assert.NotEmpty(parents.Where(c => c.Sha.StartsWith("9fd738e")));
-            Assert.Equal("abc\n", parents.Single(c => !c.Sha.StartsWith("9fd738e")).Message);
+            Assert.Equal("abc", parents.Single(c => !c.Sha.StartsWith("9fd738e")).Message);
         }
 
         [Fact]
@@ -530,7 +530,7 @@ namespace LibGit2Sharp.Tests
             AssertErrorFired(ex);
             AssertSucceedingNotFired();
 
-            Assert.Equal("abc\n", repo.Head.Tip.Message);
+            Assert.Equal("abc", repo.Head.Tip.Message);
 
             var newOriginalRefs = repo.Refs.FromGlob("refs/original/*").OrderBy(r => r.CanonicalName).ToArray();
             Assert.Equal(originalRefs, newOriginalRefs);
@@ -791,7 +791,7 @@ namespace LibGit2Sharp.Tests
             var newCommit = newAnnotationC.Target as Commit;
             Assert.NotNull(newCommit);
             Assert.NotEqual(newCommit, theCommit);
-            Assert.Equal("Rewrote\n", newCommit.Message);
+            Assert.Equal("Rewrote", newCommit.Message);
 
             // Ensure the original tag doesn't exist anymore
             Assert.Null(repo.Tags["lightweightA"]);

--- a/LibGit2Sharp/Commit.cs
+++ b/LibGit2Sharp/Commit.cs
@@ -54,7 +54,7 @@ namespace LibGit2Sharp
         /// <summary>
         /// Gets the <see cref="TreeEntry"/> pointed at by the <paramref name="relativePath"/> in the <see cref="Tree"/>.
         /// </summary>
-        /// <param name="relativePath">The relative path to the <see cref="TreeEntry"/> from the <see cref="Commit"/> working directory.</param>
+        /// <param name="relativePath">Path to the <see cref="TreeEntry"/> from the tree in this <see cref="Commit"/></param>
         /// <returns><c>null</c> if nothing has been found, the <see cref="TreeEntry"/> otherwise.</returns>
         public virtual TreeEntry this[string relativePath]
         {

--- a/LibGit2Sharp/Core/HistoryRewriter.cs
+++ b/LibGit2Sharp/Core/HistoryRewriter.cs
@@ -52,7 +52,7 @@ namespace LibGit2Sharp.Core
                 var commits = repo.Commits.QueryBy(filter);
                 foreach (var commit in commits)
                 {
-                    RewriteCommit(commit);
+                    RewriteCommit(commit, options);
                 }
 
                 // Ordering matters. In the case of `A -> B -> commit`, we need to make sure B is rewritten
@@ -199,7 +199,7 @@ namespace LibGit2Sharp.Core
             return refMap[oldRef] = movedRef;
         }
 
-        private void RewriteCommit(Commit commit)
+        private void RewriteCommit(Commit commit, RewriteHistoryOptions options)
         {
             var newHeader = CommitRewriteInfo.From(commit);
             var newTree = commit.Tree;
@@ -248,7 +248,7 @@ namespace LibGit2Sharp.Core
                                                              newHeader.Message,
                                                              newTree,
                                                              mappedNewParents,
-                                                             true);
+                                                             options.PrettifyMessages);
 
             // Record the rewrite
             objectMap[commit] = newCommit;

--- a/LibGit2Sharp/RewriteHistoryOptions.cs
+++ b/LibGit2Sharp/RewriteHistoryOptions.cs
@@ -77,5 +77,13 @@ namespace LibGit2Sharp
         /// </para>
         /// </summary>
         public Action<Exception> OnError { get; set; }
+
+        /// <summary>
+        /// Specifies Commit message prettifying behavior during rewrite.
+        /// NOTE: Prettifying may result in losing one or multiple lines in the commit message.
+        /// As such it is recommended to leave this set to false.
+        /// </summary>
+        /// <value><c>true</c> if Commit messages are prettified; otherwise, <c>false</c>.</value>
+        public bool PrettifyMessages { get; set; }
     }
 }


### PR DESCRIPTION
Implemented the breaking change for #621 and adjusted unit-tests to mimic behaviour before breakage.
Also adjusted the documentation for `Commit#this[relativePath]` as discussed in #966 

Since I don't yet fully understand the history-rewriting unit-tests I have not added new Unit-Tests.

If I missed something, please do drop a note, so I can fix it :+1: 

Note: Running all tests gives me following results with Mono on a Ubunutu: 
1989 okay, 0 failed, 0 errors, 0 inconclusive, 0 invalid, 17 ignored, 0 skipped 