### PR TITLE
Take a name instead of an instance to update a remote

### DIFF
--- a/LibGit2Sharp.Tests/BranchFixture.cs
+++ b/LibGit2Sharp.Tests/BranchFixture.cs
@@ -457,7 +457,7 @@ namespace LibGit2Sharp.Tests
                 Remote remote = repo.Network.Remotes["origin"];
                 Assert.NotNull(remote);
 
-                repo.Network.Remotes.Update(remote, r => r.FetchRefSpecs = fetchRefSpecs);
+                repo.Network.Remotes.Update("origin", r => r.FetchRefSpecs = fetchRefSpecs);
 
                 Branch branch = repo.Branches["refs/remotes/origin/master"];
 
@@ -750,7 +750,7 @@ namespace LibGit2Sharp.Tests
                 // cannot be resolved.
                 Remote remote = repo.Network.Remotes["origin"];
                 Assert.NotNull(remote);
-                repo.Network.Remotes.Update(remote, r => r.FetchRefSpecs = fetchRefSpecs);
+                repo.Network.Remotes.Update("origin", r => r.FetchRefSpecs = fetchRefSpecs);
 
                 // Now attempt to update the tracked branch
                 Branch branch = repo.CreateBranch(testBranchName);

--- a/LibGit2Sharp.Tests/FetchFixture.cs
+++ b/LibGit2Sharp.Tests/FetchFixture.cs
@@ -177,7 +177,7 @@ namespace LibGit2Sharp.Tests
                 Assert.NotNull(remote);
 
                 // Update the configured autotag setting.
-                repo.Network.Remotes.Update(remote,
+                repo.Network.Remotes.Update(remoteName,
                     r => r.TagFetchMode = tagFetchMode);
 
                 // Perform the actual fetch.

--- a/LibGit2Sharp.Tests/RemoteFixture.cs
+++ b/LibGit2Sharp.Tests/RemoteFixture.cs
@@ -66,10 +66,13 @@ namespace LibGit2Sharp.Tests
                 Remote remote = repo.Network.Remotes[name];
                 Assert.NotNull(remote);
 
-                Remote updatedremote = repo.Network.Remotes.Update(remote,
+                repo.Network.Remotes.Update(name,
                     r => r.TagFetchMode = tagFetchMode);
 
-                Assert.Equal(tagFetchMode, updatedremote.TagFetchMode);
+                using (var updatedremote = repo.Network.Remotes[name])
+                {
+                    Assert.Equal(tagFetchMode, updatedremote.TagFetchMode);
+                }
             }
         }
 
@@ -87,12 +90,14 @@ namespace LibGit2Sharp.Tests
                 Remote remote = repo.Network.Remotes[name];
                 Assert.NotNull(remote);
 
-                Remote updatedremote = repo.Network.Remotes.Update(remote,
-                    r => r.Url = newUrl);
+                repo.Network.Remotes.Update(name, r => r.Url = newUrl);
 
-                Assert.Equal(newUrl, updatedremote.Url);
-                // with no push url set, PushUrl defaults to the fetch url
-                Assert.Equal(newUrl, updatedremote.PushUrl);
+                using (var updatedremote = repo.Network.Remotes[name])
+                {
+                    Assert.Equal(newUrl, updatedremote.Url);
+                    // with no push url set, PushUrl defaults to the fetch url
+                    Assert.Equal(newUrl, updatedremote.PushUrl);
+                }
             }
         }
 
@@ -114,12 +119,14 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(url, remote.Url);
                 Assert.Equal(url, remote.PushUrl);
 
-                Remote updatedremote = repo.Network.Remotes.Update(remote,
-                    r => r.PushUrl = pushurl);
+                repo.Network.Remotes.Update(name, r => r.PushUrl = pushurl);
 
-                // url should not change, push url should be set to new value
-                Assert.Equal(url, updatedremote.Url);
-                Assert.Equal(pushurl, updatedremote.PushUrl);
+                using (var updatedremote = repo.Network.Remotes[name])
+                {
+                    // url should not change, push url should be set to new value
+                    Assert.Equal(url, updatedremote.Url);
+                    Assert.Equal(pushurl, updatedremote.PushUrl);
+                }
             }
         }
 
