### PR TITLE
Explore moving the command-simulating methods to their own namespace

### DIFF
--- a/LibGit2Sharp/Commands/Checkout.cs
+++ b/LibGit2Sharp/Commands/Checkout.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace LibGit2Sharp.Commands
+{
+    enum CheckoutMode
+    {
+        DetachHead,
+        CheckoutTree,
+    }
+
+    class Checkout
+    {
+        readonly Repository repo;
+        readonly Commit commit;
+        readonly Tree tree;
+        readonly IEnumerable<string> paths;
+        readonly CheckoutOptions options;
+        readonly CheckoutMode mode;
+
+        /// <summary>
+        /// Checkout a commit
+        /// 
+        /// This will detach HEAD to the given commit.
+        /// </summary>
+        /// <param name="repo">The repository in which to act</param>
+        /// <param name="commit">The commit to checkout</param>
+        /// <param name="options">The options for the checkout operation</param>
+        public Checkout(Repository repo, Commit commit, CheckoutOptions options)
+        {
+            this.repo = repo;
+            this.commit = commit;
+            this.options = options;
+            this.mode = CheckoutMode.DetachHead;
+        }
+
+        /// <summary>
+        /// Checkout files from a commit
+        /// 
+        /// This will put the files from the commit into the working directory and the index.
+        /// </summary>
+        /// <param name="repo">The repository in which to act</param>
+        /// <param name="commit">The commit to checkout the files from</param>
+        /// <param name="paths">List of paths to checkout. Leave null or empty for all</param>
+        /// <param name="options">The options for the checkout operation</param>
+        public Checkout(Repository repo, Commit commit, IEnumerable<string> paths, CheckoutOptions options)
+        {
+            this.repo = repo;
+            this.tree = commit.Tree;
+            this.paths = paths;
+            this.options = options;
+            this.mode = CheckoutMode.CheckoutTree;
+        }
+
+        /// <summary>
+        /// Checkout a tree
+        /// 
+        /// This will put the files from the tree into the working directory and the index.
+        /// </summary>
+        /// <param name="repo">The repository in which to act</param>
+        /// <param name="tree">The tree to checkout</param>
+        /// <param name="paths">List of paths to checkout. Leave null or empty for all</param>
+        /// <param name="options">The options for the checkout operation</param>
+        public Checkout(Repository repo, Tree tree, IEnumerable<string> paths, CheckoutOptions options)
+        {
+            this.repo = repo;
+            this.tree = tree;
+            this.paths = paths;
+            this.options = options;
+            this.mode = CheckoutMode.CheckoutTree;
+        }
+
+        void RunCheckoutTree()
+        {
+            repo.CheckoutTree(tree, null, options);
+        }
+
+        void RunDetachHead()
+        {
+            repo.Checkout(commit, options);
+        }
+
+        public void Run()
+        {
+            switch (mode)
+            {
+                case CheckoutMode.DetachHead:
+                    RunDetachHead();
+                    break;
+                case CheckoutMode.CheckoutTree:
+                    RunCheckoutTree();
+                    break;
+                default:
+                    throw new NotImplementedException("Unimplemented and undefined checkout mode");
+            }
+        }
+    }
+}

--- a/LibGit2Sharp/Commands/CommandBase.cs
+++ b/LibGit2Sharp/Commands/CommandBase.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace LibGit2Sharp.Commands
+{
+    abstract class CommandBase
+    {
+        /// <summary>
+        /// Run the command
+        /// </summary>
+        public abstract void Run();
+    }
+}

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -65,6 +65,8 @@
     <Compile Include="CherryPickOptions.cs" />
     <Compile Include="CherryPickResult.cs" />
     <Compile Include="CloneOptions.cs" />
+    <Compile Include="Commands\Checkout.cs" />
+    <Compile Include="Commands\CommandBase.cs" />
     <Compile Include="CommitFilter.cs" />
     <Compile Include="CommitOptions.cs" />
     <Compile Include="CommitSortStrategies.cs" />

--- a/LibGit2Sharp/Repository.cs
+++ b/LibGit2Sharp/Repository.cs
@@ -960,7 +960,7 @@ namespace LibGit2Sharp
         /// <param name="tree">The <see cref="Tree"/> to checkout.</param>
         /// <param name="paths">The paths to checkout.</param>
         /// <param name="opts">Collection of parameters controlling checkout behavior.</param>
-        private void CheckoutTree(
+        internal void CheckoutTree(
             Tree tree,
             IList<string> paths,
             IConvertableToGitCheckoutOpts opts)


### PR DESCRIPTION
A lot of the methods on Repository are actually trying to replicate git
commands, which makes it harder to see what's the operation vs command.

Move them to their own namespace to make it clear what they're trying to
achieve. We start with a few forms of the git-checkout command.

---

This shows a possible implementation of this. The `Checkout()` methods on Repository would still need to get deprecated, but they depend on each other in weird ways so we can figure that out if and when we decide to go forward with it.

The library itself should also likely get a similar treatment, but it's a lot more annoying to do anything in C, so we start here.

/cc @nulltoken @jamill @whoisj 