### PR TITLE
Lazy TreeChanges, move ownership of diff handle for diff results

### DIFF
--- a/LibGit2Sharp.Tests/DiffTreeToTargetFixture.cs
+++ b/LibGit2Sharp.Tests/DiffTreeToTargetFixture.cs
@@ -43,23 +43,27 @@ namespace LibGit2Sharp.Tests
             {
                 SetUpSimpleDiffContext(repo);
 
-                var changes = repo.Diff.Compare<TreeChanges>(repo.Head.Tip.Tree,
-                    DiffTargets.WorkingDirectory);
-                Assert.Equal(1, changes.Modified.Count());
+                using (var changes = repo.Diff.Compare<TreeChanges>(repo.Head.Tip.Tree,
+                    DiffTargets.WorkingDirectory))
+                {
+                    Assert.Equal(1, changes.Modified.Count());
+                }
 
-                var patch = repo.Diff.Compare<Patch>(repo.Head.Tip.Tree,
-                    DiffTargets.WorkingDirectory);
-                var expected = new StringBuilder()
-                    .Append("diff --git a/file.txt b/file.txt\n")
-                    .Append("index ce01362..4f125e3 100644\n")
-                    .Append("--- a/file.txt\n")
-                    .Append("+++ b/file.txt\n")
-                    .Append("@@ -1 +1,3 @@\n")
-                    .Append(" hello\n")
-                    .Append("+world\n")
-                    .Append("+!!!\n");
+                using (var patch = repo.Diff.Compare<Patch>(repo.Head.Tip.Tree,
+                        DiffTargets.WorkingDirectory))
+                {
+                    var expected = new StringBuilder()
+                        .Append("diff --git a/file.txt b/file.txt\n")
+                        .Append("index ce01362..4f125e3 100644\n")
+                        .Append("--- a/file.txt\n")
+                        .Append("+++ b/file.txt\n")
+                        .Append("@@ -1 +1,3 @@\n")
+                        .Append(" hello\n")
+                        .Append("+world\n")
+                        .Append("+!!!\n");
 
-                Assert.Equal(expected.ToString(), patch);
+                    Assert.Equal(expected.ToString(), patch);
+                }
             }
         }
 
@@ -71,19 +75,21 @@ namespace LibGit2Sharp.Tests
             {
                 Tree tree = repo.Head.Tip.Tree;
 
-                var changes = repo.Diff.Compare<TreeChanges>(tree, DiffTargets.WorkingDirectory);
-                Assert.NotNull(changes);
+                using (var changes = repo.Diff.Compare<TreeChanges>(tree, DiffTargets.WorkingDirectory))
+                {
+                    Assert.NotNull(changes);
 
-                Assert.Equal(6, changes.Count());
+                    Assert.Equal(6, changes.Count());
 
-                Assert.Equal(new[] { "deleted_staged_file.txt", "deleted_unstaged_file.txt" },
-                    changes.Deleted.Select(tec => tec.Path));
+                    Assert.Equal(new[] { "deleted_staged_file.txt", "deleted_unstaged_file.txt" },
+                        changes.Deleted.Select(tec => tec.Path));
 
-                Assert.Equal(new[] { "new_tracked_file.txt", "new_untracked_file.txt" },
-                    changes.Added.Select(tec => tec.Path));
+                    Assert.Equal(new[] { "new_tracked_file.txt", "new_untracked_file.txt" },
+                        changes.Added.Select(tec => tec.Path));
 
-                Assert.Equal(new[] { "modified_staged_file.txt", "modified_unstaged_file.txt" },
-                    changes.Modified.Select(tec => tec.Path));
+                    Assert.Equal(new[] { "modified_staged_file.txt", "modified_unstaged_file.txt" },
+                        changes.Modified.Select(tec => tec.Path));
+                }
             }
         }
 
@@ -107,23 +113,27 @@ namespace LibGit2Sharp.Tests
             {
                 SetUpSimpleDiffContext(repo);
 
-                var changes = repo.Diff.Compare<TreeChanges>(repo.Head.Tip.Tree,
-                    DiffTargets.Index | DiffTargets.WorkingDirectory);
-                Assert.Equal(1, changes.Modified.Count());
+                using (var changes = repo.Diff.Compare<TreeChanges>(repo.Head.Tip.Tree,
+                    DiffTargets.Index | DiffTargets.WorkingDirectory))
+                {
+                    Assert.Equal(1, changes.Modified.Count());
+                }
 
-                var patch = repo.Diff.Compare<Patch>(repo.Head.Tip.Tree,
-                    DiffTargets.Index | DiffTargets.WorkingDirectory);
-                var expected = new StringBuilder()
-                    .Append("diff --git a/file.txt b/file.txt\n")
-                    .Append("index ce01362..4f125e3 100644\n")
-                    .Append("--- a/file.txt\n")
-                    .Append("+++ b/file.txt\n")
-                    .Append("@@ -1 +1,3 @@\n")
-                    .Append(" hello\n")
-                    .Append("+world\n")
-                    .Append("+!!!\n");
+                using (var patch = repo.Diff.Compare<Patch>(repo.Head.Tip.Tree,
+                        DiffTargets.Index | DiffTargets.WorkingDirectory))
+                {
+                    var expected = new StringBuilder()
+                        .Append("diff --git a/file.txt b/file.txt\n")
+                        .Append("index ce01362..4f125e3 100644\n")
+                        .Append("--- a/file.txt\n")
+                        .Append("+++ b/file.txt\n")
+                        .Append("@@ -1 +1,3 @@\n")
+                        .Append(" hello\n")
+                        .Append("+world\n")
+                        .Append("+!!!\n");
 
-                Assert.Equal(expected.ToString(), patch);
+                    Assert.Equal(expected.ToString(), patch);
+                }
             }
         }
 