@@ -292,8 +299,7 @@ namespace LibGit2Sharp.Tests
             {
                 Assert.NotNull(repo.Network.Remotes["origin"]);
 
-                repo.Network.Remotes.Update(
-                    repo.Network.Remotes["origin"],
+                repo.Network.Remotes.Update("origin",
                     r => r.FetchRefSpecs = new[] { "+refs/heads/*:refs/remotes/upstream/*" });
 
                 repo.Network.Remotes.Rename("origin", "nondefault", problem => Assert.Equal("+refs/heads/*:refs/remotes/upstream/*", problem));

--- a/LibGit2Sharp/Configuration.cs
+++ b/LibGit2Sharp/Configuration.cs
@@ -759,5 +759,29 @@ namespace LibGit2Sharp
         {
             return Proxy.git_config_snapshot(configHandle);
         }
+
+        /// <summary>
+        /// Perform a series of actions within a transaction.
+        ///
+        /// The configuration will be locked during this function and the changes will be committed at the end. These
+        /// changes will not be visible in the configuration until the end of this method.
+        ///
+        /// If the action throws an exception, the changes will be rolled back.
+        /// </summary>
+        /// <param name="action">The code to run under the transaction</param>
+        public virtual unsafe void WithinTransaction(Action action)
+        {
+            IntPtr txn = IntPtr.Zero;
+            try
+            {
+                txn = Proxy.git_config_lock(configHandle);
+                action();
+                Proxy.git_transaction_commit(txn);
+            }
+            finally
+            {
+                Proxy.git_transaction_free(txn);
+            }
+        }
     }
 }

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -343,6 +343,9 @@ namespace LibGit2Sharp.Core
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name);
 
         [DllImport(libgit2)]
+        internal static extern unsafe int git_config_lock(out IntPtr txn, git_config* config);
+
+        [DllImport(libgit2)]
         internal static extern unsafe int git_config_delete_multivar(
             git_config* cfg,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name,
@@ -1825,6 +1828,12 @@ namespace LibGit2Sharp.Core
 
         [DllImport(libgit2)]
         internal static extern unsafe int git_cherrypick(git_repository* repo, git_object* commit, GitCherryPickOptions options);
+
+        [DllImport(libgit2)]
+        internal static extern int git_transaction_commit(IntPtr txn);
+
+        [DllImport(libgit2)]
+        internal static extern void git_transaction_free(IntPtr txn);
     }
 }
 // ReSharper restore InconsistentNaming

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -635,6 +635,15 @@ namespace LibGit2Sharp.Core
             return new ConfigurationHandle(handle, true);
         }
 
+        public static unsafe IntPtr git_config_lock(git_config* config)
+        {
+            IntPtr txn;
+            int res = NativeMethods.git_config_lock(out txn, config);
+            Ensure.ZeroResult(res);
+
+            return txn;
+        }
+
         #endregion
 
         #region git_cred_
@@ -3193,6 +3202,20 @@ namespace LibGit2Sharp.Core
             Ensure.ZeroResult(res);
 
             return oid;
+        }
+
+        #endregion
+
+        #region git_transaction_
+
+        public static void git_transaction_commit(IntPtr txn)
+        {
+            NativeMethods.git_transaction_commit(txn);
+        }
+
+        public static void git_transaction_free(IntPtr txn)
+        {
+            NativeMethods.git_transaction_free(txn);
         }
 
         #endregion

--- a/LibGit2Sharp/RemoteCollection.cs
+++ b/LibGit2Sharp/RemoteCollection.cs
@@ -53,6 +53,7 @@ namespace LibGit2Sharp
         /// <param name="remote">The remote to update.</param>
         /// <param name="actions">Delegate to perform updates on the remote.</param>
         /// <returns>The updated remote.</returns>
+        [Obsolete("This method is deprecated. Use the overload with a remote name")]
         public virtual Remote Update(Remote remote, params Action<RemoteUpdater>[] actions)
         {
             var updater = new RemoteUpdater(repository, remote);
@@ -63,6 +64,25 @@ namespace LibGit2Sharp
             }
 
             return this[remote.Name];
+        }
+
+        /// <summary>
+        /// Update properties of a remote.
+        ///
+        /// These updates will be performed as a bulk update at the end of the method.
+        /// </summary>
+        /// <param name="remote">The name of the remote to update.</param>
+        /// <param name="actions">Delegate to perform updates on the remote.</param>
+        public virtual void Update(string remote, params Action<RemoteUpdater>[] actions)
+        {
+            var updater = new RemoteUpdater(repository, remote);
+
+            repository.Config.WithinTransaction(() => {
+                foreach (Action<RemoteUpdater> action in actions)
+                {
+                    action(updater);
+                }
+            });
         }
 
         /// <summary>

--- a/LibGit2Sharp/RemoteUpdater.cs
+++ b/LibGit2Sharp/RemoteUpdater.cs
@@ -14,7 +14,7 @@ namespace LibGit2Sharp
         private readonly UpdatingCollection<string> fetchRefSpecs;
         private readonly UpdatingCollection<string> pushRefSpecs;
         private readonly Repository repo;
