### PR TITLE
Expose the Minimal diff algorithm

### DIFF
--- a/LibGit2Sharp/Diff.cs
+++ b/LibGit2Sharp/Diff.cs
@@ -53,6 +53,10 @@ namespace LibGit2Sharp
             {
                 options.Flags |= GitDiffOptionFlags.GIT_DIFF_PATIENCE;
             }
+            else if (compareOptions.Algorithm == DiffAlgorithm.Minimal)
+            {
+                options.Flags |= GitDiffOptionFlags.GIT_DIFF_MINIMAL;
+            }
 
             if (diffOptions.HasFlag(DiffModifiers.DisablePathspecMatch))
             {

--- a/LibGit2Sharp/DiffAlgorithm.cs
+++ b/LibGit2Sharp/DiffAlgorithm.cs
@@ -11,6 +11,11 @@ namespace LibGit2Sharp
         Meyers = 0,
 
         /// <summary>
+        /// Use "minimal diff" algorithm when generating patches.
+        /// </summary>
+        Minimal = 1,
+
+        /// <summary>
         /// Use "patience diff" algorithm when generating patches.
         /// </summary>
         Patience = 2,


### PR DESCRIPTION
This adds the `Minimal` diff algorithm and uses it if specified when doing a diff, fixing https://github.com/libgit2/libgit2sharp/issues/1057.

Unfortunately it's difficult to find an example which produces a different diff output for the `Meyers` and `Minimal` algorithm, so I don't have a unit test to check 1dd11be. It looks like the libgit code suffered the same problem and only test that [output from patience differs from the default](https://github.com/libgit2/libgit2/blob/855f048a7b28de8c1f44a570aee93a26cc684a60/tests/diff/workdir.c#L1633), which is already checked in `UsingPatienceAlgorithmCompareOptionProducesPatienceDiff`.

The change could be tested by extracting a class from `Diff.BuildOptions` and checking that the `GitDiffOptions` returned have the correct flags set, but that does break the encapsulation slightly. I'm happy to make that change if you want though.