### PR TITLE
Remove equality comparison from Remote

### DIFF
--- a/LibGit2Sharp.Tests/RemoteFixture.cs
+++ b/LibGit2Sharp.Tests/RemoteFixture.cs
@@ -124,28 +124,6 @@ namespace LibGit2Sharp.Tests
         }
 
         [Fact]
-        public void CanCheckEqualityOfRemote()
-        {
-            string path = SandboxStandardTestRepo();
-            using (var repo = new Repository(path))
-            {
-                Remote oneOrigin = repo.Network.Remotes["origin"];
-                Assert.NotNull(oneOrigin);
-
-                Remote otherOrigin = repo.Network.Remotes["origin"];
-                Assert.Equal(oneOrigin, otherOrigin);
-
-                Remote createdRemote = repo.Network.Remotes.Add("origin2", oneOrigin.Url);
-
-                Remote loadedRemote = repo.Network.Remotes["origin2"];
-                Assert.NotNull(loadedRemote);
-                Assert.Equal(createdRemote, loadedRemote);
-
-                Assert.NotEqual(oneOrigin, loadedRemote);
-            }
-        }
-
-        [Fact]
         public void CreatingANewRemoteAddsADefaultRefSpec()
         {
             string path = SandboxStandardTestRepo();

--- a/LibGit2Sharp/Remote.cs
+++ b/LibGit2Sharp/Remote.cs
@@ -12,11 +12,8 @@ namespace LibGit2Sharp
     /// A remote repository whose branches are tracked.
     /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
-    public class Remote : IEquatable<Remote>, IBelongToARepository, IDisposable
+    public class Remote : IBelongToARepository, IDisposable
     {
-        private static readonly LambdaEqualityHelper<Remote> equalityHelper =
-            new LambdaEqualityHelper<Remote>(x => x.Name, x => x.Url, x => x.PushUrl);
-
         internal readonly Repository repository;
 
         private readonly RefSpecCollection refSpecs;
@@ -180,25 +177,6 @@ namespace LibGit2Sharp
         public override bool Equals(object obj)
         {
             return Equals(obj as Remote);
-        }
-
-        /// <summary>
-        /// Determines whether the specified <see cref="Remote"/> is equal to the current <see cref="Remote"/>.
-        /// </summary>
-        /// <param name="other">The <see cref="Remote"/> to compare with the current <see cref="Remote"/>.</param>
-        /// <returns>True if the specified <see cref="Remote"/> is equal to the current <see cref="Remote"/>; otherwise, false.</returns>
-        public bool Equals(Remote other)
-        {
-            return equalityHelper.Equals(this, other);
-        }
-
-        /// <summary>
-        /// Returns the hash code for this instance.
-        /// </summary>
-        /// <returns>A 32-bit signed integer hash code.</returns>
-        public override int GetHashCode()
-        {
-            return equalityHelper.GetHashCode(this);
         }
 
         /// <summary>


### PR DESCRIPTION
There are no semantics for determining whether a remote is like another
one. The equality decision in libgit2sharp only looks at the name and
urls, ignoring any other number of fields which affect how a remote
behaves.

For these reaons, rip it out. Equality (in as much as it's valuable)
should be perform on whatever aspect the code is interested.

---

If there's a way to deprecate the implementation of an interface I'm all ears, but it looks like we might want to simply get rid of it.