-        private readonly Remote remote;
+        private readonly string remoteName;
 
         /// <summary>
         /// Needed for mocking purposes.
@@ -28,7 +28,19 @@ namespace LibGit2Sharp
             Ensure.ArgumentNotNull(remote, "remote");
 
             this.repo = repo;
-            this.remote = remote;
+            this.remoteName = remote.Name;
+
+            fetchRefSpecs = new UpdatingCollection<string>(GetFetchRefSpecs, SetFetchRefSpecs);
+            pushRefSpecs = new UpdatingCollection<string>(GetPushRefSpecs, SetPushRefSpecs);
+        }
+
+        internal RemoteUpdater(Repository repo, string remote)
+        {
+            Ensure.ArgumentNotNull(repo, "repo");
+            Ensure.ArgumentNotNull(remote, "remote");
+
+            this.repo = repo;
+            this.remoteName = remote;
 
             fetchRefSpecs = new UpdatingCollection<string>(GetFetchRefSpecs, SetFetchRefSpecs);
             pushRefSpecs = new UpdatingCollection<string>(GetPushRefSpecs, SetPushRefSpecs);
@@ -36,7 +48,7 @@ namespace LibGit2Sharp
 
         private IEnumerable<string> GetFetchRefSpecs()
         {
-            using (RemoteHandle remoteHandle = Proxy.git_remote_lookup(repo.Handle, remote.Name, true))
+            using (RemoteHandle remoteHandle = Proxy.git_remote_lookup(repo.Handle, remoteName, true))
             {
                 return Proxy.git_remote_get_fetch_refspecs(remoteHandle);
             }
@@ -44,17 +56,17 @@ namespace LibGit2Sharp
 
         private void SetFetchRefSpecs(IEnumerable<string> value)
         {
-            repo.Config.UnsetMultivar(string.Format("remote.{0}.fetch", remote.Name), ConfigurationLevel.Local);
+            repo.Config.UnsetMultivar(string.Format("remote.{0}.fetch", remoteName), ConfigurationLevel.Local);
 
             foreach (var url in value)
             {
-                Proxy.git_remote_add_fetch(repo.Handle, remote.Name, url);
+                Proxy.git_remote_add_fetch(repo.Handle, remoteName, url);
             }
         }
 
         private IEnumerable<string> GetPushRefSpecs()
         {
-            using (RemoteHandle remoteHandle = Proxy.git_remote_lookup(repo.Handle, remote.Name, true))
+            using (RemoteHandle remoteHandle = Proxy.git_remote_lookup(repo.Handle, remoteName, true))
             {
                 return Proxy.git_remote_get_push_refspecs(remoteHandle);
             }
@@ -62,11 +74,11 @@ namespace LibGit2Sharp
 
         private void SetPushRefSpecs(IEnumerable<string> value)
         {
-            repo.Config.UnsetMultivar(string.Format("remote.{0}.push", remote.Name), ConfigurationLevel.Local);
+            repo.Config.UnsetMultivar(string.Format("remote.{0}.push", remoteName), ConfigurationLevel.Local);
 
             foreach (var url in value)
             {
-                Proxy.git_remote_add_push(repo.Handle, remote.Name, url);
+                Proxy.git_remote_add_push(repo.Handle, remoteName, url);
             }
         }
 
@@ -75,7 +87,7 @@ namespace LibGit2Sharp
         /// </summary>
         public virtual TagFetchMode TagFetchMode
         {
-            set { Proxy.git_remote_set_autotag(repo.Handle, remote.Name, value); }
+            set { Proxy.git_remote_set_autotag(repo.Handle, remoteName, value); }
         }
 
         /// <summary>
@@ -83,7 +95,7 @@ namespace LibGit2Sharp
         /// </summary>
         public virtual string Url
         {
-            set { Proxy.git_remote_set_url(repo.Handle, remote.Name, value); }
+            set { Proxy.git_remote_set_url(repo.Handle, remoteName, value); }
         }
 
         /// <summary>
@@ -91,7 +103,7 @@ namespace LibGit2Sharp
         /// </summary>
         public virtual string PushUrl
         {
-            set { Proxy.git_remote_set_pushurl(repo.Handle, remote.Name, value); }
+            set { Proxy.git_remote_set_pushurl(repo.Handle, remoteName, value); }
         }
 
         /// <summary>


### PR DESCRIPTION
All the Remote instance does in RemoteUpdater is carry the name, as we
need it in order to perform the update. Reflect this in the class fields
as well as in the preferred way of calling it.

While we're dealing with the updater, make it perform its actions inside
a configuration transaction so the configuration does not change while
we're processing updates.