### PR TITLE
Handle exceptions and null returns from CredentialsProvider.

### DIFF
--- a/LibGit2Sharp/RemoteCallbacks.cs
+++ b/LibGit2Sharp/RemoteCallbacks.cs
@@ -285,9 +285,21 @@ namespace LibGit2Sharp
                 types |= SupportedCredentialTypes.Default;
             }
 
-            var cred = CredentialsProvider(url, username, types);
-
-            return cred.GitCredentialHandler(out ptr);
+            ptr = IntPtr.Zero;
+            try
+            {
+                var cred = CredentialsProvider(url, username, types);
+                if (cred == null)
+                {
+                    return (int)GitErrorCode.PassThrough;
+                }
+                return cred.GitCredentialHandler(out ptr);
+            }
+            catch (Exception exception)
+            {
+                Proxy.giterr_set_str(GitErrorCategory.Callback, exception);
+                return (int)GitErrorCode.Error;
+            }
         }
 
         private int GitCertificateCheck(IntPtr certPtr, int valid, IntPtr cHostname, IntPtr payload)


### PR DESCRIPTION
Add exception handling and null checking around the call to the `CredentialsProvider` callback and `GitCredentialHandler` method.  Without these, exceptions will cross the boundary into C code, which I believe is bad.  

I got here because I want to supply a `CredentialsProvider` that only applies to certain hosts, and this provides a way to return an error code to libgit2 when I have no credentials to provide.  

Pull request #1130 would add a null check here, but not other exception handling.  It would translate null to `GitErrorCode.Error`, while I'm proposing to translate it to `GitErrorCode.PassThrough` so that a null credentials object behaves like a null credentials provider.  
