### PR TITLE
Partial Git Hook Support

### DIFF
--- a/LibGit2Sharp.Tests/PushFixture.cs
+++ b/LibGit2Sharp.Tests/PushFixture.cs
@@ -85,9 +85,9 @@ namespace LibGit2Sharp.Tests
             bool packBuilderCalled = false;
             bool prePushHandlerCalled = false;
             PackBuilderProgressHandler packBuilderCb = (x, y, z) => { packBuilderCalled = true; return true; };
-            PrePushHandler prePushHook = (PrePushArguments args) =>
+            NegotiationCompletedBeforePushHandler negotiationCompletedBeforePushHandler = (IEnumerable<PushUpdate> updates) =>
             {
-                Assert.True(args.Updates.Count() == 1, "Expected 1 update, received " + args.Updates.Count());
+                Assert.True(updates.Count() == 1, "Expected 1 update, received " + updates.Count());
                 prePushHandlerCalled = true;
                 return true;
             };
@@ -99,7 +99,7 @@ namespace LibGit2Sharp.Tests
             {
                 OnPushStatusError = OnPushStatusError,
                 OnPackBuilderProgress = packBuilderCb,
-                OnNegotiationCompletedBeforePush = prePushHook,
+                OnNegotiationCompletedBeforePush = negotiationCompletedBeforePushHandler,
             };
 
             AssertPush(repo => repo.Network.Push(repo.Network.Remotes["origin"], "HEAD", @"refs/heads/master", options));
@@ -113,9 +113,9 @@ namespace LibGit2Sharp.Tests
             bool packBuilderCalled = false;
             bool prePushHandlerCalled = false;
             PackBuilderProgressHandler packBuilderCb = (x, y, z) => { packBuilderCalled = true; return true; };
-            PrePushHandler prePushHook = (PrePushArguments args) =>
+            NegotiationCompletedBeforePushHandler negotiationCompletedBeforePushHandler = (IEnumerable<PushUpdate> updates) =>
             {
-                Assert.True(args.Updates.Count() == 1, "Expected 1 update, received " + args.Updates.Count());
+                Assert.True(updates.Count() == 1, "Expected 1 update, received " + updates.Count());
                 prePushHandlerCalled = true;
                 return false;
             };
@@ -127,7 +127,7 @@ namespace LibGit2Sharp.Tests
             {
                 OnPushStatusError = OnPushStatusError,
                 OnPackBuilderProgress = packBuilderCb,
-                OnNegotiationCompletedBeforePush = prePushHook
+                OnNegotiationCompletedBeforePush = negotiationCompletedBeforePushHandler
             };
 
             Assert.Throws<UserCancelledException>(() => { AssertPush(repo => repo.Network.Push(repo.Network.Remotes["origin"], "HEAD", @"refs/heads/master", options)); });

--- a/LibGit2Sharp.Tests/PushFixture.cs
+++ b/LibGit2Sharp.Tests/PushFixture.cs
@@ -85,9 +85,9 @@ namespace LibGit2Sharp.Tests
             bool packBuilderCalled = false;
             bool prePushHandlerCalled = false;
             PackBuilderProgressHandler packBuilderCb = (x, y, z) => { packBuilderCalled = true; return true; };
-            PrePushHandler prePushHook = (IEnumerable<PushUpdate> updates) =>
+            PrePushHandler prePushHook = (PrePushArguments args) =>
             {
-                Assert.True(updates.Count() == 1, "Expected 1 update, received " + updates.Count());
+                Assert.True(args.Updates.Count() == 1, "Expected 1 update, received " + args.Updates.Count());
                 prePushHandlerCalled = true;
                 return true;
             };
@@ -113,9 +113,9 @@ namespace LibGit2Sharp.Tests
             bool packBuilderCalled = false;
             bool prePushHandlerCalled = false;
             PackBuilderProgressHandler packBuilderCb = (x, y, z) => { packBuilderCalled = true; return true; };
-            PrePushHandler prePushHook = (IEnumerable<PushUpdate> updates) =>
+            PrePushHandler prePushHook = (PrePushArguments args) =>
             {
-                Assert.True(updates.Count() == 1, "Expected 1 update, received " + updates.Count());
+                Assert.True(args.Updates.Count() == 1, "Expected 1 update, received " + args.Updates.Count());
                 prePushHandlerCalled = true;
                 return false;
             };