@@ -165,44 +175,50 @@ namespace LibGit2Sharp.Tests
                 FileStatus state = repo.RetrieveStatus("file.txt");
                 Assert.Equal(FileStatus.DeletedFromIndex | FileStatus.NewInWorkdir, state);
 
-                var wrkDirToIdxToTree = repo.Diff.Compare<TreeChanges>(repo.Head.Tip.Tree,
-                    DiffTargets.Index | DiffTargets.WorkingDirectory);
+                using (var wrkDirToIdxToTree = repo.Diff.Compare<TreeChanges>(repo.Head.Tip.Tree,
+                    DiffTargets.Index | DiffTargets.WorkingDirectory))
+                {
+                    Assert.Equal(1, wrkDirToIdxToTree.Deleted.Count());
+                    Assert.Equal(0, wrkDirToIdxToTree.Modified.Count());
+                }
 
-                Assert.Equal(1, wrkDirToIdxToTree.Deleted.Count());
-                Assert.Equal(0, wrkDirToIdxToTree.Modified.Count());
+                using (var patch = repo.Diff.Compare<Patch>(repo.Head.Tip.Tree,
+                    DiffTargets.Index | DiffTargets.WorkingDirectory))
+                {
+                    var expected = new StringBuilder()
+                        .Append("diff --git a/file.txt b/file.txt\n")
+                        .Append("deleted file mode 100644\n")
+                        .Append("index ce01362..0000000\n")
+                        .Append("--- a/file.txt\n")
+                        .Append("+++ /dev/null\n")
+                        .Append("@@ -1 +0,0 @@\n")
+                        .Append("-hello\n");
 
-                var patch = repo.Diff.Compare<Patch>(repo.Head.Tip.Tree,
-                    DiffTargets.Index | DiffTargets.WorkingDirectory);
-                var expected = new StringBuilder()
-                    .Append("diff --git a/file.txt b/file.txt\n")
-                    .Append("deleted file mode 100644\n")
-                    .Append("index ce01362..0000000\n")
-                    .Append("--- a/file.txt\n")
-                    .Append("+++ /dev/null\n")
-                    .Append("@@ -1 +0,0 @@\n")
-                    .Append("-hello\n");
+                    Assert.Equal(expected.ToString(), patch);
+                }
 
-                Assert.Equal(expected.ToString(), patch);
+                using (var wrkDirToTree = repo.Diff.Compare<TreeChanges>(repo.Head.Tip.Tree,
+                    DiffTargets.WorkingDirectory))
+                {
+                    Assert.Equal(0, wrkDirToTree.Deleted.Count());
+                    Assert.Equal(1, wrkDirToTree.Modified.Count());
+                }
 
-                var wrkDirToTree = repo.Diff.Compare<TreeChanges>(repo.Head.Tip.Tree,
-                    DiffTargets.WorkingDirectory);
+                using (var patch = repo.Diff.Compare<Patch>(repo.Head.Tip.Tree,
+                    DiffTargets.WorkingDirectory))
+                {
+                    var expected = new StringBuilder()
+                        .Append("diff --git a/file.txt b/file.txt\n")
+                        .Append("index ce01362..4f125e3 100644\n")
+                        .Append("--- a/file.txt\n")
+                        .Append("+++ b/file.txt\n")
+                        .Append("@@ -1 +1,3 @@\n")
+                        .Append(" hello\n")
+                        .Append("+world\n")
+                        .Append("+!!!\n");
 
-                Assert.Equal(0, wrkDirToTree.Deleted.Count());
-                Assert.Equal(1, wrkDirToTree.Modified.Count());
-
-                patch = repo.Diff.Compare<Patch>(repo.Head.Tip.Tree,
-                    DiffTargets.WorkingDirectory);
-                expected = new StringBuilder()
-                    .Append("diff --git a/file.txt b/file.txt\n")
-                    .Append("index ce01362..4f125e3 100644\n")
-                    .Append("--- a/file.txt\n")
-                    .Append("+++ b/file.txt\n")
-                    .Append("@@ -1 +1,3 @@\n")
-                    .Append(" hello\n")
-                    .Append("+world\n")
-                    .Append("+!!!\n");
-
-                Assert.Equal(expected.ToString(), patch);
+                    Assert.Equal(expected.ToString(), patch);
+                }
             }
         }
 
