### PR TITLE
#1098 Deploy usage of support for message formatting in exception c'tors

### DIFF
--- a/LibGit2Sharp/Configuration.cs
+++ b/LibGit2Sharp/Configuration.cs
@@ -693,9 +693,9 @@ namespace LibGit2Sharp
 
             if (handle == null && throwIfStoreHasNotBeenFound)
             {
-                throw new LibGit2SharpException(string.Format(CultureInfo.InvariantCulture,
+                throw new LibGit2SharpException(CultureInfo.InvariantCulture,
                                                               "No {0} configuration file has been found.",
-                                                              Enum.GetName(typeof(ConfigurationLevel), level)));
+                                                              Enum.GetName(typeof(ConfigurationLevel), level));
             }
 
             return handle;

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -1432,9 +1432,9 @@ namespace LibGit2Sharp.Core
 
             if (IntPtr.Zero == toReturn)
             {
-                throw new LibGit2SharpException(String.Format(CultureInfo.InvariantCulture,
+                throw new LibGit2SharpException(CultureInfo.InvariantCulture,
                                                               "Unable to allocate {0} bytes; out of memory",
-                                                              len),
+                                                              len,
                                                 GitErrorCode.Error,
                                                 GitErrorCategory.NoMemory);
             }

--- a/LibGit2Sharp/Network.cs
+++ b/LibGit2Sharp/Network.cs
@@ -400,10 +400,9 @@ namespace LibGit2Sharp
                 if (string.IsNullOrEmpty(branch.UpstreamBranchCanonicalName))
                 {
                     throw new LibGit2SharpException(
-                        string.Format(
                             CultureInfo.InvariantCulture,
                             "The branch '{0}' (\"{1}\") that you are trying to push does not track an upstream branch.",
-                            branch.FriendlyName, branch.CanonicalName));
+                            branch.FriendlyName, branch.CanonicalName);
                 }
             }
 

--- a/LibGit2Sharp/Rebase.cs
+++ b/LibGit2Sharp/Rebase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using LibGit2Sharp.Core;
 using LibGit2Sharp.Core.Handles;
+using System.Globalization;
 
 namespace LibGit2Sharp
 {
@@ -80,8 +81,9 @@ namespace LibGit2Sharp
 
             if (this.repository.Info.CurrentOperation != CurrentOperation.None)
             {
-                throw new LibGit2SharpException(string.Format(
-                    "A {0} operation is already in progress.", this.repository.Info.CurrentOperation));
+                throw new LibGit2SharpException(CultureInfo.InvariantCulture,
+                    "A {0} operation is already in progress.", 
+                    this.repository.Info.CurrentOperation);
             }
 
             Func<Branch, ReferenceSafeHandle> RefHandleFromBranch = (Branch b) =>

--- a/LibGit2Sharp/RebaseOperationImpl.cs
+++ b/LibGit2Sharp/RebaseOperationImpl.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using LibGit2Sharp.Core;
+using System.Globalization;
 
 namespace LibGit2Sharp
 {
@@ -118,9 +119,9 @@ namespace LibGit2Sharp
                 case RebaseStepOperation.Fixup:
                 case RebaseStepOperation.Reword:
                     // These operations are not yet supported by lg2.
-                    throw new LibGit2SharpException(string.Format(
+                    throw new LibGit2SharpException(CultureInfo.InvariantCulture,
                         "Rebase Operation Type ({0}) is not currently supported in LibGit2Sharp.",
-                        stepToApplyInfo.Type));
+                        stepToApplyInfo.Type);
                 default:
                     throw new ArgumentException(string.Format(
                         "Unexpected Rebase Operation Type: {0}", stepToApplyInfo.Type));

--- a/LibGit2Sharp/ReferenceCollection.cs
+++ b/LibGit2Sharp/ReferenceCollection.cs
@@ -405,8 +405,9 @@ namespace LibGit2Sharp
             if (reference == null)
             {
                 throw new LibGit2SharpException(
-                    string.Format(CultureInfo.InvariantCulture,
-                        "Reference '{0}' doesn't exist. One cannot move a non existing reference.", currentName));
+                    CultureInfo.InvariantCulture,
+                    "Reference '{0}' doesn't exist. One cannot move a non existing reference.", 
+                    currentName);
             }
 
             return Rename(reference, newName, logMessage, allowOverwrite);

--- a/LibGit2Sharp/UnbornBranchException.cs
+++ b/LibGit2Sharp/UnbornBranchException.cs
@@ -32,7 +32,7 @@ namespace LibGit2Sharp
         /// <param name="format">A composite format string for use in <see cref="String.Format(IFormatProvider, string, object[])"/>.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         public UnbornBranchException(CultureInfo cultureInfo, string format, params object[] args)
-            : base(String.Format(cultureInfo, format, args))
+            : base(cultureInfo, format, args)
         { }
 
         /// <summary>


### PR DESCRIPTION
Reviewed usages of LibGit2SharpException and removed any unnecessary
string.format calls.