### PR TITLE
Support only_follow_first_parent

### DIFF
--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -644,7 +644,7 @@ namespace LibGit2Sharp.Core
                     Version = 1,
                     DescribeStrategy = options.Strategy,
                     MaxCandidatesTags = 10,
-                    OnlyFollowFirstParent = false,
+                    OnlyFollowFirstParent = options.OnlyFollowFirstParent,
                     ShowCommitOidAsFallback = options.UseCommitIdAsFallback,
                 };
 

--- a/LibGit2Sharp/DescribeOptions.cs
+++ b/LibGit2Sharp/DescribeOptions.cs
@@ -21,6 +21,7 @@ namespace LibGit2Sharp
         {
             Strategy = DescribeStrategy.Default;
             MinimumCommitIdAbbreviatedSize = 7;
+            OnlyFollowFirstParent = false;
         }
 
         /// <summary>
@@ -54,5 +55,14 @@ namespace LibGit2Sharp
         /// </para>
         /// </summary>
         public bool AlwaysRenderLongFormat { get; set; }
+
+        /// <summary>
+        /// Follow only the first parent commit upon seeing a merge commit.
+        /// <para>
+        ///   This is useful when you wish to not match tags on branches merged in
+        ///   the history of the target commit.
+        /// </para>
+        /// </summary>
+        public bool OnlyFollowFirstParent { get; set; }
     }
 }


### PR DESCRIPTION
My team has been using `git describe --first-parent` to find the most recent tag on the current branch, allowing us to mine the following commits on that branch for issue IDs in our issue tracker. We recently switched to libgit2sharp, but discovered that the equivalent option from libgit2 (`only_follow_first_parent`) is not supported in libgit2sharp - false is always passed for this struct field.

This pull request adds an `OnlyFollowFirstParent` property to `DescribeOptions` and a corresponding test.

I've split the changes across three commits (adding the property, adding a failing test that uses the property, and adding the implementation) to support verifying that the test exercises the implementation. If this is excessive then let me know and I'll squash the changes into one commit.