### PR TITLE
Make Pull and Fetch commands

### DIFF
--- a/LibGit2Sharp.Tests/FetchFixture.cs
+++ b/LibGit2Sharp.Tests/FetchFixture.cs
@@ -22,7 +22,7 @@ namespace LibGit2Sharp.Tests
 
             using (var repo = new Repository(path))
             {
-                Remote remote = repo.Network.Remotes.Add(remoteName, url);
+                repo.Network.Remotes.Add(remoteName, url);
 
                 // Set up structures for the expected results
                 // and verifying the RemoteUpdateTips callback.
@@ -44,7 +44,7 @@ namespace LibGit2Sharp.Tests
                 }
 
                 // Perform the actual fetch
-                repo.Network.Fetch(remote, new FetchOptions { OnUpdateTips = expectedFetchState.RemoteUpdateTipsHandler });
+                new Commands.Fetch(repo, remoteName, new string[0], new FetchOptions { OnUpdateTips = expectedFetchState.RemoteUpdateTipsHandler }, null).Run();
 
                 // Verify the expected
                 expectedFetchState.CheckUpdatedReferences(repo);
@@ -61,13 +61,13 @@ namespace LibGit2Sharp.Tests
 
             using (var repo = new Repository(path))
             {
-                Remote remote = repo.Network.Remotes.Add(remoteName, Constants.PrivateRepoUrl);
+                repo.Network.Remotes.Add(remoteName, Constants.PrivateRepoUrl);
 
                 // Perform the actual fetch
-                repo.Network.Fetch(remote, new FetchOptions
+                new Commands.Fetch(repo, remoteName, new string[0], new FetchOptions
                 {
                     CredentialsProvider = Constants.PrivateRepoCredentials
-                });
+                }, null).Run();
             }
         }
 
@@ -81,7 +81,7 @@ namespace LibGit2Sharp.Tests
 
             using (var repo = new Repository(path))
             {
-                Remote remote = repo.Network.Remotes.Add(remoteName, url);
+                repo.Network.Remotes.Add(remoteName, url);
 
                 // Set up structures for the expected results
                 // and verifying the RemoteUpdateTips callback.
@@ -101,10 +101,10 @@ namespace LibGit2Sharp.Tests
                 }
 
                 // Perform the actual fetch
-                repo.Network.Fetch(remote, new FetchOptions {
+                new Commands.Fetch(repo, remoteName, new string[0], new FetchOptions {
                     TagFetchMode = TagFetchMode.All,
                     OnUpdateTips = expectedFetchState.RemoteUpdateTipsHandler
-                });
+                }, null).Run();
 
                 // Verify the expected
                 expectedFetchState.CheckUpdatedReferences(repo);
@@ -124,7 +124,7 @@ namespace LibGit2Sharp.Tests
 
             using (var repo = new Repository(path))
             {
-                Remote remote = repo.Network.Remotes.Add(remoteName, url);
+                repo.Network.Remotes.Add(remoteName, url);
 
                 string refSpec = string.Format("refs/heads/{2}:refs/remotes/{0}/{1}", remoteName, localBranchName, remoteBranchName);
 
@@ -147,10 +147,10 @@ namespace LibGit2Sharp.Tests
                 }
 
                 // Perform the actual fetch
-                repo.Network.Fetch(remote, new string[] { refSpec }, new FetchOptions {
+                new Commands.Fetch(repo, remoteName, new string[] { refSpec }, new FetchOptions {
                     TagFetchMode = TagFetchMode.None,
                     OnUpdateTips = expectedFetchState.RemoteUpdateTipsHandler
-                });
+                }, null).Run();
 
                 // Verify the expected
                 expectedFetchState.CheckUpdatedReferences(repo);
@@ -181,7 +181,7 @@ namespace LibGit2Sharp.Tests
                     r => r.TagFetchMode = tagFetchMode);
 
                 // Perform the actual fetch.
-                repo.Network.Fetch(remote);
+                new Commands.Fetch(repo, remoteName, new string[0], null, null).Run();
 
                 // Verify the number of fetched tags.
                 Assert.Equal(expectedTagCount, repo.Tags.Count());
@@ -199,7 +199,7 @@ namespace LibGit2Sharp.Tests
 
             using (var repo = new Repository(clonedRepoPath))
             {
-                repo.Fetch("origin", new FetchOptions { TagFetchMode = TagFetchMode.All });
+                new Commands.Fetch(repo, "origin", new string[0], new FetchOptions { TagFetchMode = TagFetchMode.All }, null).Run();
             }
         }
 
@@ -225,17 +225,17 @@ namespace LibGit2Sharp.Tests
 
                 // No pruning when the configuration entry isn't defined
                 Assert.Null(clonedRepo.Config.Get<bool>("fetch.prune"));
-                clonedRepo.Fetch("origin");
+                new Commands.Fetch(clonedRepo, "origin", new string[0], null, null).Run();
                 Assert.Equal(5, clonedRepo.Branches.Count(b => b.IsRemote));
 
                 // No pruning when the configuration entry is set to false
                 clonedRepo.Config.Set<bool>("fetch.prune", false);
-                clonedRepo.Fetch("origin");
+                new Commands.Fetch(clonedRepo, "origin", new string[0], null, null).Run();
                 Assert.Equal(5, clonedRepo.Branches.Count(b => b.IsRemote));
 
                 // Auto pruning when the configuration entry is set to true
                 clonedRepo.Config.Set<bool>("fetch.prune", true);
-                clonedRepo.Fetch("origin");
+                new Commands.Fetch(clonedRepo, "origin", new string[0], null, null).Run();
                 Assert.Equal(4, clonedRepo.Branches.Count(b => b.IsRemote));
             }
         }

--- a/LibGit2Sharp.Tests/FetchFixture.cs
+++ b/LibGit2Sharp.Tests/FetchFixture.cs
@@ -44,7 +44,7 @@ namespace LibGit2Sharp.Tests
                 }
 
                 // Perform the actual fetch
-                new Commands.Fetch(repo, remoteName, new string[0], new FetchOptions { OnUpdateTips = expectedFetchState.RemoteUpdateTipsHandler }, null).Run();
+                Commands.Fetch(repo, remoteName, new string[0], new FetchOptions { OnUpdateTips = expectedFetchState.RemoteUpdateTipsHandler }, null);
 
                 // Verify the expected
                 expectedFetchState.CheckUpdatedReferences(repo);
@@ -64,10 +64,10 @@ namespace LibGit2Sharp.Tests
                 repo.Network.Remotes.Add(remoteName, Constants.PrivateRepoUrl);
 
                 // Perform the actual fetch
-                new Commands.Fetch(repo, remoteName, new string[0], new FetchOptions
+                Commands.Fetch(repo, remoteName, new string[0], new FetchOptions
                 {
                     CredentialsProvider = Constants.PrivateRepoCredentials
-                }, null).Run();
+                }, null);
             }
         }
 
@@ -101,10 +101,10 @@ namespace LibGit2Sharp.Tests
                 }
 
                 // Perform the actual fetch
