### PR TITLE
String format ctor for exceptions

### DIFF
--- a/LibGit2Sharp/AmbiguousSpecificationException.cs
+++ b/LibGit2Sharp/AmbiguousSpecificationException.cs
@@ -27,11 +27,10 @@ namespace LibGit2Sharp
         /// <summary>
         /// Initializes a new instance of the <see cref="AmbiguousSpecificationException"/> class with a specified error message.
         /// </summary>
-        /// <param name="cultureInfo">An object that supplies culture-specific formatting information.</param>
         /// <param name="format">A composite format string for use in <see cref="String.Format(IFormatProvider, string, object[])"/>.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        public AmbiguousSpecificationException(CultureInfo cultureInfo, string format, params object[] args)
-            : base(String.Format(cultureInfo, format, args))
+        public AmbiguousSpecificationException(string format, params object[] args)
+            : base(String.Format(format, args))
         {
         }
 

--- a/LibGit2Sharp/BareRepositoryException.cs
+++ b/LibGit2Sharp/BareRepositoryException.cs
@@ -26,6 +26,15 @@ namespace LibGit2Sharp
         { }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="LibGit2Sharp.BareRepositoryException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="format">A composite format string for use in <see cref="String.Format(IFormatProvider, string, object[])"/>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        public BareRepositoryException(string format, params object[] args)
+            : base(format, args)
+        { }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="LibGit2Sharp.BareRepositoryException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
         /// </summary>
         /// <param name="message">The error message that explains the reason for the exception.</param>