@@ -225,22 +241,26 @@ namespace LibGit2Sharp.Tests
             {
                 SetUpSimpleDiffContext(repo);
 
-                var changes = repo.Diff.Compare<TreeChanges>(repo.Head.Tip.Tree,
-                    DiffTargets.Index);
-                Assert.Equal(1, changes.Modified.Count());
+                using (var changes = repo.Diff.Compare<TreeChanges>(repo.Head.Tip.Tree,
+                    DiffTargets.Index))
+                {
+                    Assert.Equal(1, changes.Modified.Count());
+                }
 
-                var patch = repo.Diff.Compare<Patch>(repo.Head.Tip.Tree,
-                    DiffTargets.Index);
-                var expected = new StringBuilder()
-                    .Append("diff --git a/file.txt b/file.txt\n")
-                    .Append("index ce01362..94954ab 100644\n")
-                    .Append("--- a/file.txt\n")
-                    .Append("+++ b/file.txt\n")
-                    .Append("@@ -1 +1,2 @@\n")
-                    .Append(" hello\n")
-                    .Append("+world\n");
+                using (var patch = repo.Diff.Compare<Patch>(repo.Head.Tip.Tree,
+                        DiffTargets.Index))
+                {
+                    var expected = new StringBuilder()
+                        .Append("diff --git a/file.txt b/file.txt\n")
+                        .Append("index ce01362..94954ab 100644\n")
+                        .Append("--- a/file.txt\n")
+                        .Append("+++ b/file.txt\n")
+                        .Append("@@ -1 +1,2 @@\n")
+                        .Append(" hello\n")
+                        .Append("+world\n");
 
-                Assert.Equal(expected.ToString(), patch);
+                    Assert.Equal(expected.ToString(), patch);
+                }
             }
         }
 
@@ -276,13 +296,15 @@ namespace LibGit2Sharp.Tests
             {
                 Tree tree = repo.Head.Tip.Tree;
 
-                var changes = repo.Diff.Compare<TreeChanges>(tree, DiffTargets.Index);
-                Assert.NotNull(changes);
+                using (var changes = repo.Diff.Compare<TreeChanges>(tree, DiffTargets.Index))
+                {
+                    Assert.NotNull(changes);
 
-                Assert.Equal(3, changes.Count());
-                Assert.Equal("deleted_staged_file.txt", changes.Deleted.Single().Path);
-                Assert.Equal("new_tracked_file.txt", changes.Added.Single().Path);
-                Assert.Equal("modified_staged_file.txt", changes.Modified.Single().Path);
+                    Assert.Equal(3, changes.Count());
+                    Assert.Equal("deleted_staged_file.txt", changes.Deleted.Single().Path);
+                    Assert.Equal("new_tracked_file.txt", changes.Added.Single().Path);
+                    Assert.Equal("modified_staged_file.txt", changes.Modified.Single().Path);
+                }
             }
         }
 
@@ -304,13 +326,14 @@ namespace LibGit2Sharp.Tests
             {
                 Tree tree = repo.Head.Tip.Tree;
 
-                var changes = repo.Diff.Compare<TreeChanges>(tree, DiffTargets.Index,
-                    new[] { "deleted_staged_file.txt", "1/branch_file.txt" });
+                using (var changes = repo.Diff.Compare<TreeChanges>(tree, DiffTargets.Index,
+                    new[] { "deleted_staged_file.txt", "1/branch_file.txt" }))
+                {
+                    Assert.NotNull(changes);
 
-                Assert.NotNull(changes);
-
-                Assert.Equal(1, changes.Count());
-                Assert.Equal("deleted_staged_file.txt", changes.Deleted.Single().Path);
+                    Assert.Equal(1, changes.Count());
+                    Assert.Equal("deleted_staged_file.txt", changes.Deleted.Single().Path);
+                }
             }
         }
 
@@ -329,13 +352,17 @@ namespace LibGit2Sharp.Tests
             {
                 Tree tree = repo.Head.Tip.Tree;
 
-                var changes = repo.Diff.Compare<TreeChanges>(tree, DiffTargets.Index,
-                    new[] { "deleted_staged_file.txt", "1/branch_file.txt", "I-do/not-exist" }, new ExplicitPathsOptions { ShouldFailOnUnmatchedPath = false });
-                AssertCanCompareASubsetOfTheTreeAgainstTheIndex(changes);
+                using (var changes = repo.Diff.Compare<TreeChanges>(tree, DiffTargets.Index,
+                    new[] { "deleted_staged_file.txt", "1/branch_file.txt", "I-do/not-exist" }, new ExplicitPathsOptions { ShouldFailOnUnmatchedPath = false }))
+                {
+                    AssertCanCompareASubsetOfTheTreeAgainstTheIndex(changes);
+                }
 
-                changes = repo.Diff.Compare<TreeChanges>(tree, DiffTargets.Index,
-                    new[] { "deleted_staged_file.txt", "1/branch_file.txt", "I-do/not-exist" });
-                AssertCanCompareASubsetOfTheTreeAgainstTheIndex(changes);
+                using (var changes = repo.Diff.Compare<TreeChanges>(tree, DiffTargets.Index,
+                    new[] { "deleted_staged_file.txt", "1/branch_file.txt", "I-do/not-exist" }))
+                {
+                    AssertCanCompareASubsetOfTheTreeAgainstTheIndex(changes);
+                }
             }
         }
 
