### PR TITLE
LocalDebug configuration using locally-built libgit2

### DIFF
--- a/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
+++ b/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" />
   <PropertyGroup>
@@ -33,6 +33,16 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'LocalDebug|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\LocalDebug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;NET40</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Moq, Version=4.2.1507.118, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">

--- a/LibGit2Sharp.sln
+++ b/LibGit2Sharp.sln
@@ -13,15 +13,20 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		LocalDebug|Any CPU = LocalDebug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{EE6ED99F-CB12-4683-B055-D28FC7357A34}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{EE6ED99F-CB12-4683-B055-D28FC7357A34}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EE6ED99F-CB12-4683-B055-D28FC7357A34}.LocalDebug|Any CPU.ActiveCfg = LocalDebug|Any CPU
+		{EE6ED99F-CB12-4683-B055-D28FC7357A34}.LocalDebug|Any CPU.Build.0 = LocalDebug|Any CPU
 		{EE6ED99F-CB12-4683-B055-D28FC7357A34}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EE6ED99F-CB12-4683-B055-D28FC7357A34}.Release|Any CPU.Build.0 = Release|Any CPU
 		{286E63EB-04DD-4ADE-88D6-041B57800761}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{286E63EB-04DD-4ADE-88D6-041B57800761}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{286E63EB-04DD-4ADE-88D6-041B57800761}.LocalDebug|Any CPU.ActiveCfg = LocalDebug|Any CPU
+		{286E63EB-04DD-4ADE-88D6-041B57800761}.LocalDebug|Any CPU.Build.0 = LocalDebug|Any CPU
 		{286E63EB-04DD-4ADE-88D6-041B57800761}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{286E63EB-04DD-4ADE-88D6-041B57800761}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection

--- a/LibGit2Sharp/Core/NativeDllName_LocalDebug.cs
+++ b/LibGit2Sharp/Core/NativeDllName_LocalDebug.cs
@@ -1,0 +1,32 @@
+// When the "LocalDebug" configuration is selected we want NativeMethods.cs
+// to point to a locally-built version of the LibGit2 DLL/PDB files.  These
+// are always named "git2.{dll,pdb,so,...}.
+//
+// When a normal "Debug" or "Release" configuration is selected we want
+// NativeMethods.cs to point to the DLLs in the NativeBinaries NuGet
+// package.  However, these are named "git2-<sha>.{dll,pdb,...}".
+//
+// The DllImport() statement requires a COMPILE TIME CONSTANT STRING value
+// (either a string literal or a "const string" variable), so we cannot
+// have an environment variable or similar scheme to dynamically choose
+// the DLL to use.
+//
+// Therefore, we keep the existing GENERATED NativeDllName.cs as is.
+// (It is built by $/Lib/CustomBuiltTasks/GenerateNativeDllNameTask.)
+// The LibGit2Sharp.csproj CONDITIONALLY includes/compiles in the normal
+// builds.
+//
+// The .csproj CONDITIONALLY includes/compiles this file when "LocalDebug"
+// is set.
+//
+// Note when using "LocalDebug" it is up to the user to ensure that
+// their PATH (or non-Windows equivalent) is set to allow the LibGit2Sharp
+// initialization to find the locally-built DLLs.
+
+namespace LibGit2Sharp.Core
+{
+    internal static class NativeDllName
+    {
+        public const string Name = "git2";
+    }
+}

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -72,6 +72,15 @@ namespace LibGit2Sharp.Core
                 const string pathEnvVariable = "PATH";
                 Environment.SetEnvironmentVariable(pathEnvVariable,
                     String.Format(CultureInfo.InvariantCulture, "{0}{1}{2}", path, Path.PathSeparator, Environment.GetEnvironmentVariable(pathEnvVariable)));
+
+                // In the "LocalDebug" configuration we target a locally-built version of the LibGit2 DLL.
+                // Let them give us a hint to where it is.
+                string pathLocalDebug = Environment.GetEnvironmentVariable("LIBGIT2_LOCALDEBUG");
+                if (pathLocalDebug != null)
+                {
+                    Environment.SetEnvironmentVariable(pathEnvVariable,
+                        String.Format(CultureInfo.InvariantCulture, "{0}{1}{2}", pathLocalDebug, Path.PathSeparator, Environment.GetEnvironmentVariable(pathEnvVariable)));
+                }
             }
 
             // See LibraryLifetimeObject description.

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\LibGit2Sharp.NativeBinaries.1.0.81\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.81\build\LibGit2Sharp.NativeBinaries.props')" />
   <PropertyGroup>
@@ -38,6 +38,17 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <DocumentationFile>bin\Release\LibGit2Sharp.xml</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'LocalDebug|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\LocalDebug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;NET40</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DocumentationFile>bin\Debug\LibGit2Sharp.xml</DocumentationFile>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -182,7 +193,8 @@
     <Compile Include="Core\GitStrArray.cs" />
     <Compile Include="Core\GitStrArrayManaged.cs" />
     <Compile Include="Core\GitStrArrayNative.cs" />
-    <Compile Include="Core\NativeDllName.cs" />
+    <Compile Include="Core\NativeDllName.cs" Condition="'$(Configuration)' != 'LocalDebug'" />
+    <Compile Include="Core\NativeDllName_LocalDebug.cs" Condition="'$(Configuration)' == 'LocalDebug'" />
     <Compile Include="CommitRewriteInfo.cs" />
     <Compile Include="DiffModifiers.cs" />
     <Compile Include="ObjectType.cs" />


### PR DESCRIPTION
Here is an alternative to #1193.  Much simpler.

The goal is to allow you to use a locally-built version of libgit2.dll rather than getting it from the
NativeBinaries NuGet package.  This allows you hack on libgit2 and immediately use/test it
from C# without needing to build/deploy your own local NuGet package.

It works by defining a new "LocalDebug" configuration (based upon the standard "Debug"
configuration).  We then can switch the value of Core.NativeDllName.Name at compile time
using conditionals in the .csproj.  It also allows you to quickly switch between "Debug" and
"LocalDebug" in VisualStudio to do A/B testing on libgit2.

As a convenience, I also let you set "LIBGIT2_LOCALDEBUG" environment variable to
point to the directory containing your local build. This value is prepended to your PATH.
This step is optional.
