### PR TITLE
Eagerly dispose of Remotes

### DIFF
--- a/LibGit2Sharp/BranchUpdater.cs
+++ b/LibGit2Sharp/BranchUpdater.cs
@@ -154,7 +154,7 @@ namespace LibGit2Sharp
                 if (!remoteName.Equals(".", StringComparison.Ordinal))
                 {
                     // Verify that remote exists.
-                    repo.Network.Remotes.RemoteForName(remoteName);
+                    using (repo.Network.Remotes.RemoteForName(remoteName)) { }
                 }
 
                 repo.Config.Set(configKey, remoteName);
@@ -183,8 +183,10 @@ namespace LibGit2Sharp
             {
                 remoteName = Proxy.git_branch_remote_name(repo.Handle, canonicalName, true);
 
-                Remote remote = repo.Network.Remotes.RemoteForName(remoteName);
-                mergeBranchName = remote.FetchSpecTransformToSource(canonicalName);
+                using (var remote = repo.Network.Remotes.RemoteForName(remoteName))
+                {
+                    mergeBranchName = remote.FetchSpecTransformToSource(canonicalName);
+                }
             }
             else
             {


### PR DESCRIPTION
This is a continuation of #1249. Since Remotes are now disposable we should eagerly clean up their resources rather than wait for GC to call
the destructor.

cc @ethomson @carlosmn 