-                new Commands.Fetch(repo, remoteName, new string[0], new FetchOptions {
+                Commands.Fetch(repo, remoteName, new string[0], new FetchOptions {
                     TagFetchMode = TagFetchMode.All,
                     OnUpdateTips = expectedFetchState.RemoteUpdateTipsHandler
-                }, null).Run();
+                }, null);
 
                 // Verify the expected
                 expectedFetchState.CheckUpdatedReferences(repo);
@@ -147,10 +147,10 @@ namespace LibGit2Sharp.Tests
                 }
 
                 // Perform the actual fetch
-                new Commands.Fetch(repo, remoteName, new string[] { refSpec }, new FetchOptions {
+                Commands.Fetch(repo, remoteName, new string[] { refSpec }, new FetchOptions {
                     TagFetchMode = TagFetchMode.None,
                     OnUpdateTips = expectedFetchState.RemoteUpdateTipsHandler
-                }, null).Run();
+                }, null);
 
                 // Verify the expected
                 expectedFetchState.CheckUpdatedReferences(repo);
@@ -181,7 +181,7 @@ namespace LibGit2Sharp.Tests
                     r => r.TagFetchMode = tagFetchMode);
 
                 // Perform the actual fetch.
-                new Commands.Fetch(repo, remoteName, new string[0], null, null).Run();
+                Commands.Fetch(repo, remoteName, new string[0], null, null);
 
                 // Verify the number of fetched tags.
                 Assert.Equal(expectedTagCount, repo.Tags.Count());
@@ -199,7 +199,7 @@ namespace LibGit2Sharp.Tests
 
             using (var repo = new Repository(clonedRepoPath))
             {
-                new Commands.Fetch(repo, "origin", new string[0], new FetchOptions { TagFetchMode = TagFetchMode.All }, null).Run();
+                Commands.Fetch(repo, "origin", new string[0], new FetchOptions { TagFetchMode = TagFetchMode.All }, null);
             }
         }
 
@@ -225,17 +225,17 @@ namespace LibGit2Sharp.Tests
 
                 // No pruning when the configuration entry isn't defined
                 Assert.Null(clonedRepo.Config.Get<bool>("fetch.prune"));
-                new Commands.Fetch(clonedRepo, "origin", new string[0], null, null).Run();
+                Commands.Fetch(clonedRepo, "origin", new string[0], null, null);
                 Assert.Equal(5, clonedRepo.Branches.Count(b => b.IsRemote));
 
                 // No pruning when the configuration entry is set to false
                 clonedRepo.Config.Set<bool>("fetch.prune", false);
-                new Commands.Fetch(clonedRepo, "origin", new string[0], null, null).Run();
+                Commands.Fetch(clonedRepo, "origin", new string[0], null, null);
                 Assert.Equal(5, clonedRepo.Branches.Count(b => b.IsRemote));
 
                 // Auto pruning when the configuration entry is set to true
                 clonedRepo.Config.Set<bool>("fetch.prune", true);
-                new Commands.Fetch(clonedRepo, "origin", new string[0], null, null).Run();
+                Commands.Fetch(clonedRepo, "origin", new string[0], null, null);
                 Assert.Equal(4, clonedRepo.Branches.Count(b => b.IsRemote));
             }
         }

--- a/LibGit2Sharp.Tests/NetworkFixture.cs
+++ b/LibGit2Sharp.Tests/NetworkFixture.cs
@@ -164,7 +164,7 @@ namespace LibGit2Sharp.Tests
                     }
                 };
 
-                MergeResult mergeResult = new Commands.Pull(repo, Constants.Signature, pullOptions).Run();
+                MergeResult mergeResult = Commands.Pull(repo, Constants.Signature, pullOptions);
 
                 if(fastForwardStrategy == FastForwardStrategy.Default || fastForwardStrategy == FastForwardStrategy.FastForwardOnly)
                 {
@@ -197,7 +197,7 @@ namespace LibGit2Sharp.Tests
                     b => b.UpstreamBranch = "refs/heads/master");
 
                 // Pull!
-                MergeResult mergeResult = new Commands.Pull(repo, Constants.Signature, new PullOptions()).Run();
+                MergeResult mergeResult = Commands.Pull(repo, Constants.Signature, new PullOptions());
 
                 Assert.Equal(mergeResult.Status, MergeStatus.FastForward);
                 Assert.Equal(mergeResult.Commit, repo.Branches["refs/remotes/origin/master"].Tip);
@@ -224,7 +224,7 @@ namespace LibGit2Sharp.Tests
 
                 try
                 {
-                    new Commands.Pull(repo, Constants.Signature, new PullOptions()).Run();
+                    Commands.Pull(repo, Constants.Signature, new PullOptions());
                 }
                 catch(MergeFetchHeadNotFoundException ex)
                 {
@@ -252,7 +252,7 @@ namespace LibGit2Sharp.Tests
                 Assert.False(repo.RetrieveStatus().Any());
                 Assert.Equal(repo.Lookup<Commit>("refs/remotes/origin/master~1"), repo.Head.Tip);
 
-                new Commands.Fetch(repo, repo.Head.RemoteName, new string[0], null, null).Run();
+                Commands.Fetch(repo, repo.Head.RemoteName, new string[0], null, null);
 
                 MergeOptions mergeOptions = new MergeOptions()
                 {
@@ -279,7 +279,7 @@ namespace LibGit2Sharp.Tests
             using (var repo = new Repository(clonedRepoPath))
             {
                 repo.Network.Remotes.Add("pruner", clonedRepoPath2);
-                new Commands.Fetch(repo, "pruner", new string[0], null, null).Run();
+                Commands.Fetch(repo, "pruner", new string[0], null, null);
                 Assert.NotNull(repo.Refs["refs/remotes/pruner/master"]);
 
                 // Remove the branch from the source repository
@@ -289,11 +289,11 @@ namespace LibGit2Sharp.Tests
                 }
 
                 // and by default we don't prune it
-                new Commands.Fetch(repo, "pruner", new string[0], null, null).Run();
+                Commands.Fetch(repo, "pruner", new string[0], null, null);
                 Assert.NotNull(repo.Refs["refs/remotes/pruner/master"]);
 
                 // but we do when asked by the user
-                new Commands.Fetch(repo, "pruner", new string[0], new FetchOptions { Prune = true}, null).Run();
+                Commands.Fetch(repo, "pruner", new string[0], new FetchOptions { Prune = true}, null);
                 Assert.Null(repo.Refs["refs/remotes/pruner/master"]);
             }
         }

--- a/LibGit2Sharp.Tests/NetworkFixture.cs
+++ b/LibGit2Sharp.Tests/NetworkFixture.cs
@@ -164,7 +164,7 @@ namespace LibGit2Sharp.Tests
                     }
                 };
 
