### PR TITLE
Don't load an object just to check its ID

### DIFF
--- a/LibGit2Sharp/Branch.cs
+++ b/LibGit2Sharp/Branch.cs
@@ -106,7 +106,15 @@ namespace LibGit2Sharp
         /// </value>
         public virtual bool IsCurrentRepositoryHead
         {
-            get { return repo.Head == this; }
+            get
+            {
+                if (this is DetachedHead)
+                {
+                    return repo.Head.reference.TargetIdentifier == this.reference.TargetIdentifier;
+                }
+
+                return repo.Head.reference.TargetIdentifier == this.CanonicalName;
+            }
         }
 
         /// <summary>

--- a/LibGit2Sharp/ReferenceWrapper.cs
+++ b/LibGit2Sharp/ReferenceWrapper.cs
@@ -16,10 +16,11 @@ namespace LibGit2Sharp
         /// The repository.
         /// </summary>
         protected readonly Repository repo;
+        protected readonly Reference reference;
         private readonly Lazy<TObject> objectBuilder;
 
         private static readonly LambdaEqualityHelper<ReferenceWrapper<TObject>> equalityHelper =
-            new LambdaEqualityHelper<ReferenceWrapper<TObject>>(x => x.CanonicalName, x => x.TargetObject);
+            new LambdaEqualityHelper<ReferenceWrapper<TObject>>(x => x.CanonicalName, x => x.reference.TargetIdentifier);
 
         private readonly string canonicalName;
 
@@ -40,6 +41,7 @@ namespace LibGit2Sharp
 
             this.repo = repo;
             canonicalName = canonicalNameSelector(reference);
+            this.reference = reference;
             objectBuilder = new Lazy<TObject>(() => RetrieveTargetObject(reference));
         }
 


### PR DESCRIPTION
In order to check for equality we just need to compare the ID of the
object. We do not need to look up the object but can compare their
identifiers directly.
