### PR TITLE
Add CustomHeaders member to GitPushOptions

### DIFF
--- a/LibGit2Sharp/Core/GitPushOptions.cs
+++ b/LibGit2Sharp/Core/GitPushOptions.cs
@@ -8,5 +8,6 @@ namespace LibGit2Sharp.Core
         public int Version = 1;
         public int PackbuilderDegreeOfParallelism;
         public GitRemoteCallbacks RemoteCallbacks;
+        public GitStrArrayManaged CustomHeaders;
     }
 }


### PR DESCRIPTION
This adds CustomHeaders member to GitPushOptions to match underlying c struct for marshalling and fix #1217 (error when pushing to private repo).

Supersedes #1218 – @golsby asked me to tidy things up and resubmit as per @nulltoken's comments.