-                MergeResult mergeResult = repo.Network.Pull(Constants.Signature, pullOptions);
+                MergeResult mergeResult = new Commands.Pull(repo, Constants.Signature, pullOptions).Run();
 
                 if(fastForwardStrategy == FastForwardStrategy.Default || fastForwardStrategy == FastForwardStrategy.FastForwardOnly)
                 {
@@ -197,7 +197,7 @@ namespace LibGit2Sharp.Tests
                     b => b.UpstreamBranch = "refs/heads/master");
 
                 // Pull!
-                MergeResult mergeResult = repo.Network.Pull(Constants.Signature, new PullOptions());
+                MergeResult mergeResult = new Commands.Pull(repo, Constants.Signature, new PullOptions()).Run();
 
                 Assert.Equal(mergeResult.Status, MergeStatus.FastForward);
                 Assert.Equal(mergeResult.Commit, repo.Branches["refs/remotes/origin/master"].Tip);
@@ -224,7 +224,7 @@ namespace LibGit2Sharp.Tests
 
                 try
                 {
-                    repo.Network.Pull(Constants.Signature, new PullOptions());
+                    new Commands.Pull(repo, Constants.Signature, new PullOptions()).Run();
                 }
                 catch(MergeFetchHeadNotFoundException ex)
                 {

--- a/LibGit2Sharp.Tests/NetworkFixture.cs
+++ b/LibGit2Sharp.Tests/NetworkFixture.cs
@@ -252,10 +252,7 @@ namespace LibGit2Sharp.Tests
                 Assert.False(repo.RetrieveStatus().Any());
                 Assert.Equal(repo.Lookup<Commit>("refs/remotes/origin/master~1"), repo.Head.Tip);
 
-                using (var remote = repo.Network.Remotes[repo.Head.RemoteName])
-                {
-                    repo.Network.Fetch(remote);
-                }
+                new Commands.Fetch(repo, repo.Head.RemoteName, new string[0], null, null).Run();
 
                 MergeOptions mergeOptions = new MergeOptions()
                 {
@@ -282,8 +279,7 @@ namespace LibGit2Sharp.Tests
             using (var repo = new Repository(clonedRepoPath))
             {
                 repo.Network.Remotes.Add("pruner", clonedRepoPath2);
-                var remote = repo.Network.Remotes["pruner"];
-                repo.Network.Fetch(remote);
+                new Commands.Fetch(repo, "pruner", new string[0], null, null).Run();
                 Assert.NotNull(repo.Refs["refs/remotes/pruner/master"]);
 
                 // Remove the branch from the source repository
@@ -293,11 +289,11 @@ namespace LibGit2Sharp.Tests
                 }
 
                 // and by default we don't prune it
-                repo.Network.Fetch(remote);
+                new Commands.Fetch(repo, "pruner", new string[0], null, null).Run();
                 Assert.NotNull(repo.Refs["refs/remotes/pruner/master"]);
 
                 // but we do when asked by the user
-                repo.Network.Fetch(remote, new FetchOptions { Prune = true} );
+                new Commands.Fetch(repo, "pruner", new string[0], new FetchOptions { Prune = true}, null).Run();
                 Assert.Null(repo.Refs["refs/remotes/pruner/master"]);
             }
         }

--- a/LibGit2Sharp.Tests/RepositoryFixture.cs
+++ b/LibGit2Sharp.Tests/RepositoryFixture.cs
@@ -208,13 +208,13 @@ namespace LibGit2Sharp.Tests
                 }
 
                 // Perform the actual fetch
-                new Commands.Fetch(repo, remoteName, new string[0], new FetchOptions { OnUpdateTips = expectedFetchState.RemoteUpdateTipsHandler }, null).Run();
+                Commands.Fetch(repo, remoteName, new string[0], new FetchOptions { OnUpdateTips = expectedFetchState.RemoteUpdateTipsHandler }, null);
 
                 // Verify the expected state
                 expectedFetchState.CheckUpdatedReferences(repo);
 
                 // Now fetch the rest of the tags
-                new Commands.Fetch(repo, remoteName, new string[0], new FetchOptions { TagFetchMode = TagFetchMode.All }, null).Run();
+                Commands.Fetch(repo, remoteName, new string[0], new FetchOptions { TagFetchMode = TagFetchMode.All }, null);
 
                 // Verify that the "nearly-dangling" tag is now in the repo.
                 Tag nearlyDanglingTag = repo.Tags["nearly-dangling"];

--- a/LibGit2Sharp.Tests/RepositoryFixture.cs
+++ b/LibGit2Sharp.Tests/RepositoryFixture.cs
@@ -181,7 +181,7 @@ namespace LibGit2Sharp.Tests
 
             using (var repo = new Repository(repoPath))
             {
-                Remote remote = repo.Network.Remotes.Add(remoteName, url);
+                repo.Network.Remotes.Add(remoteName, url);
 
                 // We will first fetch without specifying any Tag options.
                 // After we verify this fetch, we will perform a second fetch
@@ -208,13 +208,13 @@ namespace LibGit2Sharp.Tests
                 }
 
                 // Perform the actual fetch
-                repo.Fetch(remote.Name, new FetchOptions { OnUpdateTips = expectedFetchState.RemoteUpdateTipsHandler });
+                new Commands.Fetch(repo, remoteName, new string[0], new FetchOptions { OnUpdateTips = expectedFetchState.RemoteUpdateTipsHandler }, null).Run();
 
                 // Verify the expected state
                 expectedFetchState.CheckUpdatedReferences(repo);
 
                 // Now fetch the rest of the tags
-                repo.Fetch(remote.Name, new FetchOptions { TagFetchMode = TagFetchMode.All });
+                new Commands.Fetch(repo, remoteName, new string[0], new FetchOptions { TagFetchMode = TagFetchMode.All }, null).Run();
 
                 // Verify that the "nearly-dangling" tag is now in the repo.
                 Tag nearlyDanglingTag = repo.Tags["nearly-dangling"];

--- a/LibGit2Sharp.Tests/SmartSubtransportFixture.cs
+++ b/LibGit2Sharp.Tests/SmartSubtransportFixture.cs
@@ -63,9 +63,9 @@ namespace LibGit2Sharp.Tests
                     }
 
                     // Perform the actual fetch
-                    new Commands.Fetch(repo, remoteName, new string[0],
+                    Commands.Fetch(repo, remoteName, new string[0],
                         new FetchOptions { OnUpdateTips = expectedFetchState.RemoteUpdateTipsHandler, TagFetchMode = TagFetchMode.Auto },
-                    null).Run();
+                    null);
 
                     // Verify the expected
                     expectedFetchState.CheckUpdatedReferences(repo);
@@ -115,10 +115,10 @@ namespace LibGit2Sharp.Tests
                     }
 
                     // Perform the actual fetch
-                    new Commands.Fetch(repo, remoteName, new string[0], new FetchOptions {
+                    Commands.Fetch(repo, remoteName, new string[0], new FetchOptions {
                         OnUpdateTips = expectedFetchState.RemoteUpdateTipsHandler, TagFetchMode = TagFetchMode.Auto,
                         CredentialsProvider = (_user, _valid, _hostname) => new UsernamePasswordCredentials() { Username = "libgit3", Password = "libgit3" },
-                    }, null).Run();
+                    }, null);
 
                     // Verify the expected
                     expectedFetchState.CheckUpdatedReferences(repo);

