### PR TITLE
#1017 Add a finalizer SmartSubtransportRegistration

### DIFF
--- a/LibGit2Sharp.Tests/SmartSubtransportFixture.cs
+++ b/LibGit2Sharp.Tests/SmartSubtransportFixture.cs
@@ -70,8 +70,7 @@ namespace LibGit2Sharp.Tests
             }
             finally
             {
-                GlobalSettings.UnregisterSmartSubtransport(registration);
-
+                registration.Dispose();
                 ServicePointManager.ServerCertificateValidationCallback -= certificateValidationCallback;
             }
         }
@@ -89,20 +88,8 @@ namespace LibGit2Sharp.Tests
             }
             finally
             {
-                GlobalSettings.UnregisterSmartSubtransport(httpRegistration);
+                httpRegistration.Dispose();
             }
-        }
-
-        [Fact]
-        public void CannotUnregisterTwice()
-        {
-            SmartSubtransportRegistration<MockSmartSubtransport> httpRegistration =
-                GlobalSettings.RegisterSmartSubtransport<MockSmartSubtransport>("http");
-
-            GlobalSettings.UnregisterSmartSubtransport(httpRegistration);
-
-            Assert.Throws<NotFoundException>(() =>
-                GlobalSettings.UnregisterSmartSubtransport(httpRegistration));
         }
 
         private class MockSmartSubtransport : RpcSmartSubtransport

--- a/LibGit2Sharp/GlobalSettings.cs
+++ b/LibGit2Sharp/GlobalSettings.cs
@@ -79,21 +79,6 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
-        /// Unregisters a previously registered <see cref="SmartSubtransport"/>
-        /// as a custom smart-protocol transport with libgit2.
-        /// </summary>
-        /// <typeparam name="T">The type of SmartSubtransport to register</typeparam>
-        /// <param name="registration">The previous registration</param>
-        public static void UnregisterSmartSubtransport<T>(SmartSubtransportRegistration<T> registration)
-            where T : SmartSubtransport, new()
-        {
-            Ensure.ArgumentNotNull(registration, "registration");
-
-            Proxy.git_transport_unregister(registration.Scheme);
-            registration.Free();
-        }
-
-        /// <summary>
         /// Registers a new <see cref="LogConfiguration"/> to receive
         /// information logging information from libgit2 and LibGit2Sharp.
         ///

--- a/LibGit2Sharp/SmartSubtransportRegistration.cs
+++ b/LibGit2Sharp/SmartSubtransportRegistration.cs
@@ -9,9 +9,11 @@ namespace LibGit2Sharp
     /// under a particular scheme (eg "http").
     /// </summary>
     /// <typeparam name="T">The type of SmartSubtransport to register</typeparam>
-    public sealed class SmartSubtransportRegistration<T>
+    public sealed class SmartSubtransportRegistration<T> : IDisposable
         where T : SmartSubtransport, new()
     {
+        private bool disposed = false;
+
         /// <summary>
         /// Creates a new native registration for a smart protocol transport
         /// in libgit2.
@@ -57,6 +59,38 @@ namespace LibGit2Sharp
             RegistrationPointer = IntPtr.Zero;
         }
 
+        void Dispose(bool disposing)
+        {
+            if (!disposed)
+            {
+                if (disposing)
+                {
+                    // dispose managed objects
+                }
+                // dispose unmanaged objects
+                Proxy.git_transport_unregister(Scheme);
+                Free();
+                disposed = true;
+            }
+        }
+
+        /// <summary>
+        /// Clean up resources
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Finalizer called to free unmanaged resources
+        /// </summary>
+        ~SmartSubtransportRegistration()
+        {
+            Dispose(false);
+        }
+        
         private static class EntryPoints
         {
             // Because our GitSmartSubtransportRegistration structure exists on the managed heap only for a short time (to be marshaled


### PR DESCRIPTION
-Implement IDisposable and added finalizer to
SmartSubtransportRegistration
-Updated tests to now call dispose
-Removed CannotUnregisterTwice test, as this test is no longer
applicable after implementing dispose pattern.