--- a/LibGit2Sharp/Handlers.cs
+++ b/LibGit2Sharp/Handlers.cs
@@ -83,11 +83,36 @@ namespace LibGit2Sharp.Handlers
     public delegate bool PackBuilderProgressHandler(PackBuilderStage stage, int current, int total);
 
     /// <summary>
+    /// Arguments for the pre-push handler. Designed to be as close to git.git's pre-push hook
+    /// specification as possible.
+    /// </summary>
+    /// <remarks>
+    /// Designed to be future-proof and to avoid API breaking changes. Having this as a struct
+    /// and not a series of arguments to a method allows the fields to be changed with a minimal
+    /// amount of breaking changes.
+    /// </remarks>
+    public struct PrePushArguments
+    {
+        /// <summary>
+        /// Name of the remote to which the push is being done; null if the name is unknown.
+        /// </summary>
+        public string RemoteName;
+        /// <summary>
+        /// URL to which the push is being done.
+        /// </summary>
+        public string RemoteUrl;
+        /// <summary>
+        /// List of updates about to be performed via push.
+        /// </summary>
+        public IEnumerable<PushUpdate> Updates;
+    }
+
+    /// <summary>
     /// Provides information about what updates will be performed before a push occurs
     /// </summary>
-    /// <param name="updates">List of updates about to be performed via push</param>
+    /// <param name="arguments">Arguments for the method.</param>
     /// <returns>True to continue, false to cancel.</returns>
-    public delegate bool PrePushHandler(IEnumerable<PushUpdate> updates);
+    public delegate bool PrePushHandler(PrePushArguments arguments);
 
     /// <summary>
     /// Delegate definition to handle reporting errors when updating references on the remote.

--- a/LibGit2Sharp/Handlers.cs
+++ b/LibGit2Sharp/Handlers.cs
@@ -110,6 +110,13 @@ namespace LibGit2Sharp.Handlers
     /// <summary>
     /// Provides information about what updates will be performed before a push occurs
     /// </summary>
+    /// <param name="updates">List of updates to pushed to the server.</param>
+    /// <returns>True to continue, false to cancel.</returns>
+    public delegate bool NegotiationCompletedBeforePushHandler(IEnumerable<PushUpdate> updates);
+
+    /// <summary>
+    /// Provides information about what updates will be performed before a push occurs
+    /// </summary>
     /// <param name="arguments">Arguments for the method.</param>
     /// <returns>True to continue, false to cancel.</returns>
     public delegate bool PrePushHandler(PrePushArguments arguments);

--- a/LibGit2Sharp/IRepository.cs
+++ b/LibGit2Sharp/IRepository.cs
@@ -70,6 +70,21 @@ namespace LibGit2Sharp
         SubmoduleCollection Submodules { get; }
 
         /// <summary>
+        /// Gets the post-checkout handler registered with this repository
+        /// </summary>
+        PostCheckoutDelegate PostCheckoutCallback { get; }
+
+        /// <summary>
+        /// Gets the post-commit handler registered with this repository
+        /// </summary>
+        PostCommitDelegate PostCommitCallback { get; }
+
+        /// <summary>
+        /// Gets the pre-push handler registered with this repository
+        /// </summary>
+        PrePushDelegate PrePushCallback { get; }
+
+        /// <summary>
         /// Checkout the commit pointed at by the tip of the specified <see cref="Branch"/>.
         /// <para>
         ///   If this commit is the current tip of the branch as it exists in the repository, the HEAD
@@ -405,5 +420,11 @@ namespace LibGit2Sharp
         /// <param name="options">Determines how the commit will be described.</param>
         /// <returns>A descriptive identifier for the commit based on the nearest annotated tag.</returns>
         string Describe(Commit commit, DescribeOptions options);
+
+        /// <summary>
+        /// Registers a pre-push handler with the repository
+        /// </summary>
+        /// <param name="callbacks"><see cref="RepositoryCallbacks"/> object containing the related delegates to be registered with the repository.</param>
+        void RegisterCallbacks(RepositoryCallbacks callbacks);
     }
 }

--- a/LibGit2Sharp/IRepository.cs
+++ b/LibGit2Sharp/IRepository.cs
@@ -420,11 +420,5 @@ namespace LibGit2Sharp
         /// <param name="options">Determines how the commit will be described.</param>
         /// <returns>A descriptive identifier for the commit based on the nearest annotated tag.</returns>
         string Describe(Commit commit, DescribeOptions options);
-
-        /// <summary>
-        /// Registers callback handlers with the repository.
-        /// </summary>
-        /// <param name="callbacks"><see cref="RepositoryCallbacks"/> object containing the related delegates to be registered with the repository.</param>
-        void RegisterCallbacks(RepositoryCallbacks callbacks);
     }
 }