--- a/LibGit2Sharp.Tests/SmartSubtransportFixture.cs
+++ b/LibGit2Sharp.Tests/SmartSubtransportFixture.cs
@@ -41,7 +41,7 @@ namespace LibGit2Sharp.Tests
 
                 using (var repo = new Repository(repoPath))
                 {
-                    Remote remote = repo.Network.Remotes.Add(remoteName, url);
+                    repo.Network.Remotes.Add(remoteName, url);
 
                     // Set up structures for the expected results
                     // and verifying the RemoteUpdateTips callback.
@@ -63,7 +63,9 @@ namespace LibGit2Sharp.Tests
                     }
 
                     // Perform the actual fetch
-                    repo.Network.Fetch(remote, new FetchOptions { OnUpdateTips = expectedFetchState.RemoteUpdateTipsHandler, TagFetchMode = TagFetchMode.Auto });
+                    new Commands.Fetch(repo, remoteName, new string[0],
+                        new FetchOptions { OnUpdateTips = expectedFetchState.RemoteUpdateTipsHandler, TagFetchMode = TagFetchMode.Auto },
+                    null).Run();
 
                     // Verify the expected
                     expectedFetchState.CheckUpdatedReferences(repo);
@@ -99,7 +101,7 @@ namespace LibGit2Sharp.Tests
 
                 using (var repo = new Repository(scd.DirectoryPath))
                 {
-                    Remote remote = repo.Network.Remotes.Add(remoteName, url);
+                    repo.Network.Remotes.Add(remoteName, url);
 
                     // Set up structures for the expected results
                     // and verifying the RemoteUpdateTips callback.
@@ -113,9 +115,10 @@ namespace LibGit2Sharp.Tests
                     }
 
                     // Perform the actual fetch
-                    repo.Network.Fetch(remote, new FetchOptions { OnUpdateTips = expectedFetchState.RemoteUpdateTipsHandler, TagFetchMode = TagFetchMode.Auto,
+                    new Commands.Fetch(repo, remoteName, new string[0], new FetchOptions {
+                        OnUpdateTips = expectedFetchState.RemoteUpdateTipsHandler, TagFetchMode = TagFetchMode.Auto,
                         CredentialsProvider = (_user, _valid, _hostname) => new UsernamePasswordCredentials() { Username = "libgit3", Password = "libgit3" },
-                    });
+                    }, null).Run();
 
                     // Verify the expected
                     expectedFetchState.CheckUpdatedReferences(repo);

--- a/LibGit2Sharp/Commands/Fetch.cs
+++ b/LibGit2Sharp/Commands/Fetch.cs
@@ -3,58 +3,41 @@ using LibGit2Sharp;
 using LibGit2Sharp.Core;
 using LibGit2Sharp.Core.Handles;
 
