### PR TITLE
Add a Peel method to GitObject

### DIFF
--- a/LibGit2Sharp/GitObject.cs
+++ b/LibGit2Sharp/GitObject.cs
@@ -21,6 +21,14 @@ namespace LibGit2Sharp
                 { typeof(Blob), ObjectType.Blob },
                 { typeof(TagAnnotation), ObjectType.Tag },
             };
+        internal static IDictionary<Type, GitObjectType> TypeToGitKindMap =
+            new Dictionary<Type, GitObjectType>
+        {
+            { typeof(Commit), GitObjectType.Commit },
+            { typeof(Tree), GitObjectType.Tree },
+            { typeof(Blob), GitObjectType.Blob },
+            { typeof(TagAnnotation), GitObjectType.Tag },
+        };
 
         private static readonly LambdaEqualityHelper<GitObject> equalityHelper =
             new LambdaEqualityHelper<GitObject>(x => x.Id);
@@ -83,17 +91,30 @@ namespace LibGit2Sharp
             }
         }
 
-        internal Commit DereferenceToCommit(bool throwsIfCanNotBeDereferencedToACommit)
+        internal T Peel<T>(bool throwOnError) where T : GitObject
         {
-            using (GitObjectSafeHandle peeledHandle = Proxy.git_object_peel(repo.Handle, Id, GitObjectType.Commit, throwsIfCanNotBeDereferencedToACommit))
+            GitObjectType kind;
+            if (!TypeToGitKindMap.TryGetValue(typeof(T), out kind))
             {
-                if (peeledHandle == null)
-                {
-                    return null;
-                }
-
-                return (Commit)BuildFrom(repo, Proxy.git_object_id(peeledHandle), GitObjectType.Commit, null);
+                throw new ArgumentException("Invalid type passed to peel");
             }
+
+            using (var handle = Proxy.git_object_peel(repo.Handle, Id, kind, throwOnError))
+            {
+                return (T)BuildFrom(this.repo, Proxy.git_object_id(handle), kind, null);
+            }
+        }
+
+        /// <summary>
+        /// Peel this object to the specified type
+        ///
+        /// It will throw if the object cannot be peeled to the type.
+        /// </summary>
+        /// <typeparam name="T">The kind of <see cref="GitObject"/> to peel to.</typeparam>
+        /// <returns>The peeled object</returns>
+        public T Peel<T>() where T : GitObject
+        {
+            return Peel<T>(true);
         }
 
         /// <summary>

--- a/LibGit2Sharp/ReferenceCollection.cs
+++ b/LibGit2Sharp/ReferenceCollection.cs
@@ -736,7 +736,7 @@ namespace LibGit2Sharp
             {
                 var peeledTargetCommit = reference
                                             .ResolveToDirectReference()
-                                            .Target.DereferenceToCommit(false);
+                                            .Target.Peel<Commit>(false);
 
                 if (peeledTargetCommit == null)
                 {

--- a/LibGit2Sharp/Repository.cs
+++ b/LibGit2Sharp/Repository.cs
@@ -538,7 +538,7 @@ namespace LibGit2Sharp
 
             if (lookUpOptions.HasFlag(LookUpOptions.DereferenceResultToCommit))
             {
-                return obj.DereferenceToCommit(lookUpOptions.HasFlag(LookUpOptions.ThrowWhenCanNotBeDereferencedToACommit));
+                return obj.Peel<Commit>(lookUpOptions.HasFlag(LookUpOptions.ThrowWhenCanNotBeDereferencedToACommit));
             }
 
             return obj;
@@ -878,7 +878,7 @@ namespace LibGit2Sharp
                 refH.Dispose();
             }
 
-            Commit commit = obj.DereferenceToCommit(true);
+            Commit commit = obj.Peel<Commit>(true);
             Checkout(commit.Tree, options, committishOrBranchSpec);
 
             return Head;

--- a/LibGit2Sharp/RepositoryExtensions.cs
+++ b/LibGit2Sharp/RepositoryExtensions.cs
@@ -182,7 +182,7 @@ namespace LibGit2Sharp
         {
             GitObject obj = repository.Lookup(committish);
             Ensure.GitObjectIsNotNull(obj, committish);
-            return obj.DereferenceToCommit(true);
+            return obj.Peel<Commit>(true);
         }
 
         /// <summary>


### PR DESCRIPTION
This exposes what we've only had internally, letting you ask for e.g. a
tree from a tag.

Make use of this internally as well instead of the special-cased method
we had up to now.

---

I wanted to do something cute like attach the `GitObjectType` value to the type itself so I could do `T.GitObjectType` instead of performing a dictionary lookup, but C# won't let me have a per-class static field.

I wonder if having the dictionary is worth the overhead or a function with a bunch of `if`s would work out to be quicker (it's likely not a big deal either way).
