### PR TITLE
Bump version number to 0.23 (prerelease)

### DIFF
--- a/LibGit2Sharp/Properties/AssemblyInfo.cs
+++ b/LibGit2Sharp/Properties/AssemblyInfo.cs
@@ -42,6 +42,6 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("0.22.0")]
-[assembly: AssemblyFileVersion("0.22.0")]
-[assembly: AssemblyInformationalVersion("0.22.0-dev00000000000000")]
+[assembly: AssemblyVersion("0.23.0")]
+[assembly: AssemblyFileVersion("0.23.0")]
+[assembly: AssemblyInformationalVersion("0.23.0-dev00000000000000")]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ environment:
     secure: nuzUT+HecXGIi3KaPd/1hgFEZJan/j6+oNbPV75JKjk=
   coverity_email:
     secure: eGVilNg1Yuq+Xj+SW8r3WCtjnzhoDV0sNJkma4NRq7A=
-  version : 0.22.0
+  version : 0.23.0
   matrix:
   - xunit_runner: xunit.console.x86.exe
     Arch: 32


### PR DESCRIPTION
Historically, we have been bumping the version number immediately after releasing, so that our new packages take the new (prerelease) version numbers.

Update to use 0.23.0 prerelease version numbers.