-namespace LibGit2Sharp.Commands
+namespace LibGit2Sharp
 {
     /// <summary>
-    /// Fetch from a particular remote or the default
+    /// Class to serve as namespacing for the command-emulating methods
     /// </summary>
-    public class Fetch
+    public static partial class Commands
     {
-        private readonly Repository repository;
-        private readonly string remote;
-        private readonly FetchOptions options;
-        private readonly string logMessage;
-        private readonly IEnumerable<string> refspecs;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="LibGit2Sharp.Commands.Fetch"/> class.
-        /// </summary>
-        /// <param name="repository">The repository in which to fetch.</param>
-        /// <param name="remote">The remote to fetch from</param>
-        /// <param name="options">Fetch options.</param>
-        /// <param name="logMessage">Log message for any ref updates.</param>
-        /// <param name="refspecs">List of refspecs to apply as active.</param>
-        public Fetch(Repository repository, string remote, IEnumerable<string> refspecs, FetchOptions options, string logMessage)
-        {
-            Ensure.ArgumentNotNull(remote, "remote");
-
-            this.repository = repository;
-            this.remote = remote;
-            this.options = options ?? new FetchOptions();
-            this.logMessage = logMessage;
-            this.refspecs = refspecs;
-        }
-
-        private RemoteHandle RemoteFromNameOrUrl()
+        private static RemoteHandle RemoteFromNameOrUrl(RepositoryHandle repoHandle, string remote)
         {
             RemoteHandle handle = null;
-            handle = Proxy.git_remote_lookup(repository.Handle, remote, false);
+            handle = Proxy.git_remote_lookup(repoHandle, remote, false);
 
             // If that wasn't the name of a remote, let's use it as a url
             if (handle == null)
             {
-                handle = Proxy.git_remote_create_anonymous(repository.Handle, remote);
+                handle = Proxy.git_remote_create_anonymous(repoHandle, remote);
             }
 
             return handle;
         }
 
         /// <summary>
-        /// Run this command
+        /// Perform a fetch
         /// </summary>
-        public void Run()
+        /// <param name="repository">The repository in which to fetch.</param>
+        /// <param name="remote">The remote to fetch from. Either as a remote name or a URL</param>
+        /// <param name="options">Fetch options.</param>
+        /// <param name="logMessage">Log message for any ref updates.</param>
+        /// <param name="refspecs">List of refspecs to apply as active.</param>
+        public static void Fetch(Repository repository, string remote, IEnumerable<string> refspecs, FetchOptions options, string logMessage)
         {
-            using (var remoteHandle = RemoteFromNameOrUrl())
+            Ensure.ArgumentNotNull(remote, "remote");
+
+            options = options ?? new FetchOptions();
+            using (var remoteHandle = RemoteFromNameOrUrl(repository.Handle, remote))
             {
 
                 var callbacks = new RemoteCallbacks(options);

--- a/LibGit2Sharp/Commands/Fetch.cs
+++ b/LibGit2Sharp/Commands/Fetch.cs
@@ -1,0 +1,97 @@
+﻿using System.Collections.Generic;
+using LibGit2Sharp;
+using LibGit2Sharp.Core;
+using LibGit2Sharp.Core.Handles;
+
+namespace LibGit2Sharp.Commands
+{
+    /// <summary>
+    /// Fetch from a particular remote or the default
+    /// </summary>
+    public class Fetch
+    {
+        private readonly Repository repository;
+        private readonly string remote;
+        private readonly FetchOptions options;
+        private readonly string logMessage;
+        private readonly IEnumerable<string> refspecs;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LibGit2Sharp.Commands.Fetch"/> class.
+        /// </summary>
+        /// <param name="repository">The repository in which to fetch.</param>
+        /// <param name="remote">The remote to fetch from</param>
+        /// <param name="options">Fetch options.</param>
+        /// <param name="logMessage">Log message for any ref updates.</param>
+        /// <param name="refspecs">List of refspecs to apply as active.</param>
+        public Fetch(Repository repository, string remote, IEnumerable<string> refspecs, FetchOptions options, string logMessage)
+        {
+            Ensure.ArgumentNotNull(remote, "remote");
+
+            this.repository = repository;
+            this.remote = remote;
+            this.options = options ?? new FetchOptions();
+            this.logMessage = logMessage;
+            this.refspecs = refspecs;
+        }
+
+        private RemoteHandle RemoteFromNameOrUrl()
+        {
+            RemoteHandle handle = null;
+            handle = Proxy.git_remote_lookup(repository.Handle, remote, false);
+
+            // If that wasn't the name of a remote, let's use it as a url
+            if (handle == null)
+            {
+                handle = Proxy.git_remote_create_anonymous(repository.Handle, remote);
+            }
+
+            return handle;
+        }
+
+        /// <summary>
+        /// Run this command
+        /// </summary>
+        public void Run()
+        {
+            using (var remoteHandle = RemoteFromNameOrUrl())
+            {
+
+                var callbacks = new RemoteCallbacks(options);
+                GitRemoteCallbacks gitCallbacks = callbacks.GenerateCallbacks();
+
+                // It is OK to pass the reference to the GitCallbacks directly here because libgit2 makes a copy of
+                // the data in the git_remote_callbacks structure. If, in the future, libgit2 changes its implementation
+                // to store a reference to the git_remote_callbacks structure this would introduce a subtle bug
+                // where the managed layer could move the git_remote_callbacks to a different location in memory,
+                // but libgit2 would still reference the old address.
+                //
+                // Also, if GitRemoteCallbacks were a class instead of a struct, we would need to guard against
+                // GC occuring in between setting the remote callbacks and actual usage in one of the functions afterwords.
+                var fetchOptions = new GitFetchOptions
+                {
+                    RemoteCallbacks = gitCallbacks,
+                    download_tags = Proxy.git_remote_autotag(remoteHandle),
+                };
+
+                if (options.TagFetchMode.HasValue)
+                {
+                    fetchOptions.download_tags = options.TagFetchMode.Value;
+                }
+
+                if (options.Prune.HasValue)
+                {
+                    fetchOptions.Prune = options.Prune.Value ? FetchPruneStrategy.Prune : FetchPruneStrategy.NoPrune;
+                }
+                else
+                {
+                    fetchOptions.Prune = FetchPruneStrategy.FromConfigurationOrDefault;
+                }
+
+                Proxy.git_remote_fetch(remoteHandle, refspecs, fetchOptions, logMessage);
+            }
+
+        }
+    }
+}
+

--- a/LibGit2Sharp/Commands/Pull.cs
+++ b/LibGit2Sharp/Commands/Pull.cs
@@ -2,40 +2,27 @@
 using LibGit2Sharp;
 using LibGit2Sharp.Core;
 
-namespace LibGit2Sharp.Commands
+namespace LibGit2Sharp
 {
     /// <summary>
     /// Fetch changes from the configured upstream remote and branch into the branch pointed at by HEAD.
     /// </summary>
-    public class Pull
+    public static partial class Commands
     {
-        private readonly Repository repository;
-        private readonly Signature merger;
-        private readonly PullOptions options;
-
         /// <summary>
-        /// Initializes a new instance of the <see cref="LibGit2Sharp.Commands.Pull"/> class.
+        /// Fetch changes from the configured upstream remote and branch into the branch pointed at by HEAD.
         /// </summary>
         /// <param name="repository">The repository.</param>
         /// <param name="merger">The signature to use for the merge.</param>
         /// <param name="options">The options for fetch and merging.</param>
-        public Pull(Repository repository, Signature merger, PullOptions options)
+        public static MergeResult Pull(Repository repository, Signature merger, PullOptions options)
         {
             Ensure.ArgumentNotNull(repository, "repository");
             Ensure.ArgumentNotNull(merger, "merger");
             Ensure.ArgumentNotNull(options, "options");
 
-            this.repository = repository;
-            this.merger = merger;
-            this.options = options;
-        }
 
-        /// <summary>
-        /// Run this command
-        /// </summary>
-        public MergeResult Run()
-        {
-
+            options = options ?? new PullOptions();
             Branch currentBranch = repository.Head;
 
             if (!currentBranch.IsTracking)
@@ -48,7 +35,7 @@ namespace LibGit2Sharp.Commands
                 throw new LibGit2SharpException("No upstream remote for the current branch.");
             }
 
-            new Commands.Fetch(repository, currentBranch.RemoteName, new string[0], options.FetchOptions, null).Run();
+            Commands.Fetch(repository, currentBranch.RemoteName, new string[0], options.FetchOptions, null);
             return repository.MergeFetchedRefs(merger, options.MergeOptions);
         }
     }

--- a/LibGit2Sharp/Commands/Pull.cs
+++ b/LibGit2Sharp/Commands/Pull.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using LibGit2Sharp;
+using LibGit2Sharp.Core;
+
+namespace LibGit2Sharp.Commands
+{
+    /// <summary>
+    /// Fetch changes from the configured upstream remote and branch into the branch pointed at by HEAD.
+    /// </summary>
+    public class Pull
+    {
+        private readonly Repository repository;
+        private readonly Signature merger;
+        private readonly PullOptions options;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LibGit2Sharp.Commands.Pull"/> class.
+        /// </summary>
+        /// <param name="repository">The repository.</param>
+        /// <param name="merger">The signature to use for the merge.</param>
+        /// <param name="options">The options for fetch and merging.</param>
+        public Pull(Repository repository, Signature merger, PullOptions options)
+        {
+            Ensure.ArgumentNotNull(repository, "repository");
+            Ensure.ArgumentNotNull(merger, "merger");
+            Ensure.ArgumentNotNull(options, "options");
+
+            this.repository = repository;
+            this.merger = merger;
+            this.options = options;
+        }
+
+        /// <summary>
+        /// Run this command
+        /// </summary>
+        public MergeResult Run()
+        {
+
+            Branch currentBranch = repository.Head;
+
+            if (!currentBranch.IsTracking)
+            {
+                throw new LibGit2SharpException("There is no tracking information for the current branch.");
+            }
+
+            using (var remote = repository.Network.Remotes.RemoteForName(currentBranch.RemoteName))
+            {
+                if (remote == null)
+                {
+                    throw new LibGit2SharpException("No upstream remote for the current branch.");
+                }
+
+                repository.Network.Fetch(remote, options.FetchOptions);
+                return repository.MergeFetchedRefs(merger, options.MergeOptions);
+            }
+        }
+    }
+}
+

--- a/LibGit2Sharp/Commands/Pull.cs
+++ b/LibGit2Sharp/Commands/Pull.cs
@@ -43,16 +43,13 @@ namespace LibGit2Sharp.Commands
                 throw new LibGit2SharpException("There is no tracking information for the current branch.");
             }
 
-            using (var remote = repository.Network.Remotes.RemoteForName(currentBranch.RemoteName))
+            if (currentBranch.RemoteName == null)
             {
-                if (remote == null)
-                {
-                    throw new LibGit2SharpException("No upstream remote for the current branch.");
-                }
-
-                repository.Network.Fetch(remote, options.FetchOptions);
-                return repository.MergeFetchedRefs(merger, options.MergeOptions);
+                throw new LibGit2SharpException("No upstream remote for the current branch.");
             }
+
+            new Commands.Fetch(repository, currentBranch.RemoteName, new string[0], options.FetchOptions, null).Run();
+            return repository.MergeFetchedRefs(merger, options.MergeOptions);
         }
     }
 }

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -351,6 +351,7 @@
     <Compile Include="Core\GitCredential.cs" />
     <Compile Include="Core\GitCredentialUserpass.cs" />
     <Compile Include="Commands\Pull.cs" />