@@ -384,23 +411,27 @@ namespace LibGit2Sharp.Tests
                 File.AppendAllText(fullpath, "\n");
                 Commands.Stage(repo, "file.txt");
 
-                var changes = repo.Diff.Compare<TreeChanges>(repo.Head.Tip.Tree, DiffTargets.Index);
-                Assert.Equal(1, changes.Modified.Count());
+                using (var changes = repo.Diff.Compare<TreeChanges>(repo.Head.Tip.Tree, DiffTargets.Index))
+                {
+                    Assert.Equal(1, changes.Modified.Count());
+                }
 
-                var patch = repo.Diff.Compare<Patch>(repo.Head.Tip.Tree, DiffTargets.Index);
-                var expected = new StringBuilder()
-                    .Append("diff --git a/file.txt b/file.txt\n")
-                    .Append("index 2e65efe..7898192 100644\n")
-                    .Append("--- a/file.txt\n")
-                    .Append("+++ b/file.txt\n")
-                    .Append("@@ -1 +1 @@\n")
-                    .Append("-a\n")
-                    .Append("\\ No newline at end of file\n")
-                    .Append("+a\n");
+                using (var patch = repo.Diff.Compare<Patch>(repo.Head.Tip.Tree, DiffTargets.Index))
+                {
+                    var expected = new StringBuilder()
+                        .Append("diff --git a/file.txt b/file.txt\n")
+                        .Append("index 2e65efe..7898192 100644\n")
+                        .Append("--- a/file.txt\n")
+                        .Append("+++ b/file.txt\n")
+                        .Append("@@ -1 +1 @@\n")
+                        .Append("-a\n")
+                        .Append("\\ No newline at end of file\n")
+                        .Append("+a\n");
 
-                Assert.Equal(expected.ToString(), patch);
-                Assert.Equal(1, patch.LinesAdded);
-                Assert.Equal(1, patch.LinesDeleted);
+                    Assert.Equal(expected.ToString(), patch);
+                    Assert.Equal(1, patch.LinesAdded);
+                    Assert.Equal(1, patch.LinesDeleted);
+                }
             }
         }
 
@@ -428,13 +459,14 @@ namespace LibGit2Sharp.Tests
             {
                 SetUpSimpleDiffContext(repo);
 
-                var changes = repo.Diff.Compare<TreeChanges>(null,
-                    DiffTargets.Index);
+                using (var changes = repo.Diff.Compare<TreeChanges>(null,
+                    DiffTargets.Index))
+                {
+                    Assert.Equal(1, changes.Count());
+                    Assert.Equal(1, changes.Added.Count());
 
-                Assert.Equal(1, changes.Count());
-                Assert.Equal(1, changes.Added.Count());
-
-                Assert.Equal("file.txt", changes.Added.Single().Path);
+                    Assert.Equal("file.txt", changes.Added.Single().Path);
+                }
             }
         }
 
@@ -447,13 +479,14 @@ namespace LibGit2Sharp.Tests
             {
                 SetUpSimpleDiffContext(repo);
 
-                var changes = repo.Diff.Compare<TreeChanges>(null,
-                    DiffTargets.WorkingDirectory);
+                using (var changes = repo.Diff.Compare<TreeChanges>(null,
+                    DiffTargets.WorkingDirectory))
+                {
+                    Assert.Equal(1, changes.Count());
+                    Assert.Equal(1, changes.Added.Count());
 
-                Assert.Equal(1, changes.Count());
-                Assert.Equal(1, changes.Added.Count());
-
-                Assert.Equal("file.txt", changes.Added.Single().Path);
+                    Assert.Equal("file.txt", changes.Added.Single().Path);
+                }
             }
         }
 
@@ -466,13 +499,14 @@ namespace LibGit2Sharp.Tests
             {
                 SetUpSimpleDiffContext(repo);
 
-                var changes = repo.Diff.Compare<TreeChanges>(null,
-                    DiffTargets.WorkingDirectory | DiffTargets.Index);
+                using (var changes = repo.Diff.Compare<TreeChanges>(null,
+                    DiffTargets.WorkingDirectory | DiffTargets.Index))
+                {
+                    Assert.Equal(1, changes.Count());
+                    Assert.Equal(1, changes.Added.Count());
 
-                Assert.Equal(1, changes.Count());
-                Assert.Equal(1, changes.Added.Count());
-
-                Assert.Equal("file.txt", changes.Added.Single().Path);
+                    Assert.Equal("file.txt", changes.Added.Single().Path);
+                }
             }
         }
     }