--- a/LibGit2Sharp/IRepository.cs
+++ b/LibGit2Sharp/IRepository.cs
@@ -422,7 +422,7 @@ namespace LibGit2Sharp
         string Describe(Commit commit, DescribeOptions options);
 
         /// <summary>
-        /// Registers a pre-push handler with the repository
+        /// Registers callback handlers with the repository.
         /// </summary>
         /// <param name="callbacks"><see cref="RepositoryCallbacks"/> object containing the related delegates to be registered with the repository.</param>
         void RegisterCallbacks(RepositoryCallbacks callbacks);

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -93,6 +93,7 @@
     <Compile Include="EntryExistsException.cs" />
     <Compile Include="FetchOptionsBase.cs" />
     <Compile Include="Core\FetchPruneStrategy.cs" />
+    <Compile Include="RepositoryCallbacks.cs" />
     <Compile Include="LogEntry.cs" />
     <Compile Include="FollowFilter.cs" />
     <Compile Include="IBelongToARepository.cs" />

--- a/LibGit2Sharp/Network.cs
+++ b/LibGit2Sharp/Network.cs
@@ -521,13 +521,13 @@ namespace LibGit2Sharp
                 && repository != null 
                 && repository.PrePushCallback != null)
             {
-                pushOptions = new PushOptions() { OnNegotiationCompletedBeforePush = repository.PrePushHandler };
+                pushOptions.OnNegotiationCompletedBeforePush = repository.PrePushHandler;
             }
 
             // Load the remote.
             using (RemoteSafeHandle remoteHandle = Proxy.git_remote_lookup(repository.Handle, remote.Name, true))
             {
-                var callbacks = new RemoteCallbacks(pushOptions);
+                var callbacks = new RemoteCallbacks(pushOptions, remoteHandle);
                 GitRemoteCallbacks gitCallbacks = callbacks.GenerateCallbacks();
 
                 Proxy.git_remote_push(remoteHandle,

--- a/LibGit2Sharp/Network.cs
+++ b/LibGit2Sharp/Network.cs
@@ -517,11 +517,9 @@ namespace LibGit2Sharp
             }
 
             // if there is a pre-push callback registered with the repository, honor it.
-            if (pushOptions.OnNegotiationCompletedBeforePush == null
-                && repository != null 
-                && repository.PrePushCallback != null)
+            if (repository != null)
             {
-                pushOptions.OnNegotiationCompletedBeforePush = repository.PrePushHandler;
+                pushOptions.OnPrePush = repository.PrePushHandler;
             }
 
             // Load the remote.

--- a/LibGit2Sharp/Network.cs
+++ b/LibGit2Sharp/Network.cs
@@ -516,6 +516,14 @@ namespace LibGit2Sharp
                 pushOptions = new PushOptions();
             }
 
+            // if there is a pre-push callback registered with the repository, honor it.
+            if (pushOptions.OnNegotiationCompletedBeforePush == null
+                && repository != null 
+                && repository.PrePushCallback != null)
+            {
+                pushOptions = new PushOptions() { OnNegotiationCompletedBeforePush = repository.PrePushHandler };
+            }
+
             // Load the remote.
             using (RemoteSafeHandle remoteHandle = Proxy.git_remote_lookup(repository.Handle, remote.Name, true))
             {

--- a/LibGit2Sharp/ObjectDatabase.cs
+++ b/LibGit2Sharp/ObjectDatabase.cs
@@ -368,6 +368,12 @@ namespace LibGit2Sharp
 
             Commit commit = repo.Lookup<Commit>(commitId);
             Ensure.GitObjectIsNotNull(commit, commitId.Sha);
+
+            if (repo.PostCommitCallback != null)
+            {
+                repo.PostCommitCallback(repo);
+            }
+
             return commit;
         }
 

--- a/LibGit2Sharp/PushOptions.cs
+++ b/LibGit2Sharp/PushOptions.cs
@@ -50,6 +50,8 @@ namespace LibGit2Sharp
         /// Called once between the negotiation step and the upload. It provides
         /// information about what updates will be performed.
         /// </summary>
-        public PrePushHandler OnNegotiationCompletedBeforePush { get; set; }
+        public NegotiationCompletedBeforePushHandler OnNegotiationCompletedBeforePush { get; set; }
+
+        internal PrePushHandler OnPrePush { get; set; }
     }
 }