+    <Compile Include="Commands\Fetch.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="CustomDictionary.xml" />

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -350,6 +350,7 @@
     <Compile Include="Core\Handles\Libgit2Object.cs" />
     <Compile Include="Core\GitCredential.cs" />
     <Compile Include="Core\GitCredentialUserpass.cs" />
+    <Compile Include="Commands\Pull.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="CustomDictionary.xml" />
@@ -386,4 +387,7 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <ItemGroup>
+    <Folder Include="Commands\" />
+  </ItemGroup>
 </Project>

--- a/LibGit2Sharp/Network.cs
+++ b/LibGit2Sharp/Network.cs
@@ -130,17 +130,6 @@ namespace LibGit2Sharp
             }
         }
 
-        static RemoteHandle BuildRemoteHandle(RepositoryHandle repoHandle, Remote remote)
-        {
-            Debug.Assert(repoHandle != null && !repoHandle.IsNull);
-            Debug.Assert(remote != null && remote.Name != null);
-
-            RemoteHandle remoteHandle = Proxy.git_remote_lookup(repoHandle, remote.Name, true);
-            Debug.Assert(remoteHandle != null && !(remoteHandle.IsNull));
-
-            return remoteHandle;
-        }
-
         static RemoteHandle BuildRemoteHandle(RepositoryHandle repoHandle, string url)
         {
             Debug.Assert(repoHandle != null && !repoHandle.IsNull);
@@ -152,79 +141,14 @@ namespace LibGit2Sharp
             return remoteHandle;
         }
 
-        static void DoFetch(
-            RepositoryHandle repoHandle,
-            Remote remote,
-            FetchOptions options,
-            string logMessage,
-            IEnumerable<string> refspecs)
-        {
-            using (RemoteHandle remoteHandle = BuildRemoteHandle(repoHandle, remote))
-            {
-                DoFetch(options, remoteHandle, logMessage, refspecs);
-            }
-        }
-
-        static void DoFetch(
-            RepositoryHandle repoHandle,
-            string url,
-            FetchOptions options,
-            string logMessage,
-            IEnumerable<string> refspecs)
-        {
-            using (RemoteHandle remoteHandle = BuildRemoteHandle(repoHandle, url))
-            {
-                DoFetch(options, remoteHandle, logMessage, refspecs);
-            }
-        }
-
-        private static void DoFetch(FetchOptions options, RemoteHandle remoteHandle, string logMessage, IEnumerable<string> refspecs)
-        {
-            Debug.Assert(remoteHandle != null && !remoteHandle.IsNull);
-
-            options = options ?? new FetchOptions();
-
-            var callbacks = new RemoteCallbacks(options);
-            GitRemoteCallbacks gitCallbacks = callbacks.GenerateCallbacks();
-
-            // It is OK to pass the reference to the GitCallbacks directly here because libgit2 makes a copy of
-            // the data in the git_remote_callbacks structure. If, in the future, libgit2 changes its implementation
-            // to store a reference to the git_remote_callbacks structure this would introduce a subtle bug
-            // where the managed layer could move the git_remote_callbacks to a different location in memory,
-            // but libgit2 would still reference the old address.
-            //
-            // Also, if GitRemoteCallbacks were a class instead of a struct, we would need to guard against
-            // GC occuring in between setting the remote callbacks and actual usage in one of the functions afterwords.
-            var fetchOptions = new GitFetchOptions
-            {
-                RemoteCallbacks = gitCallbacks,
-                download_tags = Proxy.git_remote_autotag(remoteHandle),
-            };
-
-            if (options.TagFetchMode.HasValue)
-            {
-                fetchOptions.download_tags = options.TagFetchMode.Value;
-            }
-
-            if (options.Prune.HasValue)
-            {
-                fetchOptions.Prune = options.Prune.Value ? FetchPruneStrategy.Prune : FetchPruneStrategy.NoPrune;
-            }
-            else
-            {
-                fetchOptions.Prune = FetchPruneStrategy.FromConfigurationOrDefault;
-            }
-
-            Proxy.git_remote_fetch(remoteHandle, refspecs, fetchOptions, logMessage);
-        }
-
         /// <summary>
         /// Fetch from the <see cref="Remote"/>.
         /// </summary>
         /// <param name="remote">The remote to fetch</param>
+        [Obsolete("This method is deprecated. Please us the LibGit2Sharp.Commands.Pull class")]
         public virtual void Fetch(Remote remote)
         {
-            Fetch(remote, (FetchOptions)null, null);
+            new Commands.Fetch(repository, remote.Name, new string[0], null, null).Run();
         }
 
         /// <summary>
@@ -232,9 +156,10 @@ namespace LibGit2Sharp
         /// </summary>
         /// <param name="remote">The remote to fetch</param>
         /// <param name="options"><see cref="FetchOptions"/> controlling fetch behavior</param>
+        [Obsolete("This method is deprecated. Please us the LibGit2Sharp.Commands.Pull class")]
         public virtual void Fetch(Remote remote, FetchOptions options)
         {
-            Fetch(remote, options, null);
+            new Commands.Fetch(repository, remote.Name, new string[0], options, null).Run();
         }
 
         /// <summary>
@@ -242,9 +167,10 @@ namespace LibGit2Sharp
         /// </summary>
         /// <param name="remote">The remote to fetch</param>
         /// <param name="logMessage">Message to use when updating the reflog.</param>
+        [Obsolete("This method is deprecated. Please us the LibGit2Sharp.Commands.Pull class")]
         public virtual void Fetch(Remote remote, string logMessage)
         {
-            Fetch(remote, (FetchOptions)null, logMessage);
+            new Commands.Fetch(repository, remote.Name, new string[0], null, logMessage).Run();
         }
 
         /// <summary>
@@ -253,11 +179,10 @@ namespace LibGit2Sharp
         /// <param name="remote">The remote to fetch</param>
         /// <param name="options"><see cref="FetchOptions"/> controlling fetch behavior</param>
         /// <param name="logMessage">Message to use when updating the reflog.</param>
+        [Obsolete("This method is deprecated. Please us the LibGit2Sharp.Commands.Pull class")]
         public virtual void Fetch(Remote remote, FetchOptions options, string logMessage)
         {
-            Ensure.ArgumentNotNull(remote, "remote");
-
-            DoFetch(repository.Handle, remote, options, logMessage, new string[0]);
+            new Commands.Fetch(repository, remote.Name, new string[0], options, logMessage).Run();
         }
 
         /// <summary>