--- a/LibGit2Sharp.Tests/DiffTreeToTreeFixture.cs
+++ b/LibGit2Sharp.Tests/DiffTreeToTreeFixture.cs
@@ -72,7 +72,7 @@ namespace LibGit2Sharp.Tests
                     Assert.Equal("1.txt", treeEntryChanges.Path);
                     Assert.Equal(ChangeKind.Added, treeEntryChanges.Status);
 
-                    Assert.Equal(treeEntryChanges, changes.Added.Single());
+                    Assert.Equal(treeEntryChanges.Path, changes.Added.Single().Path);
 
                     Assert.Equal(Mode.Nonexistent, treeEntryChanges.OldMode);
                 }

--- a/LibGit2Sharp.Tests/DiffWorkdirToIndexFixture.cs
+++ b/LibGit2Sharp.Tests/DiffWorkdirToIndexFixture.cs
@@ -33,11 +33,12 @@ namespace LibGit2Sharp.Tests
             var path = SandboxStandardTestRepoGitDir();
             using (var repo = new Repository(path))
             {
-                var changes = repo.Diff.Compare<TreeChanges>();
-
-                Assert.Equal(2, changes.Count());
-                Assert.Equal("deleted_unstaged_file.txt", changes.Deleted.Single().Path);
-                Assert.Equal("modified_unstaged_file.txt", changes.Modified.Single().Path);
+                using (var changes = repo.Diff.Compare<TreeChanges>())
+                {
+                    Assert.Equal(2, changes.Count());
+                    Assert.Equal("deleted_unstaged_file.txt", changes.Deleted.Single().Path);
+                    Assert.Equal("modified_unstaged_file.txt", changes.Modified.Single().Path);
+                }
             }
         }
 
@@ -51,11 +52,15 @@ namespace LibGit2Sharp.Tests
             {
                 Assert.Equal(currentStatus, repo.RetrieveStatus(relativePath));
 
-                var changes = repo.Diff.Compare<TreeChanges>(new[] { relativePath }, false, new ExplicitPathsOptions { ShouldFailOnUnmatchedPath = false });
-                Assert.Equal(0, changes.Count());
+                using (var changes = repo.Diff.Compare<TreeChanges>(new[] { relativePath }, false, new ExplicitPathsOptions { ShouldFailOnUnmatchedPath = false }))
+                {
+                    Assert.Equal(0, changes.Count());
+                }
 
-                changes = repo.Diff.Compare<TreeChanges>(new[] { relativePath });
-                Assert.Equal(0, changes.Count());
+                using (var changes = repo.Diff.Compare<TreeChanges>(new[] { relativePath }))
+                {
+                    Assert.Equal(0, changes.Count());
+                }
             }
         }
 
@@ -85,12 +90,14 @@ namespace LibGit2Sharp.Tests
             {
                 Assert.Equal(currentStatus, repo.RetrieveStatus(relativePath));
 
-                repo.Diff.Compare<TreeChanges>(new[] { relativePath }, false, new ExplicitPathsOptions
+                using (var changes = repo.Diff.Compare<TreeChanges>(new[] { relativePath }, false, new ExplicitPathsOptions
                 {
                     ShouldFailOnUnmatchedPath = false,
-                    OnUnmatchedPath = callback.OnUnmatchedPath });
-
-                Assert.True(callback.WasCalled);
+                    OnUnmatchedPath = callback.OnUnmatchedPath
+                }))
+                {
+                    Assert.True(callback.WasCalled);
+                }
             }
         }
 
@@ -130,21 +137,23 @@ namespace LibGit2Sharp.Tests
             using (var repo = new Repository(path))
             {
                 SetFilemode(repo, true);
-                var changes = repo.Diff.Compare<TreeChanges>(new[] { file });
+                using(var changes = repo.Diff.Compare<TreeChanges>(new[] { file }))
+                {
+                    Assert.Equal(1, changes.Count());
 
-                Assert.Equal(1, changes.Count());
-
-                var change = changes.Modified.Single();
-                Assert.Equal(Mode.ExecutableFile, change.OldMode);
-                Assert.Equal(Mode.NonExecutableFile, change.Mode);
+                    var change = changes.Modified.Single();
+                    Assert.Equal(Mode.ExecutableFile, change.OldMode);
+                    Assert.Equal(Mode.NonExecutableFile, change.Mode);
+                }
             }
 
             using (var repo = new Repository(path))
             {
                 SetFilemode(repo, false);
-                var changes = repo.Diff.Compare<TreeChanges>(new[] { file });
-
-                Assert.Equal(0, changes.Count());
+                using(var changes = repo.Diff.Compare<TreeChanges>(new[] { file }))
+                {
+                    Assert.Equal(0, changes.Count());
+                }
             }
         }
 