--- a/LibGit2Sharp/Repository.cs
+++ b/LibGit2Sharp/Repository.cs
@@ -109,6 +109,13 @@ namespace LibGit2Sharp
                     {
                         Proxy.git_repository_set_ident(handle, options.Identity.Name, options.Identity.Email);
                     }
+
+                    if (options.Callbacks != null)
+                    {
+                        postCheckoutCallback = options.Callbacks.PostCheckoutCallback;
+                        postCommitCallback = options.Callbacks.PostCommitCallback;
+                        prePushCallback = options.Callbacks.PrePushCallback;
+                    }
                 }
 
                 if (!isBare)
@@ -1197,17 +1204,6 @@ namespace LibGit2Sharp
         {
             toCleanup.Push(disposable);
             return disposable;
-        }
-
-        /// <summary>
-        /// Registers callback handlers with the repository.
-        /// </summary>
-        /// <param name="callbacks"><see cref="RepositoryCallbacks"/> object containing the related delegates to be registered with the repository.</param>
-        public void RegisterCallbacks(RepositoryCallbacks callbacks)
-        {
-            postCheckoutCallback = callbacks.PostCheckoutCallback;
-            postCommitCallback = callbacks.PostCommitCallback;
-            prePushCallback = callbacks.PrePushCallback;
         }
 
         /// <summary>

--- a/LibGit2Sharp/Repository.cs
+++ b/LibGit2Sharp/Repository.cs
@@ -975,9 +975,9 @@ namespace LibGit2Sharp
 
             var newHead = Refs.Head;
 
-            if (_postCheckoutCallback != null)
+            if (postCheckoutCallback != null)
             {
-                _postCheckoutCallback(this, oldHead, newHead, paths == null || paths.Count == 0);
+                postCheckoutCallback(this, oldHead, newHead, paths == null || paths.Count == 0);
             }
         }
 
@@ -1200,14 +1200,14 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
-        /// Registers a pre-push handler with the repository
+        /// Registers callback handlers with the repository.
         /// </summary>
         /// <param name="callbacks"><see cref="RepositoryCallbacks"/> object containing the related delegates to be registered with the repository.</param>
         public void RegisterCallbacks(RepositoryCallbacks callbacks)
         {
-            _postCheckoutCallback = callbacks.PostCheckoutCallback;
-            _postCommitCallback = callbacks.PostCommitCallback;
-            _prePushCallback = callbacks.PrePushCallback;
+            postCheckoutCallback = callbacks.PostCheckoutCallback;
+            postCommitCallback = callbacks.PostCommitCallback;
+            prePushCallback = callbacks.PrePushCallback;
         }
 
         /// <summary>
@@ -1215,27 +1215,27 @@ namespace LibGit2Sharp
         /// </summary>
         public PostCheckoutDelegate PostCheckoutCallback
         {
-            get { return _postCheckoutCallback; }
+            get { return postCheckoutCallback; }
         }
-        private PostCheckoutDelegate _postCheckoutCallback;
+        private PostCheckoutDelegate postCheckoutCallback;
 
         /// <summary>
         /// Gets the post-commit handler registered with this repository
         /// </summary>
         public PostCommitDelegate PostCommitCallback
         {
-            get { return _postCommitCallback; }
+            get { return postCommitCallback; }
         }
-        private PostCommitDelegate _postCommitCallback;
+        private PostCommitDelegate postCommitCallback;
 
         /// <summary>
         /// Gets the pre-push handler registered with this repository
         /// </summary>
         public PrePushDelegate PrePushCallback
         {
-            get { return _prePushCallback; }
+            get { return prePushCallback; }
         }
-        private PrePushDelegate _prePushCallback;
+        private PrePushDelegate prePushCallback;
 
         /// <summary>
         /// Merges changes from commit into the branch pointed at by HEAD.
@@ -2202,14 +2202,27 @@ namespace LibGit2Sharp
             return Proxy.git_describe_commit(handle, commit.Id, options);
         }
 
-        internal bool PrePushHandler(IEnumerable<PushUpdate> updates)
+        internal bool PrePushHandler(PrePushArguments args)
         {
-            if (_prePushCallback != null)
+            if (prePushCallback != null)
             {
-                return _prePushCallback(this, updates);
+                return prePushCallback(this, args.RemoteName, args.RemoteUrl, args.Updates);
             }
 
             return true;
+        }
+        internal bool PrePushHandler(Remote remote, IEnumerable<PushUpdate> updates)
+        {
+            if (remote == null)
+                return false;
+
+            var args = new PrePushArguments()
+            {
+                RemoteName = remote.Name,
+                RemoteUrl = remote.Url,
+                Updates = updates,
+            };
+            return PrePushHandler(args);
         }
 
         private string DebuggerDisplay

