### PR TITLE
Correct the deprecation path for MergeConflictException

### DIFF
--- a/LibGit2Sharp.Tests/CheckoutFixture.cs
+++ b/LibGit2Sharp.Tests/CheckoutFixture.cs
@@ -1029,6 +1029,23 @@ namespace LibGit2Sharp.Tests
             }
         }
 
+        [Fact]
+        public void CanCatchDeprecatedException()
+        {
+            bool caught = false;
+
+            try
+            {
+                throw new CheckoutConflictException();
+            }
+            catch (MergeConflictException)
+            {
+                caught = true;
+            }
+
+            Assert.True(caught);
+        }
+
         /// <summary>
         /// Helper method to populate a simple repository with
         /// a single file and two branches.

--- a/LibGit2Sharp/CheckoutConflictException.cs
+++ b/LibGit2Sharp/CheckoutConflictException.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.Serialization;
 using LibGit2Sharp.Core;
 
 namespace LibGit2Sharp
@@ -10,47 +9,12 @@ namespace LibGit2Sharp
     /// in the working directory.
     /// </summary>
     [Serializable]
-    public class CheckoutConflictException : LibGit2SharpException
+    public class CheckoutConflictException : MergeConflictException
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="LibGit2Sharp.CheckoutConflictException"/> class.
         /// </summary>
         public CheckoutConflictException()
-        { }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="LibGit2Sharp.CheckoutConflictException"/> class with a specified error message.
-        /// </summary>
-        /// <param name="message">A message that describes the error.</param>
-        public CheckoutConflictException(string message)
-            : base(message)
-        { }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="LibGit2Sharp.CheckoutConflictException"/> class with a specified error message.
-        /// </summary>
-        /// <param name="format">A composite format string for use in <see cref="String.Format(IFormatProvider, string, object[])"/>.</param>
-        /// <param name="args">An object array that contains zero or more objects to format.</param>
-        public CheckoutConflictException(string format, params object[] args)
-            : base(format, args)
-        { }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="LibGit2Sharp.CheckoutConflictException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
-        /// </summary>
-        /// <param name="message">The error message that explains the reason for the exception.</param>
-        /// <param name="innerException">The exception that is the cause of the current exception. If the <paramref name="innerException"/> parameter is not a null reference, the current exception is raised in a catch block that handles the inner exception.</param>
-        public CheckoutConflictException(string message, Exception innerException)
-            : base(message, innerException)
-        { }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="LibGit2Sharp.CheckoutConflictException"/> class with a serialized data.
-        /// </summary>
-        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
-        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
-        protected CheckoutConflictException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
         { }
 
         internal CheckoutConflictException(string message, GitErrorCode code, GitErrorCategory category)

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -122,7 +122,7 @@
     <Compile Include="IndexReucEntryCollection.cs" />
     <Compile Include="IndexNameEntry.cs" />
     <Compile Include="MergeAndCheckoutOptionsBase.cs" />
-    <Compile Include="MergeConflictException.cs" />
+    <Compile Include="CheckoutConflictException.cs" />
     <Compile Include="MergeOptions.cs" />
     <Compile Include="MergeOptionsBase.cs" />
     <Compile Include="MergeResult.cs" />
@@ -249,7 +249,7 @@
     <Compile Include="FetchHead.cs" />
     <Compile Include="Handlers.cs" />
     <Compile Include="Ignore.cs" />
-    <Compile Include="CheckoutConflictException.cs" />
+    <Compile Include="MergeConflictException.cs" />
     <Compile Include="MergeHead.cs" />
     <Compile Include="NameConflictException.cs" />
     <Compile Include="NonFastForwardException.cs" />

--- a/LibGit2Sharp/MergeConflictException.cs
+++ b/LibGit2Sharp/MergeConflictException.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Runtime.Serialization;
+using LibGit2Sharp.Core;
 
 namespace LibGit2Sharp
 {
@@ -9,6 +11,51 @@ namespace LibGit2Sharp
     /// </summary>
     [Serializable]
     [Obsolete("This type will be removed in the next release. Please use CheckoutConflictException instead.")]
-    public class MergeConflictException : CheckoutConflictException
-    { }
+    public class MergeConflictException : LibGit2SharpException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LibGit2Sharp.MergeConflictException"/> class.
+        /// </summary>
+        public MergeConflictException()
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LibGit2Sharp.MergeConflictException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="message">A message that describes the error.</param>
+        public MergeConflictException(string message)
+            : base(message)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LibGit2Sharp.MergeConflictException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="format">A composite format string for use in <see cref="String.Format(IFormatProvider, string, object[])"/>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        public MergeConflictException(string format, params object[] args)
+            : base(format, args)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LibGit2Sharp.MergeConflictException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception. If the <paramref name="innerException"/> parameter is not a null reference, the current exception is raised in a catch block that handles the inner exception.</param>
+        public MergeConflictException(string message, Exception innerException)
+            : base(message, innerException)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LibGit2Sharp.MergeConflictException"/> class with a serialized data.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        protected MergeConflictException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        { }
+
+        internal MergeConflictException(string message, GitErrorCode code, GitErrorCategory category)
+            : base(message, code, category)
+        { }
+    }
 }


### PR DESCRIPTION
We want users to be able to have the old name in their code and catch the
new type which we throw. To enable this we must switch the inheritance for
the old vs new type.