@@ -159,12 +168,13 @@ namespace LibGit2Sharp.Tests
             var path = SandboxStandardTestRepoGitDir();
             using (var repo = new Repository(path))
             {
-                var changes = repo.Diff.Compare<TreeChanges>(null, true);
-
-                Assert.Equal(3, changes.Count());
-                Assert.Equal("deleted_unstaged_file.txt", changes.Deleted.Single().Path);
-                Assert.Equal("modified_unstaged_file.txt", changes.Modified.Single().Path);
-                Assert.Equal("new_untracked_file.txt", changes.Added.Single().Path);
+                using (var changes = repo.Diff.Compare<TreeChanges>(null, true))
+                {
+                    Assert.Equal(3, changes.Count());
+                    Assert.Equal("deleted_unstaged_file.txt", changes.Deleted.Single().Path);
+                    Assert.Equal("modified_unstaged_file.txt", changes.Modified.Single().Path);
+                    Assert.Equal("new_untracked_file.txt", changes.Added.Single().Path);
+                }
             }
         }
     }

--- a/LibGit2Sharp.Tests/PatchStatsFixture.cs
+++ b/LibGit2Sharp.Tests/PatchStatsFixture.cs
@@ -13,14 +13,15 @@ namespace LibGit2Sharp.Tests
             {
                 var oldTree = repo.Lookup<Commit>("origin/packed-test").Tree;
                 var newTree = repo.Lookup<Commit>("HEAD").Tree;
-                var stats = repo.Diff.Compare<PatchStats>(oldTree, newTree);
+                using (var stats = repo.Diff.Compare<PatchStats>(oldTree, newTree))
+                {
+                    Assert.Equal(8, stats.TotalLinesAdded);
+                    Assert.Equal(1, stats.TotalLinesDeleted);
 
-                Assert.Equal(8, stats.TotalLinesAdded);
-                Assert.Equal(1, stats.TotalLinesDeleted);
-
-                var contentStats = stats["new.txt"];
-                Assert.Equal(1, contentStats.LinesAdded);
-                Assert.Equal(1, contentStats.LinesDeleted);
+                    var contentStats = stats["new.txt"];
+                    Assert.Equal(1, contentStats.LinesAdded);
+                    Assert.Equal(1, contentStats.LinesDeleted);
+                }
             }
         }
     }

--- a/LibGit2Sharp/Core/FileHistory.cs
+++ b/LibGit2Sharp/Core/FileHistory.cs
@@ -163,11 +163,13 @@ namespace LibGit2Sharp.Core
 
         private static string ParentPath(IRepository repo, Commit currentCommit, string currentPath, Commit parentCommit)
         {
-            var treeChanges = repo.Diff.Compare<TreeChanges>(parentCommit.Tree, currentCommit.Tree);
-            var treeEntryChanges = treeChanges.FirstOrDefault(c => c.Path == currentPath);
-            return treeEntryChanges != null && treeEntryChanges.Status == ChangeKind.Renamed
-                ? treeEntryChanges.OldPath
-                : currentPath;
+            using (var treeChanges = repo.Diff.Compare<TreeChanges>(parentCommit.Tree, currentCommit.Tree))
+            {
+                var treeEntryChanges = treeChanges.FirstOrDefault(c => c.Path == currentPath);
+                return treeEntryChanges != null && treeEntryChanges.Status == ChangeKind.Renamed
+                    ? treeEntryChanges.OldPath
+                    : currentPath;
+            }
         }
     }
 }

--- a/LibGit2Sharp/Core/Handles/Libgit2Object.cs
+++ b/LibGit2Sharp/Core/Handles/Libgit2Object.cs
@@ -5,7 +5,7 @@
 //
 // Uncomment the line below or add a conditional symbol to activate this mode
 
-// #define LEAKS_IDENTIFYING
+#define LEAKS_IDENTIFYING
 
 // This activates a more throrough mode which will show the stack trace of the
 // allocation code path for each handle that has been improperly released.
@@ -15,7 +15,7 @@
 //
 // Uncomment the line below or add a conditional symbol to activate this mode
 
-// #define LEAKS_TRACKING
+#define LEAKS_TRACKING
 
 using System;
 using System.Linq;

--- a/LibGit2Sharp/Diff.cs
+++ b/LibGit2Sharp/Diff.cs
@@ -241,9 +241,16 @@ namespace LibGit2Sharp
                 }
             }
 
-            using (DiffHandle diff = BuildDiffList(oldTreeId, newTreeId, comparer, diffOptions, paths, explicitPathsOptions, compareOptions))
+            DiffHandle diff = BuildDiffList(oldTreeId, newTreeId, comparer, diffOptions, paths, explicitPathsOptions, compareOptions);
+
+            try
             {
                 return BuildDiffResult<T>(diff);
+            }
+            catch
+            {
+                diff.SafeDispose();
+                throw;
             }
         }
 
@@ -343,9 +350,16 @@ namespace LibGit2Sharp
                 }
             }
 
