### PR TITLE
SubmoduleCollection.Add() using clone

### DIFF
--- a/LibGit2Sharp.Tests/SubmoduleFixture.cs
+++ b/LibGit2Sharp.Tests/SubmoduleFixture.cs
@@ -267,6 +267,68 @@ namespace LibGit2Sharp.Tests
             }
         }
 
+
+        [Fact]
+        public void CanAddSubmoduleWithManualClone()
+        {
+            string configPath = CreateConfigurationWithDummyUser(Constants.Identity);
+            var options = new RepositoryOptions { GlobalConfigurationLocation = configPath };
+
+            //var path = SandboxSubmoduleTestRepo();
+            var path = SandboxStandardTestRepo();
+            var pathSubRepoOrigin = SandboxStandardTestRepo();
+
+            string submoduleSubPath = "submodule_target_wd";
+            string expectedSubmodulePath = Path.GetFullPath(Path.Combine(path, submoduleSubPath));
+            string expectedSubmoduleUrl = pathSubRepoOrigin.Replace('\\', '/');
+            ObjectId expectedCommitId = (ObjectId)"32eab9cb1f450b5fe7ab663462b77d7f4b703344";
+
+            using (var repo = new Repository(path, options))
+            {
+                // check on adding config entry
+                var configEntryBeforeAdd = repo.Config.Get<string>(string.Format("submodule.{0}.url", submoduleSubPath));
+                Assert.Null(configEntryBeforeAdd);
+
+                // add submodule
+                Submodule submodule = repo.Submodules.Add(pathSubRepoOrigin, submoduleSubPath, x => Repository.Clone(pathSubRepoOrigin, x, new CloneOptions() { } ));
+                Assert.NotNull(submodule);
+
+                // check that the expected commit is checked out, but not set in parent repo until committed
+                Assert.Equal(expectedCommitId, repo.Submodules[submoduleSubPath].WorkDirCommitId);
+                Assert.Null(repo.Submodules[submoduleSubPath].HeadCommitId);
+
+                // check status
+                var submoduleStatus = submodule.RetrieveStatus();
+                Assert.True((submoduleStatus & SubmoduleStatus.InIndex) == SubmoduleStatus.InIndex);
+                Assert.True((submoduleStatus & SubmoduleStatus.InConfig) == SubmoduleStatus.InConfig);
+                Assert.True((submoduleStatus & SubmoduleStatus.InWorkDir) == SubmoduleStatus.InWorkDir);
+                Assert.True((submoduleStatus & SubmoduleStatus.IndexAdded) == SubmoduleStatus.IndexAdded);
+
+                // check that config entry was added with the correct url
+                var configEntryAfterAdd = repo.Config.Get<string>(string.Format("submodule.{0}.url", submoduleSubPath));
+                Assert.NotNull(configEntryAfterAdd);
+                Assert.Equal(expectedSubmoduleUrl, configEntryAfterAdd.Value);
+
+                // check on directory being added and repository directory
+                Assert.True(Directory.Exists(expectedSubmodulePath));
+                Assert.True(Directory.Exists(Path.Combine(expectedSubmodulePath, ".git")));
+
+                // manually check commit by opening submodule as a repository
+                using (var repo2 = new Repository(expectedSubmodulePath))
+                {
+                    Assert.False(repo2.Info.IsHeadDetached);
+                    Assert.False(repo2.Info.IsHeadUnborn);
+                    Commit headCommit = repo2.Head.Tip;
+                    Assert.Equal(headCommit.Id, expectedCommitId);
+                }
+
+                // commit parent repository, then verify it reports the correct CommitId for the submodule
+                Signature signature = repo.Config.BuildSignature(DateTimeOffset.Now);
+                repo.Commit("Added submodule " + submoduleSubPath, signature, signature);
+                Assert.Equal(expectedCommitId, repo.Submodules[submoduleSubPath].HeadCommitId);
+            }
+        }
+
         [Fact]
         public void UpdatingUninitializedSubmoduleThrows()
         {

--- a/LibGit2Sharp.Tests/SubmoduleFixture.cs
+++ b/LibGit2Sharp.Tests/SubmoduleFixture.cs
@@ -207,6 +207,64 @@ namespace LibGit2Sharp.Tests
         }
 
         [Fact]
