### PR TITLE
Rename Myers diff algorithm to fix the spelling

### DIFF
--- a/LibGit2Sharp/CompareOptions.cs
+++ b/LibGit2Sharp/CompareOptions.cs
@@ -14,7 +14,7 @@ namespace LibGit2Sharp
         {
             ContextLines = 3;
             InterhunkLines = 0;
-            Algorithm = DiffAlgorithm.Meyers;
+            Algorithm = DiffAlgorithm.Myers;
         }
 
         /// <summary>
@@ -47,7 +47,7 @@ namespace LibGit2Sharp
 
         /// <summary>
         /// Algorithm to be used when performing a Diff.
-        /// By default, <see cref="DiffAlgorithm.Meyers"/> will be used.
+        /// By default, <see cref="DiffAlgorithm.Myers"/> will be used.
         /// </summary>
         public DiffAlgorithm Algorithm { get; set; }
     }

--- a/LibGit2Sharp/DiffAlgorithm.cs
+++ b/LibGit2Sharp/DiffAlgorithm.cs
@@ -8,7 +8,7 @@ namespace LibGit2Sharp
         /// <summary>
         /// The basic greedy diff algorithm.
         /// </summary>
-        Meyers = 0,
+        Myers = 0,
 
         /// <summary>
         /// Use "patience diff" algorithm when generating patches.


### PR DESCRIPTION
This renames `DiffAlgorithm.Meyers` to `DiffAlgorithm.Myers`, fixing https://github.com/libgit2/libgit2sharp/issues/1228.

The change is covered by the existing diff tests.