@@ -265,9 +190,10 @@ namespace LibGit2Sharp
         /// </summary>
         /// <param name="remote">The remote to fetch</param>
         /// <param name="refspecs">Refspecs to use, replacing the remote's fetch refspecs</param>
+        [Obsolete("This method is deprecated. Please us the LibGit2Sharp.Commands.Pull class")]
         public virtual void Fetch(Remote remote, IEnumerable<string> refspecs)
         {
-            Fetch(remote, refspecs, null, null);
+            new Commands.Fetch(repository, remote.Name, refspecs, null, null).Run();
         }
 
         /// <summary>
@@ -276,9 +202,10 @@ namespace LibGit2Sharp
         /// <param name="remote">The remote to fetch</param>
         /// <param name="refspecs">Refspecs to use, replacing the remote's fetch refspecs</param>
         /// <param name="options"><see cref="FetchOptions"/> controlling fetch behavior</param>
+        [Obsolete("This method is deprecated. Please us the LibGit2Sharp.Commands.Pull class")]
         public virtual void Fetch(Remote remote, IEnumerable<string> refspecs, FetchOptions options)
         {
-            Fetch(remote, refspecs, options, null);
+            new Commands.Fetch(repository, remote.Name, refspecs, options, null).Run();
         }
 
         /// <summary>
@@ -287,9 +214,10 @@ namespace LibGit2Sharp
         /// <param name="remote">The remote to fetch</param>
         /// <param name="refspecs">Refspecs to use, replacing the remote's fetch refspecs</param>
         /// <param name="logMessage">Message to use when updating the reflog.</param>
+        [Obsolete("This method is deprecated. Please us the LibGit2Sharp.Commands.Pull class")]
         public virtual void Fetch(Remote remote, IEnumerable<string> refspecs, string logMessage)
         {
-            Fetch(remote, refspecs, null, logMessage);
+            new Commands.Fetch(repository, remote.Name, refspecs, null, logMessage).Run();
         }
 
         /// <summary>
@@ -299,12 +227,13 @@ namespace LibGit2Sharp
         /// <param name="refspecs">Refspecs to use, replacing the remote's fetch refspecs</param>
         /// <param name="options"><see cref="FetchOptions"/> controlling fetch behavior</param>
         /// <param name="logMessage">Message to use when updating the reflog.</param>
+        [Obsolete("This method is deprecated. Please us the LibGit2Sharp.Commands.Pull class")]
         public virtual void Fetch(Remote remote, IEnumerable<string> refspecs, FetchOptions options, string logMessage)
         {
             Ensure.ArgumentNotNull(remote, "remote");
             Ensure.ArgumentNotNull(refspecs, "refspecs");
 
-            DoFetch(repository.Handle, remote, options, logMessage, refspecs);
+            new Commands.Fetch(repository, remote.Name, refspecs, options, logMessage).Run();
         }
 
         /// <summary>
@@ -355,7 +284,7 @@ namespace LibGit2Sharp
             Ensure.ArgumentNotNull(url, "url");
             Ensure.ArgumentNotNull(refspecs, "refspecs");
 
-            DoFetch(repository.Handle, url, options, logMessage, refspecs);
+            new Commands.Fetch(repository, url, refspecs, options, logMessage).Run();
         }
 
         /// <summary>

--- a/LibGit2Sharp/Network.cs
+++ b/LibGit2Sharp/Network.cs
@@ -145,10 +145,10 @@ namespace LibGit2Sharp
         /// Fetch from the <see cref="Remote"/>.
         /// </summary>
         /// <param name="remote">The remote to fetch</param>
-        [Obsolete("This method is deprecated. Please us the LibGit2Sharp.Commands.Pull class")]
+        [Obsolete("This method is deprecated. Please us LibGit2Sharp.Commands.Fetch()")]
         public virtual void Fetch(Remote remote)
         {
-            new Commands.Fetch(repository, remote.Name, new string[0], null, null).Run();
+            Commands.Fetch(repository, remote.Name, new string[0], null, null);
         }
 
         /// <summary>
@@ -156,10 +156,10 @@ namespace LibGit2Sharp
         /// </summary>
         /// <param name="remote">The remote to fetch</param>
         /// <param name="options"><see cref="FetchOptions"/> controlling fetch behavior</param>
-        [Obsolete("This method is deprecated. Please us the LibGit2Sharp.Commands.Pull class")]
+        [Obsolete("This method is deprecated. Please use LibGit2Sharp.Commands.Fetch()")]
         public virtual void Fetch(Remote remote, FetchOptions options)
         {
-            new Commands.Fetch(repository, remote.Name, new string[0], options, null).Run();
+            Commands.Fetch(repository, remote.Name, new string[0], options, null);
         }
 
         /// <summary>
@@ -167,10 +167,10 @@ namespace LibGit2Sharp
         /// </summary>
         /// <param name="remote">The remote to fetch</param>
         /// <param name="logMessage">Message to use when updating the reflog.</param>
-        [Obsolete("This method is deprecated. Please us the LibGit2Sharp.Commands.Pull class")]
+        [Obsolete("This method is deprecated. Please use the LibGit2Sharp.Commands.Fetch()")]
         public virtual void Fetch(Remote remote, string logMessage)
         {
-            new Commands.Fetch(repository, remote.Name, new string[0], null, logMessage).Run();
+            Commands.Fetch(repository, remote.Name, new string[0], null, logMessage);
         }
 
         /// <summary>
@@ -179,10 +179,10 @@ namespace LibGit2Sharp
         /// <param name="remote">The remote to fetch</param>
         /// <param name="options"><see cref="FetchOptions"/> controlling fetch behavior</param>
         /// <param name="logMessage">Message to use when updating the reflog.</param>
-        [Obsolete("This method is deprecated. Please us the LibGit2Sharp.Commands.Pull class")]
+        [Obsolete("This method is deprecated. Please use LibGit2Sharp.Commands.Fetch()")]
         public virtual void Fetch(Remote remote, FetchOptions options, string logMessage)
         {
-            new Commands.Fetch(repository, remote.Name, new string[0], options, logMessage).Run();
+            Commands.Fetch(repository, remote.Name, new string[0], options, logMessage);
         }
 
         /// <summary>
@@ -190,10 +190,10 @@ namespace LibGit2Sharp
         /// </summary>
         /// <param name="remote">The remote to fetch</param>
         /// <param name="refspecs">Refspecs to use, replacing the remote's fetch refspecs</param>
-        [Obsolete("This method is deprecated. Please us the LibGit2Sharp.Commands.Pull class")]
+        [Obsolete("This method is deprecated. Please use LibGit2Sharp.Commands.Fetch()")]
         public virtual void Fetch(Remote remote, IEnumerable<string> refspecs)
         {
-            new Commands.Fetch(repository, remote.Name, refspecs, null, null).Run();
+            Commands.Fetch(repository, remote.Name, refspecs, null, null);
         }
 
         /// <summary>
