### PR TITLE
Obsolete the config paths in RepositoryOptions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@
 
 ### Changes
 
+ - Obsolete the config paths in RepositoryOptions
+
 ### Fixes
 
 ## v0.22 - ([diff](https://github.com/libgit2/libgit2sharp/compare/v0.21.1...v0.22))

--- a/LibGit2Sharp.Tests/AttributesFixture.cs
+++ b/LibGit2Sharp.Tests/AttributesFixture.cs
@@ -9,7 +9,7 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void StagingHonorsTheAttributesFiles()
         {
-            using (var repo = InitIsolatedRepository())
+            using (var repo = new Repository(InitNewRepository()))
             {
                 CreateAttributesFile(repo);
 

--- a/LibGit2Sharp.Tests/BranchFixture.cs
+++ b/LibGit2Sharp.Tests/BranchFixture.cs
@@ -447,11 +447,10 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void QueryUnresolvableRemoteForRemoteBranch()
         {
-            var path = SandboxStandardTestRepo();
-
             var fetchRefSpecs = new string[] { "+refs/heads/notfound/*:refs/remotes/origin/notfound/*" };
 
-            using (var repo = InitIsolatedRepository(path))
+            var path = SandboxStandardTestRepo();
+            using (var repo = new Repository(path))
             {
                 // Update the remote config such that the remote for a
                 // remote branch cannot be resolved
@@ -472,12 +471,11 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void QueryAmbigousRemoteForRemoteBranch()
         {
-            var path = SandboxStandardTestRepo();
-
             const string fetchRefSpec = "+refs/heads/*:refs/remotes/origin/*";
             const string url = "http://github.com/libgit2/TestGitRepository";
 
-            using (var repo = InitIsolatedRepository(path))
+            var path = SandboxStandardTestRepo();
+            using (var repo = new Repository(path))
             {
                 // Add a second remote so that it is ambiguous which remote
                 // the remote-tracking branch tracks.

--- a/LibGit2Sharp.Tests/CommitFixture.cs
+++ b/LibGit2Sharp.Tests/CommitFixture.cs
@@ -542,11 +542,10 @@ namespace LibGit2Sharp.Tests
         public void CanCommitWithSignatureFromConfig()
         {
             string repoPath = InitNewRepository();
-            string configPath = CreateConfigurationWithDummyUser(Constants.Identity);
-            var options = new RepositoryOptions { GlobalConfigurationLocation = configPath };
 
-            using (var repo = new Repository(repoPath, options))
+            using (var repo = new Repository(repoPath))
             {
+                CreateConfigurationWithDummyUser(repo, Constants.Identity);
                 string dir = repo.Info.Path;
                 Assert.True(Path.IsPathRooted(dir));
                 Assert.True(Directory.Exists(dir));

--- a/LibGit2Sharp.Tests/ConfigurationFixture.cs
+++ b/LibGit2Sharp.Tests/ConfigurationFixture.cs
@@ -36,12 +36,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanUnsetAnEntryFromTheGlobalConfiguration()
         {
-            SelfCleaningDirectory scd = BuildSelfCleaningDirectory();
-
-            var options = BuildFakeConfigs(scd);
-
             string path = SandboxBareTestRepo();
-            using (var repo = new Repository(path, options))
+            using (var repo = new Repository(path))
             {
                 Assert.True(repo.Config.HasConfig(ConfigurationLevel.Global));
                 Assert.Equal(42, repo.Config.Get<int>("Wow.Man-I-am-totally-global").Value);
@@ -331,12 +327,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanGetAnEntryFromASpecificStore()
         {
-            SelfCleaningDirectory scd = BuildSelfCleaningDirectory();
-
-            var options = BuildFakeConfigs(scd);
-
             string path = SandboxStandardTestRepo();
-            using (var repo = new Repository(path, options))
+            using (var repo = new Repository(path))
             {
                 Assert.True(repo.Config.HasConfig(ConfigurationLevel.Local));
                 Assert.True(repo.Config.HasConfig(ConfigurationLevel.Global));
@@ -356,12 +348,8 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanTellIfASpecificStoreContainsAKey()
         {
-            SelfCleaningDirectory scd = BuildSelfCleaningDirectory();
-
-            var options = BuildFakeConfigs(scd);
-
             string path = SandboxBareTestRepo();
-            using (var repo = new Repository(path, options))
+            using (var repo = new Repository(path))
             {
                 Assert.True(repo.Config.HasConfig(ConfigurationLevel.System));
 

--- a/LibGit2Sharp.Tests/DiffTreeToTreeFixture.cs
+++ b/LibGit2Sharp.Tests/DiffTreeToTreeFixture.cs
@@ -1044,12 +1044,9 @@ namespace LibGit2Sharp.Tests
                 repo.Config.Unset("core.filemode");
             }
 
-            SelfCleaningDirectory scd = BuildSelfCleaningDirectory();
-
-            var options = BuildFakeSystemConfigFilemodeOption(scd, true);
-
-            using (var repo = new Repository(path, options))
+            using (var repo = new Repository(path))
             {
+                SetFilemode(repo, true);
                 var changes = repo.Diff.Compare<TreeChanges>(new[] { file });
 
                 Assert.Equal(1, changes.Count());
@@ -1059,34 +1056,18 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(Mode.NonExecutableFile, change.Mode);
             }
 
-            options = BuildFakeSystemConfigFilemodeOption(scd, false);
-
-            using (var repo = new Repository(path, options))
+            using (var repo = new Repository(path))
             {
+                SetFilemode(repo, false);
                 var changes = repo.Diff.Compare<TreeChanges>(new[] { file });
 
                 Assert.Equal(0, changes.Count());
             }
         }
 
-        private RepositoryOptions BuildFakeSystemConfigFilemodeOption(
-            SelfCleaningDirectory scd,
-            bool value)
+        void SetFilemode(Repository repo, bool value)
         {
-            Directory.CreateDirectory(scd.DirectoryPath);
-
-            var options = new RepositoryOptions
-                              {
-                                  SystemConfigurationLocation = Path.Combine(
-                                      scd.RootedDirectoryPath, "fake-system.config")
-                              };
-
-            StringBuilder sb = new StringBuilder()
-                .AppendFormat("[core]{0}", Environment.NewLine)
-                .AppendFormat("filemode = {1}{0}", Environment.NewLine, value);
-            Touch("", options.SystemConfigurationLocation, sb.ToString());
-
-            return options;
+            repo.Config.Set("core.filemode", value);
         }
 
         [Fact]

--- a/LibGit2Sharp.Tests/DiffWorkdirToIndexFixture.cs
+++ b/LibGit2Sharp.Tests/DiffWorkdirToIndexFixture.cs
@@ -127,12 +127,9 @@ namespace LibGit2Sharp.Tests
                 repo.Config.Unset("core.filemode", ConfigurationLevel.Local);
             }
 
-            SelfCleaningDirectory scd = BuildSelfCleaningDirectory();
-
-            var options = BuildFakeSystemConfigFilemodeOption(scd, true);
-
-            using (var repo = new Repository(path, options))
+            using (var repo = new Repository(path))
             {
+                SetFilemode(repo, true);
                 var changes = repo.Diff.Compare<TreeChanges>(new[] { file });
 
                 Assert.Equal(1, changes.Count());
@@ -142,34 +139,18 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(Mode.NonExecutableFile, change.Mode);
             }
 
-            options = BuildFakeSystemConfigFilemodeOption(scd, false);
-
-            using (var repo = new Repository(path, options))
+            using (var repo = new Repository(path))
             {
+                SetFilemode(repo, false);
                 var changes = repo.Diff.Compare<TreeChanges>(new[] { file });
 
                 Assert.Equal(0, changes.Count());
             }
         }
 
-        private RepositoryOptions BuildFakeSystemConfigFilemodeOption(
-            SelfCleaningDirectory scd,
-            bool value)
+        void SetFilemode(Repository repo, bool value)
         {
-            Directory.CreateDirectory(scd.DirectoryPath);
-
-            var options = new RepositoryOptions
-            {
-                SystemConfigurationLocation = Path.Combine(
-                    scd.RootedDirectoryPath, "fake-system.config")
-            };
-
-            StringBuilder sb = new StringBuilder()
-                .AppendFormat("[core]{0}", Environment.NewLine)
-                .AppendFormat("filemode = {1}{0}", Environment.NewLine, value);
-            File.WriteAllText(options.SystemConfigurationLocation, sb.ToString());
-
-            return options;
+            repo.Config.Set("core.filemode", value);
         }
 
         [Fact]

--- a/LibGit2Sharp.Tests/FetchFixture.cs
+++ b/LibGit2Sharp.Tests/FetchFixture.cs
@@ -213,9 +213,7 @@ namespace LibGit2Sharp.Tests
 
             string clonedRepoPath = Repository.Clone(url, scd.DirectoryPath);
 
-            var options = BuildFakeConfigs(BuildSelfCleaningDirectory());
-
-            using (var clonedRepo = new Repository(clonedRepoPath, options))
+            using (var clonedRepo = new Repository(clonedRepoPath))
             {
                 Assert.Equal(5, clonedRepo.Branches.Count(b => b.IsRemote));
 

--- a/LibGit2Sharp.Tests/FilterFixture.cs
+++ b/LibGit2Sharp.Tests/FilterFixture.cs
@@ -276,11 +276,9 @@ namespace LibGit2Sharp.Tests
                 string attributesPath = Path.Combine(Directory.GetParent(repoPath).Parent.FullName, ".gitattributes");
                 FileInfo attributesFile = new FileInfo(attributesPath);
 
-                string configPath = CreateConfigurationWithDummyUser(Constants.Identity);
-                var repositoryOptions = new RepositoryOptions { GlobalConfigurationLocation = configPath };
-
-                using (Repository repo = new Repository(repoPath, repositoryOptions))
+                using (Repository repo = new Repository(repoPath))
                 {
+                    CreateConfigurationWithDummyUser(repo, Constants.Identity);
                     File.WriteAllText(attributesPath, "*.blob filter=test");
                     repo.Stage(attributesFile.Name);
                     repo.Stage(contentFile.Name);
@@ -421,9 +419,8 @@ namespace LibGit2Sharp.Tests
 
         private Repository CreateTestRepository(string path)
         {
-            string configPath = CreateConfigurationWithDummyUser(Constants.Identity);
-            var repositoryOptions = new RepositoryOptions { GlobalConfigurationLocation = configPath };
-            var repository = new Repository(path, repositoryOptions);
+            var repository = new Repository(path);
+            CreateConfigurationWithDummyUser(repository, Constants.Identity);
             CreateAttributesFile(repository, "* filter=test");
             return repository;
         }

--- a/LibGit2Sharp.Tests/FilterSubstitutionCipherFixture.cs
+++ b/LibGit2Sharp.Tests/FilterSubstitutionCipherFixture.cs
@@ -21,10 +21,9 @@ namespace LibGit2Sharp.Tests
 
             string repoPath = InitNewRepository();
             string fileName = Guid.NewGuid() + ".rot13";
-            string configPath = CreateConfigurationWithDummyUser(Constants.Identity);
-            var repositoryOptions = new RepositoryOptions { GlobalConfigurationLocation = configPath };
-            using (var repo = new Repository(repoPath, repositoryOptions))
+            using (var repo = new Repository(repoPath))
             {
+                CreateConfigurationWithDummyUser(repo, Constants.Identity);
                 CreateAttributesFile(repo, "*.rot13 filter=rot13");
 
                 var blob = CommitOnBranchAndReturnDatabaseBlob(repo, fileName, decodedInput);
@@ -61,10 +60,9 @@ namespace LibGit2Sharp.Tests
 
             string repoPath = InitNewRepository();
             string fileName = Guid.NewGuid() + ".rot13";
-            string configPath = CreateConfigurationWithDummyUser(Constants.Identity);
-            var repositoryOptions = new RepositoryOptions { GlobalConfigurationLocation = configPath };
-            using (var repo = new Repository(repoPath, repositoryOptions))
+            using (var repo = new Repository(repoPath))
             {
+                CreateConfigurationWithDummyUser(repo, Constants.Identity);
                 CreateAttributesFile(repo, "*.rot13 filter=rot13");
 
                 var blob = CommitOnBranchAndReturnDatabaseBlob(repo, fileName, decodedInput);
@@ -106,10 +104,9 @@ namespace LibGit2Sharp.Tests
             string repoPath = InitNewRepository();
             string fileName = Guid.NewGuid() + fileExtension;
 
-            string configPath = CreateConfigurationWithDummyUser(Constants.Identity);
-            var repositoryOptions = new RepositoryOptions { GlobalConfigurationLocation = configPath };
-            using (var repo = new Repository(repoPath, repositoryOptions))
+            using (var repo = new Repository(repoPath))
             {
+                CreateConfigurationWithDummyUser(repo, Constants.Identity);
                 CreateAttributesFile(repo, attributeFileEntry);
 
                 CommitOnBranchAndReturnDatabaseBlob(repo, fileName, decodedInput);
@@ -141,10 +138,9 @@ namespace LibGit2Sharp.Tests
             string repoPath = InitNewRepository();
             string fileName = Guid.NewGuid() + ".txt";
 
-            string configPath = CreateConfigurationWithDummyUser(Constants.Identity);
-            var repositoryOptions = new RepositoryOptions { GlobalConfigurationLocation = configPath };
-            using (var repo = new Repository(repoPath, repositoryOptions))
+            using (var repo = new Repository(repoPath))
             {
+                CreateConfigurationWithDummyUser(repo, Constants.Identity);
                 CreateAttributesFile(repo, attributeEntry);
 
                 CommitOnBranchAndReturnDatabaseBlob(repo, fileName, decodedInput);
@@ -172,10 +168,9 @@ namespace LibGit2Sharp.Tests
             string repoPath = InitNewRepository();
             string fileName = Guid.NewGuid() + ".txt";
 
-            string configPath = CreateConfigurationWithDummyUser(Constants.Identity);
-            var repositoryOptions = new RepositoryOptions { GlobalConfigurationLocation = configPath };
-            using (var repo = new Repository(repoPath, repositoryOptions))
+            using (var repo = new Repository(repoPath))
             {
+                CreateConfigurationWithDummyUser(repo, Constants.Identity);
                 CreateAttributesFile(repo, attributeEntry);
 
                 CommitOnBranchAndReturnDatabaseBlob(repo, fileName, decodedInput);

--- a/LibGit2Sharp.Tests/MergeFixture.cs
+++ b/LibGit2Sharp.Tests/MergeFixture.cs
@@ -678,7 +678,7 @@ namespace LibGit2Sharp.Tests
             const string conflictBranchName = "conflicts";
 
             string path = SandboxMergeTestRepo();
-            using (var repo = InitIsolatedRepository(path))
+            using (var repo = new Repository(path))
             {
                 Branch branch = repo.Branches[conflictBranchName];
                 Assert.NotNull(branch);

--- a/LibGit2Sharp.Tests/NoteFixture.cs
+++ b/LibGit2Sharp.Tests/NoteFixture.cs
@@ -168,12 +168,11 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanAddANoteWithSignatureFromConfig()
         {
-            string configPath = CreateConfigurationWithDummyUser(Constants.Identity);
-            var options = new RepositoryOptions { GlobalConfigurationLocation = configPath };
             string path = SandboxBareTestRepo();
 
-            using (var repo = new Repository(path, options))
+            using (var repo = new Repository(path))
             {
+                CreateConfigurationWithDummyUser(repo, Constants.Identity);
                 var commit = repo.Lookup<Commit>("9fd738e8f7967c078dceed8190330fc8648ee56a");
 
                 Signature signature = repo.Config.BuildSignature(DateTimeOffset.Now);
@@ -268,12 +267,11 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanRemoveANoteWithSignatureFromConfig()
         {
-            string configPath = CreateConfigurationWithDummyUser(Constants.Identity);
-            RepositoryOptions options = new RepositoryOptions() { GlobalConfigurationLocation = configPath };
             string path = SandboxBareTestRepo();
 
-            using (var repo = new Repository(path, options))
+            using (var repo = new Repository(path))
             {
+                CreateConfigurationWithDummyUser(repo, Constants.Identity);
                 var commit = repo.Lookup<Commit>("8496071c1b46c854b31185ea97743be6a8774479");
                 var notes = repo.Notes[commit.Id];
 

--- a/LibGit2Sharp.Tests/ObjectDatabaseFixture.cs
+++ b/LibGit2Sharp.Tests/ObjectDatabaseFixture.cs
@@ -109,7 +109,7 @@ namespace LibGit2Sharp.Tests
                 sb.Append("libgit2\n\r\n");
             }
 
-            using (var repo = InitIsolatedRepository())
+            using (var repo = new Repository(InitNewRepository()))
             {
                 CreateAttributesFiles(Path.Combine(repo.Info.Path, "info"), "attributes");
 

--- a/LibGit2Sharp.Tests/RefSpecFixture.cs
+++ b/LibGit2Sharp.Tests/RefSpecFixture.cs
@@ -11,7 +11,7 @@ namespace LibGit2Sharp.Tests
         public void CanCountRefSpecs()
         {
             var path = SandboxStandardTestRepo();
-            using (var repo = InitIsolatedRepository(path))
+            using (var repo = new Repository(path))
             {
                 var remote = repo.Network.Remotes["origin"];
                 Assert.Equal(1, remote.RefSpecs.Count());
@@ -22,7 +22,7 @@ namespace LibGit2Sharp.Tests
         public void CanIterateOverRefSpecs()
         {
             var path = SandboxStandardTestRepo();
-            using (var repo = InitIsolatedRepository(path))
+            using (var repo = new Repository(path))
             {
                 var remote = repo.Network.Remotes["origin"];
                 int count = 0;
@@ -39,7 +39,7 @@ namespace LibGit2Sharp.Tests
         public void FetchAndPushRefSpecsComposeRefSpecs()
         {
             var path = SandboxStandardTestRepo();
-            using (var repo = InitIsolatedRepository(path))
+            using (var repo = new Repository(path))
             {
                 var remote = repo.Network.Remotes["origin"];
 
@@ -53,7 +53,7 @@ namespace LibGit2Sharp.Tests
         public void CanReadRefSpecDetails()
         {
             var path = SandboxStandardTestRepo();
-            using (var repo = InitIsolatedRepository(path))
+            using (var repo = new Repository(path))
             {
                 var remote = repo.Network.Remotes["origin"];
 
@@ -73,7 +73,7 @@ namespace LibGit2Sharp.Tests
         public void CanReplaceRefSpecs(string[] newFetchRefSpecs, string[] newPushRefSpecs)
         {
             var path = SandboxStandardTestRepo();
-            using (var repo = InitIsolatedRepository(path))
+            using (var repo = new Repository(path))
             {
                 var remote = repo.Network.Remotes["origin"];
                 var oldRefSpecs = remote.RefSpecs.ToList();
@@ -101,15 +101,15 @@ namespace LibGit2Sharp.Tests
         public void RemoteUpdaterSavesRefSpecsPermanently()
         {
             var fetchRefSpecs = new string[] { "refs/their/heads/*:refs/my/heads/*", "+refs/their/tag:refs/my/tag" };
-
             var path = SandboxStandardTestRepo();
-            using (var repo = InitIsolatedRepository(path))
+
+            using (var repo = new Repository(path))
             {
                 var remote = repo.Network.Remotes["origin"];
                 repo.Network.Remotes.Update(remote, r => r.FetchRefSpecs = fetchRefSpecs);
             }
 
-            using (var repo = InitIsolatedRepository(path))
+            using (var repo = new Repository(path))
             {
                 var remote = repo.Network.Remotes["origin"];
                 var actualRefSpecs = remote.RefSpecs
@@ -124,9 +124,9 @@ namespace LibGit2Sharp.Tests
         public void CanAddAndRemoveRefSpecs()
         {
             string newRefSpec = "+refs/heads/test:refs/heads/other-test";
-
             var path = SandboxStandardTestRepo();
-            using (var repo = InitIsolatedRepository(path))
+
+            using (var repo = new Repository(path))
             {
                 var remote = repo.Network.Remotes["origin"];
 
@@ -150,7 +150,7 @@ namespace LibGit2Sharp.Tests
         public void CanClearRefSpecs()
         {
             var path = SandboxStandardTestRepo();
-            using (var repo = InitIsolatedRepository(path))
+            using (var repo = new Repository(path))
             {
                 var remote = repo.Network.Remotes["origin"];
 
@@ -178,7 +178,7 @@ namespace LibGit2Sharp.Tests
         public void SettingInvalidRefSpecsThrows(string refSpec)
         {
             var path = SandboxStandardTestRepo();
-            using (var repo = InitIsolatedRepository(path))
+            using (var repo = new Repository(path))
             {
                 var remote = repo.Network.Remotes["origin"];
                 var oldRefSpecs = remote.RefSpecs.Select(r => r.Specification).ToList();
@@ -198,8 +198,7 @@ namespace LibGit2Sharp.Tests
         [InlineData("refs/tags/foo", false, false)]
         public void CanCheckForMatches(string reference, bool shouldMatchSource, bool shouldMatchDest)
         {
-            var path = SandboxStandardTestRepo();
-            using (var repo = InitIsolatedRepository(path))
+            using (var repo = new Repository(InitNewRepository()))
             {
                 var remote = repo.Network.Remotes.Add("foo", "blahblah", "refs/heads/*:refs/remotes/foo/*");
                 var refspec = remote.RefSpecs.Single();
@@ -215,8 +214,7 @@ namespace LibGit2Sharp.Tests
         [InlineData("refs/heads/master", "refs/remotes/foo/master")]
         public void CanTransformRefspecs(string lhs, string rhs)
         {
-            var path = SandboxStandardTestRepo();
-            using (var repo = InitIsolatedRepository(path))
+            using (var repo = new Repository(InitNewRepository()))
             {
                 var remote = repo.Network.Remotes.Add("foo", "blahblah", "refs/heads/*:refs/remotes/foo/*");
                 var refspec = remote.RefSpecs.Single();

--- a/LibGit2Sharp.Tests/RemoteFixture.cs
+++ b/LibGit2Sharp.Tests/RemoteFixture.cs
@@ -377,9 +377,8 @@ namespace LibGit2Sharp.Tests
         public void ShoudlPruneOnFetchReflectsTheConfiguredSetting(bool? fetchPrune, bool? remotePrune, bool expectedFetchPrune)
         {
             var path = SandboxStandardTestRepo();
-            var scd = BuildSelfCleaningDirectory();
 
-            using (var repo = new Repository(path, BuildFakeConfigs(scd)))
+            using (var repo = new Repository(path))
             {
                 Assert.Null(repo.Config.Get<bool>("fetch.prune"));
                 Assert.Null(repo.Config.Get<bool>("remote.origin.prune"));

--- a/LibGit2Sharp.Tests/TestHelpers/BaseFixture.cs
+++ b/LibGit2Sharp.Tests/TestHelpers/BaseFixture.cs
@@ -335,18 +335,14 @@ namespace LibGit2Sharp.Tests.TestHelpers
         /// <remarks>The configuration file will be removed automatically when the tests are finished</remarks>
         /// <param name="identity">The identity to use for user.name and user.email</param>
         /// <returns>The path to the configuration file</returns>
-        protected string CreateConfigurationWithDummyUser(Identity identity)
+        protected void CreateConfigurationWithDummyUser(Repository repo, Identity identity)
         {
-            return CreateConfigurationWithDummyUser(identity.Name, identity.Email);
+            CreateConfigurationWithDummyUser(repo, identity.Name, identity.Email);
         }
 
-        protected string CreateConfigurationWithDummyUser(string name, string email)
+        protected void CreateConfigurationWithDummyUser(Repository repo, string name, string email)
         {
-            SelfCleaningDirectory scd = BuildSelfCleaningDirectory();
-
-            string configFilePath = Touch(scd.DirectoryPath, "fake-config");
-
-            using (Configuration config = Configuration.BuildFrom(configFilePath))
+            Configuration config = repo.Config;
             {
                 if (name != null)
                 {
@@ -358,8 +354,6 @@ namespace LibGit2Sharp.Tests.TestHelpers
                     config.Set("user.email", email);
                 }
             }
-
-            return configFilePath;
         }
 
         /// <summary>

--- a/LibGit2Sharp.Tests/TestHelpers/BaseFixture.cs
+++ b/LibGit2Sharp.Tests/TestHelpers/BaseFixture.cs
@@ -86,8 +86,8 @@ namespace LibGit2Sharp.Tests.TestHelpers
         {
             var scd = new SelfCleaningDirectory(dirRemover);
 
-            string global = null, xdg = null, system = null;
-            BuildFakeRepositoryOptions(scd, out global, out xdg, out system);
+            string global = null, xdg = null, system = null, programData = null;
+            BuildFakeRepositoryOptions(scd, out global, out xdg, out system, out programData);
 
             StringBuilder sb = new StringBuilder()
                 .AppendFormat("[Woot]{0}", Environment.NewLine)
@@ -106,9 +106,15 @@ namespace LibGit2Sharp.Tests.TestHelpers
                 .AppendFormat("this-rocks = xdg{0}", Environment.NewLine);
             File.WriteAllText(Path.Combine(xdg, "config"), sb.ToString());
 
+            sb = new StringBuilder()
+                .AppendFormat("[Woot]{0}", Environment.NewLine)
+                .AppendFormat("this-rocks = programdata{0}", Environment.NewLine);
+            File.WriteAllText(Path.Combine(programData, "config"), sb.ToString());
+
             GlobalSettings.SetConfigSearchPaths(ConfigurationLevel.Global, global);
             GlobalSettings.SetConfigSearchPaths(ConfigurationLevel.Xdg, xdg);
             GlobalSettings.SetConfigSearchPaths(ConfigurationLevel.System, system);
+            GlobalSettings.SetConfigSearchPaths(ConfigurationLevel.ProgramData, programData);
         }
 
         private static void CleanupTestReposOlderThan(TimeSpan olderThan)
@@ -316,7 +322,7 @@ namespace LibGit2Sharp.Tests.TestHelpers
             Assert.True(r.Success, text);
         }
 
-        private static void BuildFakeRepositoryOptions(SelfCleaningDirectory scd, out string global, out string xdg, out string system)
+        private static void BuildFakeRepositoryOptions(SelfCleaningDirectory scd, out string global, out string xdg, out string system, out string programData)
         {
             string confs = Path.Combine(scd.DirectoryPath, "confs");
             Directory.CreateDirectory(confs);
@@ -327,6 +333,8 @@ namespace LibGit2Sharp.Tests.TestHelpers
             Directory.CreateDirectory(xdg);
             system = Path.Combine(confs, "my-system-config");
             Directory.CreateDirectory(system);
+            programData = Path.Combine(confs, "my-programdata-config");
+            Directory.CreateDirectory(programData);
         }
 
         /// <summary>

--- a/LibGit2Sharp/Configuration.cs
+++ b/LibGit2Sharp/Configuration.cs
@@ -19,6 +19,7 @@ namespace LibGit2Sharp
         private readonly FilePath globalConfigPath;
         private readonly FilePath xdgConfigPath;
         private readonly FilePath systemConfigPath;
+        private readonly FilePath programDataConfigPath;
 
         private ConfigurationSafeHandle configHandle;
 
@@ -43,6 +44,7 @@ namespace LibGit2Sharp
             globalConfigPath = globalConfigurationFileLocation ?? Proxy.git_config_find_global();
             xdgConfigPath = xdgConfigurationFileLocation ?? Proxy.git_config_find_xdg();
             systemConfigPath = systemConfigurationFileLocation ?? Proxy.git_config_find_system();
+            programDataConfigPath = Proxy.git_config_find_programdata();
 
             Init(repository);
         }
@@ -80,6 +82,11 @@ namespace LibGit2Sharp
             if (systemConfigPath != null)
             {
                 Proxy.git_config_add_file_ondisk(configHandle, systemConfigPath, ConfigurationLevel.System);
+            }
+
+            if (programDataConfigPath != null)
+            {
+                Proxy.git_config_add_file_ondisk(configHandle, programDataConfigPath, ConfigurationLevel.ProgramData);
             }
         }
 

--- a/LibGit2Sharp/ConfigurationLevel.cs
+++ b/LibGit2Sharp/ConfigurationLevel.cs
@@ -24,5 +24,10 @@
         /// The system wide .gitconfig.
         /// </summary>
         System = 2,
+
+        /// <summary>
+        /// Another system-wide configuration on Windows.
+        /// </summary>
+        ProgramData = 1,
     }
 }

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -345,6 +345,9 @@ namespace LibGit2Sharp.Core
         internal static extern int git_config_find_xdg(GitBuf xdg_config_path);
 
         [DllImport(libgit2)]
+        internal static extern int git_config_find_programdata(GitBuf programdata_config_path);
+
+        [DllImport(libgit2)]
         internal static extern void git_config_free(IntPtr cfg);
 
         [DllImport(libgit2)]

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -468,6 +468,11 @@ namespace LibGit2Sharp.Core
             return ConvertPath(NativeMethods.git_config_find_xdg);
         }
 
+        public static FilePath git_config_find_programdata()
+        {
+            return ConvertPath(NativeMethods.git_config_find_programdata);
+        }
+
         public static void git_config_free(IntPtr config)
         {
             NativeMethods.git_config_free(config);

--- a/LibGit2Sharp/RepositoryOptions.cs
+++ b/LibGit2Sharp/RepositoryOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace LibGit2Sharp
+﻿using System;
+
+namespace LibGit2Sharp
 {
     /// <summary>
     /// Provides optional additional information to the Repository to be opened.
@@ -34,6 +36,7 @@
         /// </para>
         /// <seealso cref="GlobalSettings.SetConfigSearchPaths"/>.
         /// </summary>
+        [Obsolete("This option is deprecated. Use GlobalConfiguration.SetConfigSearchPaths()")]
         public string GlobalConfigurationLocation { get; set; }
 
         /// <summary>
@@ -44,6 +47,7 @@
         /// </para>
         /// <seealso cref="GlobalSettings.SetConfigSearchPaths"/>.
         /// </summary>
+        [Obsolete("This option is deprecated. Use GlobalConfiguration.SetConfigSearchPaths()")]
         public string XdgConfigurationLocation { get; set; }
 
         /// <summary>
@@ -54,6 +58,7 @@
         /// </para>
         /// <seealso cref="GlobalSettings.SetConfigSearchPaths"/>.
         /// </summary>
+        [Obsolete("This option is deprecated. Use GlobalConfiguration.SetConfigSearchPaths()")]
         public string SystemConfigurationLocation { get; set; }
 
         /// <summary>


### PR DESCRIPTION
The usage in our test suite seems rather gratuitous, and most of the config would have been more at home in the local configuration.

Fixes #1188 