-            using (DiffHandle diff = BuildDiffList(oldTreeId, null, comparer, diffOptions, paths, explicitPathsOptions, compareOptions))
+            DiffHandle diff = BuildDiffList(oldTreeId, null, comparer, diffOptions, paths, explicitPathsOptions, compareOptions);
+            
+            try
             {
                 return BuildDiffResult<T>(diff);
+            }
+            catch
+            {
+                diff.SafeDispose();
+                throw;
             }
         }
 
@@ -462,9 +476,16 @@ namespace LibGit2Sharp
                 }
             }
 
-            using (DiffHandle diff = BuildDiffList(null, null, comparer, diffOptions, paths, explicitPathsOptions, compareOptions))
+            DiffHandle diff = BuildDiffList(null, null, comparer, diffOptions, paths, explicitPathsOptions, compareOptions);
+
+            try
             {
                 return BuildDiffResult<T>(diff);
+            }
+            catch
+            {
+                diff.SafeDispose();
+                throw;
             }
         }
 

--- a/LibGit2Sharp/IDiffResult.cs
+++ b/LibGit2Sharp/IDiffResult.cs
@@ -1,8 +1,10 @@
-﻿namespace LibGit2Sharp
+﻿using System;
+
+namespace LibGit2Sharp
 {
     /// <summary>
     ///   Marker interface to identify Diff results.
     /// </summary>
-    public interface IDiffResult
+    public interface IDiffResult: IDisposable
     { }
 }

--- a/LibGit2Sharp/Index.cs
+++ b/LibGit2Sharp/Index.cs
@@ -292,8 +292,10 @@ namespace LibGit2Sharp
         {
             Ensure.ArgumentNotNull(commit, "commit");
 
-            var changes = repo.Diff.Compare<TreeChanges>(commit.Tree, DiffTargets.Index, paths, explicitPathsOptions, new CompareOptions { Similarity = SimilarityOptions.None });
-            Replace(changes);
+            using (var changes = repo.Diff.Compare<TreeChanges>(commit.Tree, DiffTargets.Index, paths, explicitPathsOptions, new CompareOptions { Similarity = SimilarityOptions.None }))
+            {
+                Replace(changes);
+            }
         }
 
         /// <summary>

--- a/LibGit2Sharp/Patch.cs
+++ b/LibGit2Sharp/Patch.cs
@@ -32,14 +32,17 @@ namespace LibGit2Sharp
 
         internal unsafe Patch(DiffHandle diff)
         {
-            int count = Proxy.git_diff_num_deltas(diff);
-            for (int i = 0; i < count; i++)
+            using (diff)
             {
-                using (var patch = Proxy.git_patch_from_diff(diff, i))
+                int count = Proxy.git_diff_num_deltas(diff);
+                for (int i = 0; i < count; i++)
                 {
-                    var delta = Proxy.git_diff_get_delta(diff, i);
-                    AddFileChange(delta);
-                    Proxy.git_patch_print(patch, PrintCallBack);
+                    using (var patch = Proxy.git_patch_from_diff(diff, i))
+                    {
+                        var delta = Proxy.git_diff_get_delta(diff, i);
+                        AddFileChange(delta);
+                        Proxy.git_patch_print(patch, PrintCallBack);
+                    }
                 }
             }
         }
@@ -179,6 +182,25 @@ namespace LibGit2Sharp
                                      linesAdded,
                                      linesDeleted);
             }
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Releases unmanaged and - optionally - managed resources.
+        /// </summary>
+        /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            // This doesn't do anything yet because it loads everything
+            // eagerly and disposes of the diff handle in the constructor.
         }
     }
 }

--- a/LibGit2Sharp/PatchStats.cs
+++ b/LibGit2Sharp/PatchStats.cs
@@ -27,23 +27,25 @@ namespace LibGit2Sharp
 
         internal unsafe PatchStats(DiffHandle diff)
         {
-            int count = Proxy.git_diff_num_deltas(diff);
-            for (int i = 0; i < count; i++)
+            using (diff)
             {
-                using (var patch = Proxy.git_patch_from_diff(diff, i))
+                int count = Proxy.git_diff_num_deltas(diff);
+                for (int i = 0; i < count; i++)
                 {
-                    var delta = Proxy.git_diff_get_delta(diff, i);
-                    var pathPtr = delta->new_file.Path != null ? delta->new_file.Path : delta->old_file.Path;
-                    var newFilePath = LaxFilePathMarshaler.FromNative(pathPtr);
+                    using (var patch = Proxy.git_patch_from_diff(diff, i))
+                    {
+                        var delta = Proxy.git_diff_get_delta(diff, i);
+                        var pathPtr = delta->new_file.Path != null ? delta->new_file.Path : delta->old_file.Path;
+                        var newFilePath = LaxFilePathMarshaler.FromNative(pathPtr);
 
-                    var stats = Proxy.git_patch_line_stats(patch);
-                    int added = stats.Item1;
-                    int deleted = stats.Item2;
-                    changes.Add(newFilePath, new ContentChangeStats(added, deleted));
-                    totalLinesAdded += added;
-                    totalLinesDeleted += deleted;
+                        var stats = Proxy.git_patch_line_stats(patch);
+                        int added = stats.Item1;
+                        int deleted = stats.Item2;
+                        changes.Add(newFilePath, new ContentChangeStats(added, deleted));
+                        totalLinesAdded += added;
+                        totalLinesDeleted += deleted;
+                    }
                 }
-
             }
         }
 
