### PR TITLE
Don't provide a diff notify callback unless necessary

### DIFF
--- a/LibGit2Sharp/Diff.cs
+++ b/LibGit2Sharp/Diff.cs
@@ -516,14 +516,25 @@ namespace LibGit2Sharp
             ExplicitPathsOptions explicitPathsOptions,
             CompareOptions compareOptions)
         {
-            var matchedPaths = new MatchedPathsAggregator();
             var filePaths = repo.ToFilePaths(paths);
+
+            MatchedPathsAggregator matchedPaths = null;
+
+            // We can't match paths unless we've got something to match 
+            // against and we're told to do so.
+            if (filePaths != null && explicitPathsOptions != null)
+            {
+                if (explicitPathsOptions.OnUnmatchedPath != null || explicitPathsOptions.ShouldFailOnUnmatchedPath)
+                {
+                    matchedPaths = new MatchedPathsAggregator();
+                }
+            }
 
             using (GitDiffOptions options = BuildOptions(diffOptions, filePaths, matchedPaths, compareOptions))
             {
                 var diffList = comparisonHandleRetriever(oldTreeId, newTreeId, options);
 
-                if (explicitPathsOptions != null)
+                if (matchedPaths != null)
                 {
                     try
                     {


### PR DESCRIPTION
We only seem to care about what ends up being collected in the `MatchedPathsAggregator` when we've got some file paths to match agains and either an `OnUnmatchedPath` delegate or instructions to throw
on unmatched paths.

If none of those condition are true we shouldn't be sending a callback function pointer at all and by not doing so we avoid one marshalled invocation per delta in the diff.