+        public void CanAddSubmodule()
+        {
+            //var path = SandboxSubmoduleTestRepo();
+            var path = SandboxStandardTestRepo();
+            var pathSubRepoOrigin = SandboxStandardTestRepo();
+
+            string submoduleSubPath = "submodule_target_wd";
+            string expectedSubmodulePath = Path.GetFullPath(Path.Combine(path, submoduleSubPath));
+            string expectedSubmoduleUrl = pathSubRepoOrigin.Replace('\\', '/');
+            ObjectId expectedCommitId = (ObjectId)"32eab9cb1f450b5fe7ab663462b77d7f4b703344";
+
+            using (var repo = new Repository(path))
+            {
+                // check on adding config entry
+                var configEntryBeforeAdd = repo.Config.Get<string>(string.Format("submodule.{0}.url", submoduleSubPath));
+                Assert.Null(configEntryBeforeAdd);
+
+                // add submodule
+                Submodule submodule = repo.Submodules.Add(pathSubRepoOrigin, submoduleSubPath);
+                Assert.NotNull(submodule);
+
+                // check that the expected commit is checked out, but not set in parent repo until committed
+                Assert.Equal(expectedCommitId, repo.Submodules[submoduleSubPath].WorkDirCommitId);
+                Assert.Null(repo.Submodules[submoduleSubPath].HeadCommitId);
+
+                // check status
+                var submoduleStatus = submodule.RetrieveStatus();
+                Assert.True((submoduleStatus & SubmoduleStatus.InIndex) == SubmoduleStatus.InIndex);
+                Assert.True((submoduleStatus & SubmoduleStatus.InConfig) == SubmoduleStatus.InConfig);
+                Assert.True((submoduleStatus & SubmoduleStatus.InWorkDir) == SubmoduleStatus.InWorkDir);
+                Assert.True((submoduleStatus & SubmoduleStatus.IndexAdded) == SubmoduleStatus.IndexAdded);
+
+                // check that config entry was added with the correct url
+                var configEntryAfterAdd = repo.Config.Get<string>(string.Format("submodule.{0}.url", submoduleSubPath));
+                Assert.NotNull(configEntryAfterAdd);
+                Assert.Equal(expectedSubmoduleUrl, configEntryAfterAdd.Value);
+
+                // check on directory being added and repository directory
+                Assert.True(Directory.Exists(expectedSubmodulePath));
+                Assert.True(Directory.Exists(Path.Combine(expectedSubmodulePath, ".git")));
+
+                // manually check commit by opening submodule as a repository
+                using (var repo2 = new Repository(expectedSubmodulePath))
+                {
+                    Assert.False(repo2.Info.IsHeadDetached);
+                    Assert.False(repo2.Info.IsHeadUnborn);
+                    Commit headCommit = repo2.Head.Tip;
+                    Assert.Equal(headCommit.Id, expectedCommitId);
+                }
+
+                // commit parent repository, then verify it reports the correct CommitId for the submodule
+                Signature signature = repo.Config.BuildSignature(DateTimeOffset.Now);
+                repo.Commit("Added submodule " + submoduleSubPath, signature, signature);
+                Assert.Equal(expectedCommitId, repo.Submodules[submoduleSubPath].HeadCommitId);
+            }
+        }
+
+        [Fact]
         public void UpdatingUninitializedSubmoduleThrows()
         {
             var path = SandboxSubmoduleSmallTestRepo();

--- a/LibGit2Sharp.Tests/SubmoduleFixture.cs
+++ b/LibGit2Sharp.Tests/SubmoduleFixture.cs
@@ -209,6 +209,9 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanAddSubmodule()
         {
+            string configPath = CreateConfigurationWithDummyUser(Constants.Identity);
+            var options = new RepositoryOptions { GlobalConfigurationLocation = configPath };
+
             //var path = SandboxSubmoduleTestRepo();
             var path = SandboxStandardTestRepo();
             var pathSubRepoOrigin = SandboxStandardTestRepo();
@@ -218,7 +221,7 @@ namespace LibGit2Sharp.Tests
             string expectedSubmoduleUrl = pathSubRepoOrigin.Replace('\\', '/');
             ObjectId expectedCommitId = (ObjectId)"32eab9cb1f450b5fe7ab663462b77d7f4b703344";
 
-            using (var repo = new Repository(path))
+            using (var repo = new Repository(path, options))
             {
                 // check on adding config entry
                 var configEntryBeforeAdd = repo.Config.Get<string>(string.Format("submodule.{0}.url", submoduleSubPath));

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -1558,6 +1558,18 @@ namespace LibGit2Sharp.Core
             ref GitStrArray array);
 
         [DllImport(libgit2)]
+        internal static extern int git_submodule_add_setup(
+            out SubmoduleSafeHandle reference,
+            RepositorySafeHandle repo,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string url,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath path,
+            bool use_gitlink);
+
+        [DllImport(libgit2)]
+        internal static extern int git_submodule_add_finalize(
+            SubmoduleSafeHandle submodule);
+
+        [DllImport(libgit2)]
         internal static extern int git_submodule_lookup(
             out SubmoduleSafeHandle reference,
             RepositorySafeHandle repo,

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -2924,6 +2924,21 @@ namespace LibGit2Sharp.Core
             return git_foreach(resultSelector, c => NativeMethods.git_submodule_foreach(repo, (x, y, p) => c(x, y, p), IntPtr.Zero));
         }
 
+        public static SubmoduleSafeHandle git_submodule_add_setup(RepositorySafeHandle repo, string url, FilePath path, bool useGitLink)
+        {
+            SubmoduleSafeHandle sub;
+            var res = NativeMethods.git_submodule_add_setup(out sub, repo, url, path, useGitLink);
+            Ensure.ZeroResult(res);
+            return sub;
+        }
+
+        public static void git_submodule_add_finalize(SubmoduleSafeHandle submodule)
+        {
+            // This should be called on a submodule once you have called add setup and done the clone of the submodule. This adds the .gitmodules file and the newly cloned submodule to the index to be ready to be committed (but doesn't actually do the commit).
+            var res = NativeMethods.git_submodule_add_finalize(submodule);
+            Ensure.ZeroResult(res);
+        }
+
         public static void git_submodule_add_to_index(SubmoduleSafeHandle submodule, bool write_index)
         {
             var res = NativeMethods.git_submodule_add_to_index(submodule, write_index);

--- a/LibGit2Sharp/SubmoduleCollection.cs
+++ b/LibGit2Sharp/SubmoduleCollection.cs
@@ -48,15 +48,43 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
-        /// Adds a new submodule, cloning into the new directory and staging it and
-        /// .gitmodules to the parent repository just like the command line 'git submodule add'
+        /// Adds a new submodule, calling the passed action to allow the caller
+        /// to clone the submodule into the passed path.  The submodule ends
+        /// up being staged along with the .gitmodules just like the command
+        /// line 'git submodule add'
         /// </summary>
         /// <param name="url">The url of the remote repository</param>
         /// <param name="relativePath">The path of the submodule inside of the parent repository, which will also become the submodule name.</param>
         /// <param name="cloneMethod">A method that takes the full path to where we expect the repository to be cloned to so the caller
         /// can clone it themselves.  If not specified or if null, Add() will perform the clone using Repository.Clone(url, subPath, new CloneOptions() { } ).</param>
-        /// <returns></returns>
-        public virtual Submodule Add(string url, string relativePath, Action<string> cloneMethod = null)
+        /// <returns>The new Submodule</returns>
+        public virtual Submodule Add(string url, string relativePath, Action<string> cloneMethod)
+        {
+            return MainAddSubmodule(url, relativePath, cloneMethod);
+        }
+
+        /// <summary>
+        /// Adds a new submodule and clones it using the passed url.  The
+        /// url must be supported for cloning by LibGit2Sharp.
+        /// </summary>
+        /// <param name="url">The url of the remote repository</param>
+        /// <param name="relativePath">The path of the submodule inside of the parent repository, which will also become the submodule name.</param>
+        /// <returns>The new Submodule</returns>
+        public virtual Submodule Add(string url, string relativePath)
+        {
+            return MainAddSubmodule(url, relativePath);
+        }
+
+        /// <summary>
+        /// Method that actually adds a submodule, called by overloaded Add()
+        /// methods.
+        /// </summary>
+        /// <param name="url">The url of the remote repository</param>
+        /// <param name="relativePath">The path of the submodule inside of the parent repository, which will also become the submodule name.</param>
+        /// <param name="cloneMethod">A method that takes the full path to where we expect the repository to be cloned to so the caller
+        /// can clone it themselves.  If not specified or if null, Add() will perform the clone using Repository.Clone(url, subPath, new CloneOptions() { } ).</param>
+        /// <returns>The new Submodule</returns>
+        Submodule MainAddSubmodule(string url, string relativePath, Action<string> cloneMethod = null)
         {
             Ensure.ArgumentNotNullOrEmptyString(relativePath, "relativePath");
 
@@ -76,7 +104,8 @@ namespace LibGit2Sharp
                 if (cloneMethod != null)
                 {
                     cloneMethod(subPath);
-                } else
+                }
+                else
                 {
                     string result = Repository.Clone(url, subPath, new CloneOptions() { });
                 }

--- a/LibGit2Sharp/SubmoduleCollection.cs
+++ b/LibGit2Sharp/SubmoduleCollection.cs
@@ -53,8 +53,10 @@ namespace LibGit2Sharp
         /// </summary>
         /// <param name="url">The url of the remote repository</param>
         /// <param name="relativePath">The path of the submodule inside of the parent repository, which will also become the submodule name.</param>
+        /// <param name="cloneMethod">A method that takes the full path to where we expect the repository to be cloned to so the caller
+        /// can clone it themselves.  If not specified or if null, Add() will perform the clone using Repository.Clone(url, subPath, new CloneOptions() { } ).</param>
         /// <returns></returns>
-        public virtual Submodule Add(string url, string relativePath)
+        public virtual Submodule Add(string url, string relativePath, Action<string> cloneMethod = null)
         {
             Ensure.ArgumentNotNullOrEmptyString(relativePath, "relativePath");
 
@@ -70,20 +72,14 @@ namespace LibGit2Sharp
                 // branches and checkout whatever the remote HEAD is, which seems hard to find.
                 System.IO.Directory.Delete(subPath, true);
 
-                // now clone
-                //Proxy.git_submodule_init(handle, true);
-                //GitSubmoduleOptions options = new GitSubmoduleOptions();
-                //Proxy.git_submodule_update(handle, true, ref options);
-                string result = Repository.Clone(url, subPath, new CloneOptions() { } );
-
-                //using (Repository subRep = new Repository(subPath))
-                //{
-                //    subRep.Fetch("origin");
-                //    var refs = subRep.Network.ListReferences(subRep.Network.Remotes["origin"]);
-                //    //Branch b = subRep.Checkout(dr.CanonicalName);
-                //    var fhs = subRep.Network.FetchHeads.Select(_ => new { CN = _.CanonicalName, RCN = _.RemoteCanonicalName }).ToArray();
-                //    //string defbranch = subRep.Network.Remotes["origin"].DefaultBranch;
-                //}
+                // now clone the repository, or let the caller do it if an action was specified
+                if (cloneMethod != null)
+                {
+                    cloneMethod(subPath);
+                } else
+                {
+                    string result = Repository.Clone(url, subPath, new CloneOptions() { });
+                }
 
                 Proxy.git_submodule_add_finalize(handle);
             }


### PR DESCRIPTION
I see two other pull requests for the same feature ([#482](https://github.com/libgit2/libgit2sharp/pull/482) and [#684](https://github.com/libgit2/libgit2sharp/pull/684)) that haven't been updated in 18 months, so I thought I would give it a try since I need this functionality for a project to convert from another source control system.

SubmoduleCollection.Add(url, subdir) acts like the command line 'git submodule add url subdir'.
It calls git_submodule_add_setup, then deletes the directory created by that and clones
into the same directory and calls git_submodule_add_finalize.  The end result is that the
.gitmodules file and the 'file' for the submodule directory are staged and ready to commit.