--- a/LibGit2Sharp/RepositoryCallbacks.cs
+++ b/LibGit2Sharp/RepositoryCallbacks.cs
@@ -1,0 +1,48 @@
+﻿using System.Collections.Generic;
+
+namespace LibGit2Sharp
+{
+    /// <summary>
+    /// Callback delegates for a <see cref="Repository"/> to invoke when appropriate. 
+    /// Use <see cref="Repository.RegisterCallbacks(RepositoryCallbacks)"/> to register
+    /// the association.
+    /// </summary>
+    public sealed class RepositoryCallbacks
+    {
+        /// <summary>
+        /// Delegate called by the repository after a checkout has completed.
+        /// </summary>
+        public PostCheckoutDelegate PostCheckoutCallback;
+        /// <summary>
+        /// Delegate called by a repository after a commit has been created.
+        /// </summary>
+        public PostCommitDelegate PostCommitCallback;
+        /// <summary>
+        /// Delegate called by a repository before a push is completed, after negotiation is successful.
+        /// </summary>
+        public PrePushDelegate PrePushCallback;
+    }
+
+    /// <summary>
+    /// Called by the repository after a checkout has completed.
+    /// </summary>
+    /// <param name="repository">The repository object which called the delegate.</param>
+    /// <param name="oldHead">The previous head of the repository.</param>
+    /// <param name="newHead">The current (new) head of the repository.</param>
+    /// <param name="branchSwitch">True if a whole tree checkout occured; false otherwise.</param>
+    public delegate void PostCheckoutDelegate(Repository repository, Reference oldHead, Reference newHead, bool branchSwitch);
+
+    /// <summary>
+    /// Called by a repository after a commit has been created.
+    /// </summary>
+    /// <param name="repository">The repository object which called the delegate.</param>
+    public delegate void PostCommitDelegate(Repository repository);
+
+    /// <summary>
+    /// Called by a repository before a push is completed, after negotiation is successful.
+    /// </summary>
+    /// <param name="repository">The repository object which called the delegate.</param>
+    /// <param name="updates">The list of updates to be sent to the server as part of the push.</param>
+    /// <returns>True is the push should continue; false otherwise.</returns>
+    public delegate bool PrePushDelegate(Repository repository, IEnumerable<PushUpdate> updates);
+}

--- a/LibGit2Sharp/RepositoryCallbacks.cs
+++ b/LibGit2Sharp/RepositoryCallbacks.cs
@@ -39,10 +39,13 @@ namespace LibGit2Sharp
     public delegate void PostCommitDelegate(Repository repository);
 
     /// <summary>
-    /// Called by a repository before a push is completed, after negotiation is successful.
+    /// Called by a repository before a push is completed, after it has checked the remote status, 
+    /// but before anything has been pushed.
     /// </summary>
     /// <param name="repository">The repository object which called the delegate.</param>
+    /// <param name="remoteName">Name of the remote to which the push is being done; null if the name is unknown.</param>
+    /// <param name="remoteUrl">URL to which the push is being done.</param>
     /// <param name="updates">The list of updates to be sent to the server as part of the push.</param>
     /// <returns>True is the push should continue; false otherwise.</returns>
-    public delegate bool PrePushDelegate(Repository repository, IEnumerable<PushUpdate> updates);
+    public delegate bool PrePushDelegate(Repository repository, string remoteName, string remoteUrl, IEnumerable<PushUpdate> updates);
 }

--- a/LibGit2Sharp/RepositoryOptions.cs
+++ b/LibGit2Sharp/RepositoryOptions.cs
@@ -65,5 +65,10 @@
         /// </para>
         /// </summary>
         public Identity Identity { get; set; }
+
+        /// <summary>
+        /// Registers callback handlers with the repository.
+        /// </summary>
+        public RepositoryCallbacks Callbacks { get; set; }
     }
 }


### PR DESCRIPTION
Adds Git-Hook like callbacks at the repository level, with support for the following hooks:
- post-checkout
- post-commit
- pre-push

The concept here is to add hook support at the repo level, instead of say globally or per call (via `*Options`). Where a method took a callback via `*Options`, I let that override the repository level callback.

Still need to add proper comments and test, but this is a litmus test to see what the community thinks of the idea.