@@ -116,6 +118,25 @@ namespace LibGit2Sharp
                                      TotalLinesAdded,
                                      TotalLinesDeleted);
             }
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Releases unmanaged and - optionally - managed resources.
+        /// </summary>
+        /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            // This doesn't do anything yet because it loads everything
+            // eagerly and disposes of the diff handle in the constructor.
         }
     }
 }

--- a/LibGit2Sharp/TreeChanges.cs
+++ b/LibGit2Sharp/TreeChanges.cs
@@ -39,8 +39,7 @@ namespace LibGit2Sharp
         private IEnumerable<TreeEntryChanges> GetChangesOfKind(ChangeKind changeKind)
         {
             TreeEntryChanges entry;
-
-            for (int i = 0; i < count.Value; i++)
+            for (int i = 0; i < Count; i++)
             {
                 if (TryGetEntryWithChangeTypeAt(i, changeKind, out entry))
                 {
@@ -78,7 +77,7 @@ namespace LibGit2Sharp
         /// <returns>An <see cref="IEnumerator{T}"/> object that can be used to iterate through the collection.</returns>
         public virtual IEnumerator<TreeEntryChanges> GetEnumerator()
         {
-            for (int i = 0; i < count.Value; i++)
+            for (int i = 0; i < Count; i++)
             {
                 yield return GetEntryAt(i);
             }
@@ -169,6 +168,14 @@ namespace LibGit2Sharp
         public virtual IEnumerable<TreeEntryChanges> Conflicted
         {
             get { return GetChangesOfKind(ChangeKind.Conflicted); }
+        }
+
+        /// <summary>
+        /// Gets the number of <see cref="TreeEntryChanges"/> in this comparison.
+        /// </summary>
+        public virtual int Count
+        {
+            get { return count.Value; }
         }
 
         private string DebuggerDisplay

--- a/LibGit2Sharp/TreeChanges.cs
+++ b/LibGit2Sharp/TreeChanges.cs
@@ -52,7 +52,8 @@ namespace LibGit2Sharp
 
         internal unsafe TreeChanges(DiffHandle diff)
         {
-            Proxy.git_diff_foreach(diff, FileCallback, null, null);
+            using(diff)
+                Proxy.git_diff_foreach(diff, FileCallback, null, null);
         }
 
         private unsafe int FileCallback(git_diff_delta* delta, float progress, IntPtr payload)
@@ -168,6 +169,25 @@ namespace LibGit2Sharp
                                      Renamed.Count(),
                                      Copied.Count());
             }
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Releases unmanaged and - optionally - managed resources.
+        /// </summary>
+        /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            // This doesn't do anything yet because it loads everything
+            // eagerly and disposes of the diff handle in the constructor.
         }
     }
 }

--- a/LibGit2Sharp/TreeEntryChanges.cs
+++ b/LibGit2Sharp/TreeEntryChanges.cs
@@ -28,9 +28,23 @@ namespace LibGit2Sharp
             Exists = (delta->new_file.Flags & GitDiffFlags.GIT_DIFF_FLAG_EXISTS) != 0;
             OldExists = (delta->old_file.Flags & GitDiffFlags.GIT_DIFF_FLAG_EXISTS) != 0;
 
-            Status = (delta->status == ChangeKind.Untracked || delta->status == ChangeKind.Ignored)
-                ? ChangeKind.Added
-                : delta->status;
+            Status = GetStatusFromChangeKind(delta->status);
+        }
+
+        // This treatment of change kind was apparently introduced in order to be able
+        // to compare a tree against the index, see commit fdc972b. It's extracted
+        // here so that TreeEntry can use the same rules without having to instantiate
+        // a TreeEntryChanges object.
+        internal static ChangeKind GetStatusFromChangeKind(ChangeKind changeKind)
+        {
+            switch (changeKind)
+            {
+                case ChangeKind.Untracked:
+                case ChangeKind.Ignored:
+                    return ChangeKind.Added;
+                default:
+                    return changeKind;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This will let us perform lazy loading of diff details in `Patch`, `PatchStats` and `TreeChanges` just as we do with commits and some other classes.

In this initial PR I've only worked with `TreeChanges` which was where our performance concerns were. We need the fastest possible way to get the number of changed files between two trees.

In order for this to be possible I had to move ownership of the diff handle to the individual diff result classes. To keep this PR as small as possible I've kept the behavior of `Patch` and `PatchStats` such that while they're now disposable they eagerly load everything and dispose of the handle in their respective constructors.

cc @ethomson @carlosmn 