@@ -202,10 +202,10 @@ namespace LibGit2Sharp
         /// <param name="remote">The remote to fetch</param>
         /// <param name="refspecs">Refspecs to use, replacing the remote's fetch refspecs</param>
         /// <param name="options"><see cref="FetchOptions"/> controlling fetch behavior</param>
-        [Obsolete("This method is deprecated. Please us the LibGit2Sharp.Commands.Pull class")]
+        [Obsolete("This method is deprecated. Please use LibGit2Sharp.Commands.Fetch")]
         public virtual void Fetch(Remote remote, IEnumerable<string> refspecs, FetchOptions options)
         {
-            new Commands.Fetch(repository, remote.Name, refspecs, options, null).Run();
+            Commands.Fetch(repository, remote.Name, refspecs, options, null);
         }
 
         /// <summary>
@@ -214,10 +214,10 @@ namespace LibGit2Sharp
         /// <param name="remote">The remote to fetch</param>
         /// <param name="refspecs">Refspecs to use, replacing the remote's fetch refspecs</param>
         /// <param name="logMessage">Message to use when updating the reflog.</param>
-        [Obsolete("This method is deprecated. Please us the LibGit2Sharp.Commands.Pull class")]
+        [Obsolete("This method is deprecated. Please use LibGit2Sharp.Commands.Fetch")]
         public virtual void Fetch(Remote remote, IEnumerable<string> refspecs, string logMessage)
         {
-            new Commands.Fetch(repository, remote.Name, refspecs, null, logMessage).Run();
+            Commands.Fetch(repository, remote.Name, refspecs, null, logMessage);
         }
 
         /// <summary>
@@ -227,13 +227,13 @@ namespace LibGit2Sharp
         /// <param name="refspecs">Refspecs to use, replacing the remote's fetch refspecs</param>
         /// <param name="options"><see cref="FetchOptions"/> controlling fetch behavior</param>
         /// <param name="logMessage">Message to use when updating the reflog.</param>
-        [Obsolete("This method is deprecated. Please us the LibGit2Sharp.Commands.Pull class")]
+        [Obsolete("This method is deprecated. Please use LibGit2Sharp.Commands.Fetch()")]
         public virtual void Fetch(Remote remote, IEnumerable<string> refspecs, FetchOptions options, string logMessage)
         {
             Ensure.ArgumentNotNull(remote, "remote");
             Ensure.ArgumentNotNull(refspecs, "refspecs");
 
-            new Commands.Fetch(repository, remote.Name, refspecs, options, logMessage).Run();
+            Commands.Fetch(repository, remote.Name, refspecs, options, logMessage);
         }
 
         /// <summary>
@@ -284,7 +284,7 @@ namespace LibGit2Sharp
             Ensure.ArgumentNotNull(url, "url");
             Ensure.ArgumentNotNull(refspecs, "refspecs");
 
-            new Commands.Fetch(repository, url, refspecs, options, logMessage).Run();
+            Commands.Fetch(repository, url, refspecs, options, logMessage);
         }
 
         /// <summary>
@@ -478,10 +478,10 @@ namespace LibGit2Sharp
         /// </summary>
         /// <param name="merger">If the merge is a non-fast forward merge that generates a merge commit, the <see cref="Signature"/> of who made the merge.</param>
         /// <param name="options">Specifies optional parameters controlling merge behavior of pull; if null, the defaults are used.</param>
-        [Obsolete("This method is deprecated. Please use the LibGit2Sharp.Commands.Pull class")]
+        [Obsolete("This method is deprecated. Please use LibGit2Sharp.Commands.Pull()")]
         public virtual MergeResult Pull(Signature merger, PullOptions options)
         {
-            return new Commands.Pull(repository, merger, options).Run();
+            return Commands.Pull(repository, merger, options);
         }
 
         /// <summary>

--- a/LibGit2Sharp/Network.cs
+++ b/LibGit2Sharp/Network.cs
@@ -549,29 +549,10 @@ namespace LibGit2Sharp
         /// </summary>
         /// <param name="merger">If the merge is a non-fast forward merge that generates a merge commit, the <see cref="Signature"/> of who made the merge.</param>
         /// <param name="options">Specifies optional parameters controlling merge behavior of pull; if null, the defaults are used.</param>
+        [Obsolete("This method is deprecated. Please use the LibGit2Sharp.Commands.Pull class")]
         public virtual MergeResult Pull(Signature merger, PullOptions options)
         {
-            Ensure.ArgumentNotNull(merger, "merger");
-            Ensure.ArgumentNotNull(options, "options");
-
-            Branch currentBranch = repository.Head;
-
-            if (!currentBranch.IsTracking)
-            {
-                throw new LibGit2SharpException("There is no tracking information for the current branch.");
-            }
-
-            string remoteName = currentBranch.RemoteName;
-            if (remoteName == null)
-            {
-                throw new LibGit2SharpException("No upstream remote for the current branch.");
-            }
-
-            using (var remote = repository.Network.Remotes.RemoteForName(remoteName))
-            {
-                Fetch(remote, options.FetchOptions);
-                return repository.MergeFetchedRefs(merger, options.MergeOptions);
-            }
+            return new Commands.Pull(repository, merger, options).Run();
         }
 
         /// <summary>

--- a/LibGit2Sharp/RepositoryExtensions.cs
+++ b/LibGit2Sharp/RepositoryExtensions.cs
@@ -205,6 +205,7 @@ namespace LibGit2Sharp
         /// </summary>
         /// <param name="repository">The <see cref="Repository"/> being worked with.</param>
         /// <param name="remoteName">The name of the <see cref="Remote"/> to fetch from.</param>
+        [Obsolete("This method is deprecated. Please us the LibGit2Sharp.Commands.Fetch class")]
         public static void Fetch(this IRepository repository, string remoteName)
         {
             repository.Fetch(remoteName, null);
@@ -216,6 +217,7 @@ namespace LibGit2Sharp
         /// <param name="repository">The <see cref="Repository"/> being worked with.</param>
         /// <param name="remoteName">The name of the <see cref="Remote"/> to fetch from.</param>
         /// <param name="options"><see cref="FetchOptions"/> controlling fetch behavior</param>
+        [Obsolete("This method is deprecated. Please us the LibGit2Sharp.Commands.Fetch class")]
         public static void Fetch(this IRepository repository, string remoteName, FetchOptions options)
         {
             Ensure.ArgumentNotNull(repository, "repository");


### PR DESCRIPTION
These want to behave like commands, so let's put them in a namespace that says as much.

This is similar to #1248 but I'm touching the network area so I wanted to send this one as well, so we can discuss the design with more data points.

In particular, should these be classes? They don't really do anything that needs a class. A static method in a static class might work out better for keeping namespacing but not forcing undue instantiations.

These commands take a string instead of having `Remote` and `string` variants since that's what a command would take and all the `Remote` instances were doing was carry the name.