### PR TITLE
Run mono with --debug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ os:
  - osx
  - linux
 
+env:
+ global:
+  - MONO_OPTIONS=--debug
+
 before_install:
  - date -u
  - uname -a


### PR DESCRIPTION
This makes mono load debug information from the assembly so we get e.g. line numbers in stack traces.