--- a/LibGit2Sharp/BranchCollection.cs
+++ b/LibGit2Sharp/BranchCollection.cs
@@ -263,8 +263,7 @@ namespace LibGit2Sharp
 
             if (branch.IsRemote)
             {
-                throw new LibGit2SharpException(CultureInfo.InvariantCulture,
-                                                "Cannot rename branch '{0}'. It's a remote tracking branch.",
+                throw new LibGit2SharpException("Cannot rename branch '{0}'. It's a remote tracking branch.",
                                                 branch.FriendlyName);
             }
 

--- a/LibGit2Sharp/CheckoutConflictException.cs
+++ b/LibGit2Sharp/CheckoutConflictException.cs
@@ -27,6 +27,15 @@ namespace LibGit2Sharp
         { }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="LibGit2Sharp.CheckoutConflictException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="format">A composite format string for use in <see cref="String.Format(IFormatProvider, string, object[])"/>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        public CheckoutConflictException(string format, params object[] args)
+            : base(format, args)
+        { }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="LibGit2Sharp.CheckoutConflictException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
         /// </summary>
         /// <param name="message">The error message that explains the reason for the exception.</param>

--- a/LibGit2Sharp/Configuration.cs
+++ b/LibGit2Sharp/Configuration.cs
@@ -693,8 +693,7 @@ namespace LibGit2Sharp
 
             if (handle == null && throwIfStoreHasNotBeenFound)
             {
-                throw new LibGit2SharpException(CultureInfo.InvariantCulture,
-                                                              "No {0} configuration file has been found.",
+                throw new LibGit2SharpException("No {0} configuration file has been found.",
                                                               Enum.GetName(typeof(ConfigurationLevel), level));
             }
 

--- a/LibGit2Sharp/Core/Ensure.cs
+++ b/LibGit2Sharp/Core/Ensure.cs
@@ -261,16 +261,14 @@ namespace LibGit2Sharp.Core
                 return;
             }
 
-            var message = string.Format(CultureInfo.InvariantCulture,
-                                        "No valid git object identified by '{0}' exists in the repository.",
-                                        identifier);
-
+            var messageFormat = "No valid git object identified by '{0}' exists in the repository.";
+                                        
             if (string.Equals("HEAD", identifier, StringComparison.Ordinal))
             {
-                throw new UnbornBranchException(message);
+                throw new UnbornBranchException(messageFormat, identifier);
             }
 
-            throw new NotFoundException(message);
+            throw new NotFoundException(messageFormat, identifier);
         }
     }
 }

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -1432,9 +1432,8 @@ namespace LibGit2Sharp.Core
 
             if (IntPtr.Zero == toReturn)
             {
-                throw new LibGit2SharpException(CultureInfo.InvariantCulture,
-                                                              "Unable to allocate {0} bytes; out of memory",
-                                                              len,
+                throw new LibGit2SharpException("Unable to allocate {0} bytes; out of memory",
+                                                len,
                                                 GitErrorCode.Error,
                                                 GitErrorCategory.NoMemory);
             }
@@ -2556,8 +2555,7 @@ namespace LibGit2Sharp.Core
                     return null;
 
                 case (int)GitErrorCode.Ambiguous:
-                    throw new AmbiguousSpecificationException(CultureInfo.InvariantCulture,
-                                                              "Provided abbreviated ObjectId '{0}' is too short.",
+                    throw new AmbiguousSpecificationException("Provided abbreviated ObjectId '{0}' is too short.",
                                                               objectish);
 
                 default:
@@ -2778,8 +2776,7 @@ namespace LibGit2Sharp.Core
                     return FileStatus.Nonexistent;
 
                 case (int)GitErrorCode.Ambiguous:
-                    throw new AmbiguousSpecificationException(CultureInfo.InvariantCulture,
-                                                              "More than one file matches the pathspec '{0}'. " +
+                    throw new AmbiguousSpecificationException("More than one file matches the pathspec '{0}'. " +
                                                               "You can either force a literal path evaluation " +
                                                               "(GIT_STATUS_OPT_DISABLE_PATHSPEC_MATCH), or use git_status_foreach().",
                                                               path);

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -823,8 +823,7 @@ namespace LibGit2Sharp.Core
             int res = NativeMethods.git_filter_register(name, filterPtr, priority);
             if (res == (int)GitErrorCode.Exists)
             {
-                var message = String.Format("A filter with the name '{0}' is already registered", name);
-                throw new EntryExistsException(message);
+                throw new EntryExistsException("A filter with the name '{0}' is already registered", name);
             }
             Ensure.ZeroResult(res);
         }
@@ -2256,7 +2255,7 @@ namespace LibGit2Sharp.Core
 
                 if (res == (int)GitErrorCode.NotFound)
                 {
-                    throw new NotFoundException(string.Format("Remote '{0}' does not exist and cannot be renamed.", name));
+                    throw new NotFoundException("Remote '{0}' does not exist and cannot be renamed.", name);
                 }
 
                 Ensure.ZeroResult(res);
@@ -2404,9 +2403,8 @@ namespace LibGit2Sharp.Core
 
             if (res == (int)GitErrorCode.NotFound)
             {
-                throw new RepositoryNotFoundException(String.Format(CultureInfo.InvariantCulture,
-                                                                    "Path '{0}' doesn't point at a valid Git repository or workdir.",
-                                                                    path));
+                throw new RepositoryNotFoundException("Path '{0}' doesn't point at a valid Git repository or workdir.",
+                                                                    path);
             }
 
             Ensure.ZeroResult(res);
@@ -2435,9 +2433,8 @@ namespace LibGit2Sharp.Core
 
             if (res == (int)GitErrorCode.NotFound)
             {
-                throw new RepositoryNotFoundException(String.Format(CultureInfo.InvariantCulture,
-                                                                    "Path '{0}' doesn't point at a valid Git repository or workdir.",
-                                                                    path));
+                throw new RepositoryNotFoundException("Path '{0}' doesn't point at a valid Git repository or workdir.",
+                                                                    path);
             }
 
             Ensure.ZeroResult(res);
@@ -3076,8 +3073,8 @@ namespace LibGit2Sharp.Core
 
             if (res == (int)GitErrorCode.Exists)
             {
-                throw new EntryExistsException(String.Format("A custom transport for '{0}' is already registered",
-                    prefix));
+                throw new EntryExistsException("A custom transport for '{0}' is already registered",
+                    prefix);
             }
 
             Ensure.ZeroResult(res);

--- a/LibGit2Sharp/Diff.cs
+++ b/LibGit2Sharp/Diff.cs
@@ -109,8 +109,7 @@ namespace LibGit2Sharp
 
             if (!ChangesBuilders.TryGetValue(typeof(T), out builder))
             {
-                throw new LibGit2SharpException(CultureInfo.InvariantCulture,
-                    "User-defined types passed to Compare are not supported. Supported values are: {0}",
+                throw new LibGit2SharpException("User-defined types passed to Compare are not supported. Supported values are: {0}",
                     string.Join(", ", ChangesBuilders.Keys.Select(x => x.Name)));
             }
 

--- a/LibGit2Sharp/EmptyCommitException.cs
+++ b/LibGit2Sharp/EmptyCommitException.cs
@@ -25,6 +25,15 @@ namespace LibGit2Sharp
         { }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="EmptyCommitException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="format">A composite format string for use in <see cref="String.Format(IFormatProvider, string, object[])"/>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        public EmptyCommitException(string format, params object[] args)
+            : base(format, args)
+        { }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="EmptyCommitException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
         /// </summary>
         /// <param name="message">The error message that explains the reason for the exception.</param>

--- a/LibGit2Sharp/EntryExistsException.cs
+++ b/LibGit2Sharp/EntryExistsException.cs
@@ -25,6 +25,15 @@ namespace LibGit2Sharp
         { }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="LibGit2Sharp.EntryExistsException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="format">A composite format string for use in <see cref="String.Format(IFormatProvider, string, object[])"/>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        public EntryExistsException(string format, params object[] args)
+            : base(format, args)
+        { }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="LibGit2Sharp.EntryExistsException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
         /// </summary>
         /// <param name="message">The error message that explains the reason for the exception.</param>

--- a/LibGit2Sharp/GitObject.cs
+++ b/LibGit2Sharp/GitObject.cs
@@ -77,8 +77,7 @@ namespace LibGit2Sharp
                     return new Blob(repo, id);
 
                 default:
-                    throw new LibGit2SharpException(CultureInfo.InvariantCulture,
-                                                    "Unexpected type '{0}' for object '{1}'.",
+                    throw new LibGit2SharpException("Unexpected type '{0}' for object '{1}'.",
                                                     type,
                                                     id);
             }

--- a/LibGit2Sharp/InvalidSpecificationException.cs
+++ b/LibGit2Sharp/InvalidSpecificationException.cs
@@ -28,6 +28,15 @@ namespace LibGit2Sharp
         { }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="InvalidSpecificationException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="format">A composite format string for use in <see cref="String.Format(IFormatProvider, string, object[])"/>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        public InvalidSpecificationException(string format, params object[] args)
+            : base(format, args)
+        { }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="InvalidSpecificationException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
         /// </summary>
         /// <param name="message">The error message that explains the reason for the exception.</param>

--- a/LibGit2Sharp/LibGit2SharpException.cs
+++ b/LibGit2Sharp/LibGit2SharpException.cs
@@ -37,11 +37,10 @@ namespace LibGit2Sharp
         /// <summary>
         /// Initializes a new instance of the <see cref="LibGit2SharpException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
         /// </summary>
-        /// <param name="cultureInfo">An object that supplies culture-specific formatting information.</param>
         /// <param name="format">A composite format string for use in <see cref="String.Format(IFormatProvider, string, object[])"/>.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        public LibGit2SharpException(CultureInfo cultureInfo, string format, params object[] args)
-            : base(String.Format(cultureInfo, format, args))
+        public LibGit2SharpException(string format, params object[] args)
+            : base(String.Format(CultureInfo.InvariantCulture, format, args))
         {
         }
 

--- a/LibGit2Sharp/LockedFileException.cs
+++ b/LibGit2Sharp/LockedFileException.cs
@@ -25,6 +25,15 @@ namespace LibGit2Sharp
         { }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="LibGit2Sharp.LockedFileException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="format">A composite format string for use in <see cref="String.Format(IFormatProvider, string, object[])"/>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        public LockedFileException(string format, params object[] args)
+            : base(format, args)
+        { }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="LibGit2Sharp.LockedFileException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
         /// </summary>
         /// <param name="message">The error message that explains the reason for the exception.</param>

--- a/LibGit2Sharp/MergeFetchHeadNotFoundException.cs
+++ b/LibGit2Sharp/MergeFetchHeadNotFoundException.cs
@@ -24,6 +24,15 @@ namespace LibGit2Sharp
         { }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="MergeFetchHeadNotFoundException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="format">A composite format string for use in <see cref="String.Format(IFormatProvider, string, object[])"/>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        public MergeFetchHeadNotFoundException(string format, params object[] args)
+            : base(format, args)
+        { }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="MergeFetchHeadNotFoundException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
         /// </summary>
         /// <param name="message">The error message that explains the reason for the exception.</param>

--- a/LibGit2Sharp/NameConflictException.cs
+++ b/LibGit2Sharp/NameConflictException.cs
@@ -25,6 +25,15 @@ namespace LibGit2Sharp
         { }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="NameConflictException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="format">A composite format string for use in <see cref="String.Format(IFormatProvider, string, object[])"/>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        public NameConflictException(string format, params object[] args)
+            : base(format, args)
+        { }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="NameConflictException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
         /// </summary>
         /// <param name="message">The error message that explains the reason for the exception.</param>

--- a/LibGit2Sharp/Network.cs
+++ b/LibGit2Sharp/Network.cs
@@ -399,9 +399,7 @@ namespace LibGit2Sharp
             {
                 if (string.IsNullOrEmpty(branch.UpstreamBranchCanonicalName))
                 {
-                    throw new LibGit2SharpException(
-                            CultureInfo.InvariantCulture,
-                            "The branch '{0}' (\"{1}\") that you are trying to push does not track an upstream branch.",
+                    throw new LibGit2SharpException("The branch '{0}' (\"{1}\") that you are trying to push does not track an upstream branch.",
                             branch.FriendlyName, branch.CanonicalName);
                 }
             }

--- a/LibGit2Sharp/NonFastForwardException.cs
+++ b/LibGit2Sharp/NonFastForwardException.cs
@@ -26,6 +26,15 @@ namespace LibGit2Sharp
         { }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="LibGit2Sharp.NonFastForwardException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="format">A composite format string for use in <see cref="String.Format(IFormatProvider, string, object[])"/>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        public NonFastForwardException(string format, params object[] args)
+            : base(format, args)
+        { }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="LibGit2Sharp.NonFastForwardException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
         /// </summary>
         /// <param name="message">The error message that explains the reason for the exception.</param>

--- a/LibGit2Sharp/NotFoundException.cs
+++ b/LibGit2Sharp/NotFoundException.cs
@@ -25,6 +25,15 @@ namespace LibGit2Sharp
         { }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="LibGit2Sharp.NotFoundException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="format">A composite format string for use in <see cref="String.Format(IFormatProvider, string, object[])"/>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        public NotFoundException(string format, params object[] args)
+            : base(format, args)
+        { }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="LibGit2Sharp.NotFoundException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
         /// </summary>
         /// <param name="message">The error message that explains the reason for the exception.</param>

--- a/LibGit2Sharp/PeelException.cs
+++ b/LibGit2Sharp/PeelException.cs
@@ -26,6 +26,15 @@ namespace LibGit2Sharp
         { }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="PeelException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="format">A composite format string for use in <see cref="String.Format(IFormatProvider, string, object[])"/>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        public PeelException(string format, params object[] args)
+            : base(format, args)
+        { }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="PeelException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
         /// </summary>
         /// <param name="message">The error message that explains the reason for the exception.</param>

--- a/LibGit2Sharp/Rebase.cs
+++ b/LibGit2Sharp/Rebase.cs
@@ -81,8 +81,7 @@ namespace LibGit2Sharp
 
             if (this.repository.Info.CurrentOperation != CurrentOperation.None)
             {
-                throw new LibGit2SharpException(CultureInfo.InvariantCulture,
-                    "A {0} operation is already in progress.", 
+                throw new LibGit2SharpException("A {0} operation is already in progress.", 
                     this.repository.Info.CurrentOperation);
             }
 

--- a/LibGit2Sharp/RebaseOperationImpl.cs
+++ b/LibGit2Sharp/RebaseOperationImpl.cs
@@ -119,8 +119,7 @@ namespace LibGit2Sharp
                 case RebaseStepOperation.Fixup:
                 case RebaseStepOperation.Reword:
                     // These operations are not yet supported by lg2.
-                    throw new LibGit2SharpException(CultureInfo.InvariantCulture,
-                        "Rebase Operation Type ({0}) is not currently supported in LibGit2Sharp.",
+                    throw new LibGit2SharpException("Rebase Operation Type ({0}) is not currently supported in LibGit2Sharp.",
                         stepToApplyInfo.Type);
                 default:
                     throw new ArgumentException(string.Format(

--- a/LibGit2Sharp/Reference.cs
+++ b/LibGit2Sharp/Reference.cs
@@ -59,7 +59,7 @@ namespace LibGit2Sharp
                     break;
 
                 default:
-                    throw new LibGit2SharpException(CultureInfo.InvariantCulture, "Unable to build a new reference from a type '{0}'.", type);
+                    throw new LibGit2SharpException("Unable to build a new reference from a type '{0}'.", type);
             }
 
             return reference as T;

--- a/LibGit2Sharp/ReferenceCollection.cs
+++ b/LibGit2Sharp/ReferenceCollection.cs
@@ -404,9 +404,7 @@ namespace LibGit2Sharp
 
             if (reference == null)
             {
-                throw new LibGit2SharpException(
-                    CultureInfo.InvariantCulture,
-                    "Reference '{0}' doesn't exist. One cannot move a non existing reference.", 
+                throw new LibGit2SharpException("Reference '{0}' doesn't exist. One cannot move a non existing reference.", 
                     currentName);
             }
 
@@ -547,8 +545,7 @@ namespace LibGit2Sharp
                 return UpdateTarget(symbolicReference, targetRef, logMessage);
             }
 
-            throw new LibGit2SharpException(CultureInfo.InvariantCulture,
-                                            "Reference '{0}' has an unexpected type ('{1}').",
+            throw new LibGit2SharpException("Reference '{0}' has an unexpected type ('{1}').",
                                             name,
                                             reference.GetType());
         }

--- a/LibGit2Sharp/ReflogCollection.cs
+++ b/LibGit2Sharp/ReflogCollection.cs
@@ -37,8 +37,7 @@ namespace LibGit2Sharp
 
             if (!Reference.IsValidName(canonicalName))
             {
-                throw new InvalidSpecificationException(
-                    string.Format(CultureInfo.InvariantCulture, "The given reference name '{0}' is not valid", canonicalName));
+                throw new InvalidSpecificationException("The given reference name '{0}' is not valid", canonicalName);
             }
 
             this.repo = repo;

--- a/LibGit2Sharp/RemoveFromIndexException.cs
+++ b/LibGit2Sharp/RemoveFromIndexException.cs
@@ -25,7 +25,7 @@ namespace LibGit2Sharp
         { }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="LibGit2SharpException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
+        /// Initializes a new instance of the <see cref="RemoveFromIndexException"/> class with a specified error message.
         /// </summary>
         /// <param name="format">A composite format string for use in <see cref="String.Format(IFormatProvider, string, object[])"/>.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>

--- a/LibGit2Sharp/RemoveFromIndexException.cs
+++ b/LibGit2Sharp/RemoveFromIndexException.cs
@@ -27,11 +27,10 @@ namespace LibGit2Sharp
         /// <summary>
         /// Initializes a new instance of the <see cref="LibGit2SharpException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
         /// </summary>
-        /// <param name="cultureInfo">An object that supplies culture-specific formatting information.</param>
         /// <param name="format">A composite format string for use in <see cref="String.Format(IFormatProvider, string, object[])"/>.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        public RemoveFromIndexException(CultureInfo cultureInfo, string format, params object[] args)
-            : base(cultureInfo, format, args)
+        public RemoveFromIndexException(string format, params object[] args)
+            : base(format, args)
         {
         }
 

--- a/LibGit2Sharp/Repository.cs
+++ b/LibGit2Sharp/Repository.cs
@@ -900,8 +900,7 @@ namespace LibGit2Sharp
             // Make sure this is not an unborn branch.
             if (branch.Tip == null)
             {
-                throw new UnbornBranchException(CultureInfo.InvariantCulture,
-                                                "The tip of branch '{0}' is null. There's nothing to checkout.",
+                throw new UnbornBranchException("The tip of branch '{0}' is null. There's nothing to checkout.",
                                                 branch.FriendlyName);
             }
 
@@ -1858,8 +1857,7 @@ namespace LibGit2Sharp
                 FileStatus sourceStatus = keyValuePair.Key.Item2;
                 if (sourceStatus.HasAny(new Enum[] { FileStatus.Nonexistent, FileStatus.DeletedFromIndex, FileStatus.NewInWorkdir, FileStatus.DeletedFromWorkdir }))
                 {
-                    throw new LibGit2SharpException(CultureInfo.InvariantCulture,
-                                                    "Unable to move file '{0}'. Its current status is '{1}'.",
+                    throw new LibGit2SharpException("Unable to move file '{0}'. Its current status is '{1}'.",
                                                     sourcePath,
                                                     sourceStatus);
                 }
@@ -1870,8 +1868,7 @@ namespace LibGit2Sharp
                     continue;
                 }
 
-                throw new LibGit2SharpException(CultureInfo.InvariantCulture,
-                                                "Unable to overwrite file '{0}'. Its current status is '{1}'.",
+                throw new LibGit2SharpException("Unable to overwrite file '{0}'. Its current status is '{1}'.",
                                                 destPath,
                                                 desStatus);
             }
@@ -2106,8 +2103,7 @@ namespace LibGit2Sharp
                             status.HasFlag(FileStatus.ModifiedInIndex) ||
                             status.HasFlag(FileStatus.NewInIndex)))
                         {
-                            throw new RemoveFromIndexException(CultureInfo.InvariantCulture,
-                                                               "Unable to remove file '{0}', as it has changes staged in the index. You can call the Remove() method with removeFromWorkingDirectory=false if you want to remove it from the index only.",
+                            throw new RemoveFromIndexException("Unable to remove file '{0}', as it has changes staged in the index. You can call the Remove() method with removeFromWorkingDirectory=false if you want to remove it from the index only.",
                                                                treeEntryChanges.Path);
                         }
                         removed.Add(RemoveFromIndex(treeEntryChanges.Path));
@@ -2116,22 +2112,19 @@ namespace LibGit2Sharp
                     case ChangeKind.Modified:
                         if (status.HasFlag(FileStatus.ModifiedInWorkdir) && status.HasFlag(FileStatus.ModifiedInIndex))
                         {
-                            throw new RemoveFromIndexException(CultureInfo.InvariantCulture,
-                                                               "Unable to remove file '{0}', as it has staged content different from both the working directory and the HEAD.",
+                            throw new RemoveFromIndexException("Unable to remove file '{0}', as it has staged content different from both the working directory and the HEAD.",
                                                                treeEntryChanges.Path);
                         }
                         if (removeFromWorkingDirectory)
                         {
-                            throw new RemoveFromIndexException(CultureInfo.InvariantCulture,
-                                                               "Unable to remove file '{0}', as it has local modifications. You can call the Remove() method with removeFromWorkingDirectory=false if you want to remove it from the index only.",
+                            throw new RemoveFromIndexException("Unable to remove file '{0}', as it has local modifications. You can call the Remove() method with removeFromWorkingDirectory=false if you want to remove it from the index only.",
                                                                treeEntryChanges.Path);
                         }
                         removed.Add(RemoveFromIndex(treeEntryChanges.Path));
                         continue;
 
                     default:
-                        throw new RemoveFromIndexException(CultureInfo.InvariantCulture,
-                                                           "Unable to remove file '{0}'. Its current status is '{1}'.",
+                        throw new RemoveFromIndexException("Unable to remove file '{0}'. Its current status is '{1}'.",
                                                            treeEntryChanges.Path,
                                                            treeEntryChanges.Status);
                 }

--- a/LibGit2Sharp/Repository.cs
+++ b/LibGit2Sharp/Repository.cs
@@ -1080,11 +1080,9 @@ namespace LibGit2Sharp
 
                 if (treesame && !amendMergeCommit)
                 {
-                    throw new EmptyCommitException(
-                        options.AmendPreviousCommit ?
-                        String.Format(CultureInfo.InvariantCulture,
-                            "Amending this commit would produce a commit that is identical to its parent (id = {0})", parents[0].Id) :
-                        "No changes; nothing to commit.");
+                    throw (options.AmendPreviousCommit ? 
+                        new EmptyCommitException("Amending this commit would produce a commit that is identical to its parent (id = {0})", parents[0].Id) :
+                        new EmptyCommitException("No changes; nothing to commit."));
                 }
             }
 
@@ -1273,8 +1271,8 @@ namespace LibGit2Sharp
             if (fetchHeads.Length == 0)
             {
                 var expectedRef = this.Head.UpstreamBranchCanonicalName;
-                throw new MergeFetchHeadNotFoundException(string.Format(CultureInfo.InvariantCulture,
-                    "The current branch is configured to merge with the reference '{0}' from the remote, but this reference was not fetched.", expectedRef));
+                throw new MergeFetchHeadNotFoundException("The current branch is configured to merge with the reference '{0}' from the remote, but this reference was not fetched.", 
+                    expectedRef);
             }
 
             GitAnnotatedCommitHandle[] annotatedCommitHandles = fetchHeads.Select(fetchHead =>

--- a/LibGit2Sharp/RepositoryExtensions.cs
+++ b/LibGit2Sharp/RepositoryExtensions.cs
@@ -485,7 +485,7 @@ namespace LibGit2Sharp
 
             if (throwIfNotFound)
             {
-                throw new LibGit2SharpException(CultureInfo.InvariantCulture, "Unexpected kind of identifier '{0}'.", identifier);
+                throw new LibGit2SharpException("Unexpected kind of identifier '{0}'.", identifier);
             }
 
             yield return null;

--- a/LibGit2Sharp/RepositoryNotFoundException.cs
+++ b/LibGit2Sharp/RepositoryNotFoundException.cs
@@ -25,6 +25,15 @@ namespace LibGit2Sharp
         { }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="RepositoryNotFoundException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="format">A composite format string for use in <see cref="String.Format(IFormatProvider, string, object[])"/>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        public RepositoryNotFoundException(string format, params object[] args)
+            : base(format, args)
+        { }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="RepositoryNotFoundException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
         /// </summary>
         /// <param name="message">The error message that explains the reason for the exception.</param>

--- a/LibGit2Sharp/SubmoduleCollection.cs
+++ b/LibGit2Sharp/SubmoduleCollection.cs
@@ -62,9 +62,8 @@ namespace LibGit2Sharp
             {
                 if (handle == null)
                 {
-                    throw new NotFoundException(string.Format(CultureInfo.InvariantCulture,
-                                                              "Submodule lookup failed for '{0}'.",
-                                                              name));
+                    throw new NotFoundException("Submodule lookup failed for '{0}'.",
+                                                name);
                 }
 
                 Proxy.git_submodule_init(handle, overwrite);
@@ -90,9 +89,8 @@ namespace LibGit2Sharp
             {
                 if (handle == null)
                 {
-                    throw new NotFoundException(string.Format(CultureInfo.InvariantCulture,
-                                                              "Submodule lookup failed for '{0}'.",
-                                                              name));
+                    throw new NotFoundException("Submodule lookup failed for '{0}'.",
+                                                              name);
                 }
 
                 using (GitCheckoutOptsWrapper checkoutOptionsWrapper = new GitCheckoutOptsWrapper(options))

--- a/LibGit2Sharp/SubmoduleCollection.cs
+++ b/LibGit2Sharp/SubmoduleCollection.cs
@@ -160,7 +160,7 @@ namespace LibGit2Sharp
 
                 if (throwIfNotFound)
                 {
-                    throw new LibGit2SharpException(CultureInfo.InvariantCulture, "Submodule lookup failed for '{0}'.", name);
+                    throw new LibGit2SharpException("Submodule lookup failed for '{0}'.", name);
                 }
 
                 return default(T);

--- a/LibGit2Sharp/UnbornBranchException.cs
+++ b/LibGit2Sharp/UnbornBranchException.cs
@@ -28,11 +28,10 @@ namespace LibGit2Sharp
         /// <summary>
         /// Initializes a new instance of the <see cref="UnbornBranchException"/> class with a specified error message.
         /// </summary>
-        /// <param name="cultureInfo">An object that supplies culture-specific formatting information.</param>
         /// <param name="format">A composite format string for use in <see cref="String.Format(IFormatProvider, string, object[])"/>.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        public UnbornBranchException(CultureInfo cultureInfo, string format, params object[] args)
-            : base(cultureInfo, format, args)
+        public UnbornBranchException(string format, params object[] args)
+            : base(format, args)
         { }
 
         /// <summary>

--- a/LibGit2Sharp/UnmatchedPathException.cs
+++ b/LibGit2Sharp/UnmatchedPathException.cs
@@ -24,6 +24,15 @@ namespace LibGit2Sharp
         { }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="UnmatchedPathException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="format">A composite format string for use in <see cref="String.Format(IFormatProvider, string, object[])"/>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        public UnmatchedPathException(string format, params object[] args)
+            : base(format, args)
+        { }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="UnmatchedPathException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
         /// </summary>
         /// <param name="message">The error message that explains the reason for the exception.</param>

--- a/LibGit2Sharp/UnmergedIndexEntriesException.cs
+++ b/LibGit2Sharp/UnmergedIndexEntriesException.cs
@@ -26,6 +26,15 @@ namespace LibGit2Sharp
         { }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="UnmergedIndexEntriesException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="format">A composite format string for use in <see cref="String.Format(IFormatProvider, string, object[])"/>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        public UnmergedIndexEntriesException(string format, params object[] args)
+            : base(format, args)
+        { }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="UnmergedIndexEntriesException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
         /// </summary>
         /// <param name="message">The error message that explains the reason for the exception.</param>

--- a/LibGit2Sharp/UserCanceledException.cs
+++ b/LibGit2Sharp/UserCanceledException.cs
@@ -25,6 +25,15 @@ namespace LibGit2Sharp
         { }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="LibGit2Sharp.UserCancelledException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="format">A composite format string for use in <see cref="String.Format(IFormatProvider, string, object[])"/>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        public UserCancelledException(string format, params object[] args)
+            : base(format, args)
+        { }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="LibGit2Sharp.UserCancelledException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
         /// </summary>
         /// <param name="message">The error message that explains the reason for the exception.</param>


### PR DESCRIPTION
* Added a c'tor to all exceptions that accepts (IFormatProvider provider, string format, params object[] args) and calls the corresponding LibGit2SharpException c'tor
* changed the LibGit2SharpException c'tor (and all the rest) to accept IFormatProvider instead of CultureInfo.
* Changed all usages to use the new c'tors (where applicable)