### PR TITLE
Add a RemoteName property to avoid lookups

### DIFF
--- a/LibGit2Sharp/Branch.cs
+++ b/LibGit2Sharp/Branch.cs
@@ -182,6 +182,7 @@ namespace LibGit2Sharp
         ///   the tracked branch.
         /// </para>
         /// </summary>
+        [Obsolete("This property is deprecated. Use Repository.Network.Remotes[] using the RemoteName property")]
         public virtual Remote Remote
         {
             get

--- a/LibGit2Sharp/Branch.cs
+++ b/LibGit2Sharp/Branch.cs
@@ -154,6 +154,26 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
+        /// Get the name of the remote for the branch.
+        /// <para>
+        ///   If this is a local branch, this will return the configured
+        ///   <see cref="Remote"/> to fetch from and push to. If this is a
+        ///   remote-tracking branch, this will return the name of the remote 
+        ///   containing the tracked branch. If there no tracking information 
+        ///   this will return null.
+        /// </para>
+        /// </summary>
+        public virtual string RemoteName
+        {
+            get
+            {
+                return IsRemote
+                    ? RemoteNameFromRemoteTrackingBranch()
+                    : RemoteNameFromLocalBranch();
+            }
+        }
+
+        /// <summary>
         /// Get the remote for the branch.
         /// <para>
         ///   If this is a local branch, this will return the configured
@@ -166,16 +186,7 @@ namespace LibGit2Sharp
         {
             get
             {
-                string remoteName;
-
-                if (IsRemote)
-                {
-                    remoteName = RemoteNameFromRemoteTrackingBranch();
-                }
-                else
-                {
-                    remoteName = RemoteNameFromLocalBranch();
-                }
+                string remoteName = RemoteName;
 
                 if (remoteName == null)
                 {


### PR DESCRIPTION
Sometimes all you need is the name and right now there's no way of getting it short of `git_remote_lookup`. While going through a lookup guarantees that the remote exists that shouldn't be the concern of the `Branch`, it should just let the caller know what's been configured as it's remote.

cc @carlosmn We could/should ditch the `Remote` property here IMO seeing how it's disposable now and have callers to go through `Repository.Remotes`

cc @ethomson 