### PR TITLE
Expose the underlying reference for ReferenceWrapper

### DIFF
--- a/LibGit2Sharp/Branch.cs
+++ b/LibGit2Sharp/Branch.cs
@@ -110,10 +110,10 @@ namespace LibGit2Sharp
             {
                 if (this is DetachedHead)
                 {
-                    return repo.Head.reference.TargetIdentifier == this.reference.TargetIdentifier;
+                    return repo.Head.Reference.TargetIdentifier == this.Reference.TargetIdentifier;
                 }
 
-                return repo.Head.reference.TargetIdentifier == this.CanonicalName;
+                return repo.Head.Reference.TargetIdentifier == this.CanonicalName;
             }
         }
 

--- a/LibGit2Sharp/ReferenceWrapper.cs
+++ b/LibGit2Sharp/ReferenceWrapper.cs
@@ -16,7 +16,7 @@ namespace LibGit2Sharp
         /// The repository.
         /// </summary>
         protected readonly Repository repo;
-        protected readonly Reference reference;
+        private readonly Reference reference;
         private readonly Lazy<TObject> objectBuilder;
 
         private static readonly LambdaEqualityHelper<ReferenceWrapper<TObject>> equalityHelper =
@@ -59,6 +59,17 @@ namespace LibGit2Sharp
         public virtual string FriendlyName
         {
             get { return Shorten(); }
+        }
+
+        /// <summary>
+        /// The underlying <see cref="Reference"/>
+        /// </summary>
+        public virtual Reference Reference
+        {
+            get
+            {
+                return reference;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This lets us get to the reference's information without having to ask
the wrapper object for the information.

/cc @niik