### PR TITLE
Move Stage and Remove to commands

### DIFF
--- a/LibGit2Sharp.Tests/AttributesFixture.cs
+++ b/LibGit2Sharp.Tests/AttributesFixture.cs
@@ -29,7 +29,7 @@ namespace LibGit2Sharp.Tests
 
             Touch(repo.Info.WorkingDirectory, filename, sb.ToString());
 
-            repo.Stage(filename);
+            Commands.Stage(repo, filename);
 
             IndexEntry entry = repo.Index[filename];
             Assert.NotNull(entry);

--- a/LibGit2Sharp.Tests/BlobFixture.cs
+++ b/LibGit2Sharp.Tests/BlobFixture.cs
@@ -63,7 +63,7 @@ namespace LibGit2Sharp.Tests
                 var bomPath = Touch(repo.Info.WorkingDirectory, bomFile, content, encoding);
                 Assert.Equal(expectedContentBytes, File.ReadAllBytes(bomPath).Length);
 
-                repo.Stage(bomFile);
+                Commands.Stage(repo, bomFile);
                 var commit = repo.Commit("bom", Constants.Signature, Constants.Signature);
 
                 var blob = (Blob)commit.Tree[bomFile].Target;
@@ -190,7 +190,7 @@ namespace LibGit2Sharp.Tests
                     File.AppendAllText(Path.Combine(repo.Info.WorkingDirectory, "small.txt"), sb.ToString());
                 }
 
-                repo.Stage("small.txt");
+                Commands.Stage(repo, "small.txt");
                 IndexEntry entry = repo.Index["small.txt"];
                 Assert.Equal("baae1fb3760a73481ced1fa03dc15614142c19ef", entry.Id.Sha);
 
@@ -202,7 +202,7 @@ namespace LibGit2Sharp.Tests
                     CopyStream(stream, file);
                 }
 
-                repo.Stage("small.fromblob.txt");
+                Commands.Stage(repo, "small.fromblob.txt");
                 IndexEntry newentry = repo.Index["small.fromblob.txt"];
 
                 Assert.Equal("baae1fb3760a73481ced1fa03dc15614142c19ef", newentry.Id.Sha);

--- a/LibGit2Sharp.Tests/BranchFixture.cs
+++ b/LibGit2Sharp.Tests/BranchFixture.cs
@@ -1137,7 +1137,7 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal("origin", repo.Head.RemoteName);
 
                 Touch(repo.Info.WorkingDirectory, "a.txt", "a");
-                repo.Stage("a.txt");
+                Commands.Stage(repo, "a.txt");
                 repo.Commit("A file", Constants.Signature, Constants.Signature);
 
                 Assert.NotNull(repo.Head.Tip);

--- a/LibGit2Sharp.Tests/CheckoutFixture.cs
+++ b/LibGit2Sharp.Tests/CheckoutFixture.cs
@@ -156,7 +156,7 @@ namespace LibGit2Sharp.Tests
                 // Remove the file in master branch
                 // Verify it exists after checking out otherBranch.
                 string fileFullPath = Path.Combine(repo.Info.WorkingDirectory, originalFilePath);
-                repo.Remove(fileFullPath);
+                Commands.Remove(repo, fileFullPath);
                 repo.Commit("2nd commit", Constants.Signature, Constants.Signature);
 
                 // Checkout other_branch

--- a/LibGit2Sharp.Tests/CheckoutFixture.cs
+++ b/LibGit2Sharp.Tests/CheckoutFixture.cs
@@ -184,7 +184,7 @@ namespace LibGit2Sharp.Tests
                 string newFileFullPath = Touch(
                     repo.Info.WorkingDirectory, "b.txt", "hello from master branch!\n");
 
-                repo.Stage(newFileFullPath);
+                Commands.Stage(repo, newFileFullPath);
                 repo.Commit("2nd commit", Constants.Signature, Constants.Signature);
 
                 // Checkout other_branch
@@ -212,7 +212,7 @@ namespace LibGit2Sharp.Tests
                 string fullPath = Touch(
                     repo.Info.WorkingDirectory, originalFilePath, "Update : hello from master branch!\n");
 
-                repo.Stage(fullPath);
+                Commands.Stage(repo, fullPath);
                 repo.Commit("2nd commit", Constants.Signature, Constants.Signature);
 
                 // Checkout other_branch
@@ -254,7 +254,7 @@ namespace LibGit2Sharp.Tests
                 // Add change to master.
                 Touch(repo.Info.WorkingDirectory, originalFilePath, originalFileContent);
 
-                repo.Stage(originalFilePath);
+                Commands.Stage(repo, originalFilePath);
                 repo.Commit("change in master", Constants.Signature, Constants.Signature);
 
                 // Checkout otherBranch.
@@ -262,7 +262,7 @@ namespace LibGit2Sharp.Tests
 
                 // Add change to otherBranch.
                 Touch(repo.Info.WorkingDirectory, originalFilePath, alternateFileContent);
-                repo.Stage(originalFilePath);
+                Commands.Stage(repo, originalFilePath);
 
                 // Assert that normal checkout throws exception
                 // for the conflict.
@@ -287,7 +287,7 @@ namespace LibGit2Sharp.Tests
             using (var repo = new Repository(repoPath))
             {
                 Touch(repo.Info.WorkingDirectory, originalFilePath, "Hello\n");
-                repo.Stage(originalFilePath);
+                Commands.Stage(repo, originalFilePath);
                 repo.Commit("Initial commit", Constants.Signature, Constants.Signature);
 
                 // Create 2nd branch
@@ -295,7 +295,7 @@ namespace LibGit2Sharp.Tests
 
                 // Update file in main
                 Touch(repo.Info.WorkingDirectory, originalFilePath, "Hello from master!\n");
-                repo.Stage(originalFilePath);
+                Commands.Stage(repo, originalFilePath);
                 repo.Commit("2nd commit", Constants.Signature, Constants.Signature);
 
                 // Checkout branch2
@@ -307,7 +307,7 @@ namespace LibGit2Sharp.Tests
                 Assert.Throws<CheckoutConflictException>(() => repo.Checkout("master"));
 
                 // And when there are staged commits
-                repo.Stage(originalFilePath);
+                Commands.Stage(repo, originalFilePath);
                 Assert.Throws<CheckoutConflictException>(() => repo.Checkout("master"));
             }
         }
@@ -322,7 +322,7 @@ namespace LibGit2Sharp.Tests
                 const string relativePath = "a.txt";
                 Touch(repo.Info.WorkingDirectory, relativePath, "Hello\n");
 
-                repo.Stage(relativePath);
+                Commands.Stage(repo, relativePath);
                 repo.Commit("Initial commit", Constants.Signature, Constants.Signature);
 
                 // Create 2nd branch
@@ -330,7 +330,7 @@ namespace LibGit2Sharp.Tests
 
                 // Update file in main
                 Touch(repo.Info.WorkingDirectory, relativePath, "Hello from master!\n");
-                repo.Stage(relativePath);
+                Commands.Stage(repo, relativePath);
                 repo.Commit("2nd commit", Constants.Signature, Constants.Signature);
 
                 // Checkout branch2
@@ -453,13 +453,13 @@ namespace LibGit2Sharp.Tests
 
                 const string relativePathUpdated = "updated.txt";
                 Touch(repo.Info.WorkingDirectory, relativePathUpdated, "updated file text A");
-                repo.Stage(relativePathUpdated);
+                Commands.Stage(repo, relativePathUpdated);
                 repo.Commit("Commit initial update file", Constants.Signature, Constants.Signature);
 
                 // Create conflicting change
                 const string relativePathConflict = "conflict.txt";
                 Touch(repo.Info.WorkingDirectory, relativePathConflict, "conflict file text A");
-                repo.Stage(relativePathConflict);
+                Commands.Stage(repo, relativePathConflict);
                 repo.Commit("Initial commit of conflict.txt and update.txt", Constants.Signature, Constants.Signature);
 
                 // Create another branch
@@ -467,9 +467,9 @@ namespace LibGit2Sharp.Tests
 
                 // Make an edit to conflict.txt and update.txt
                 Touch(repo.Info.WorkingDirectory, relativePathUpdated, "updated file text BB");
-                repo.Stage(relativePathUpdated);
+                Commands.Stage(repo, relativePathUpdated);
                 Touch(repo.Info.WorkingDirectory, relativePathConflict, "conflict file text BB");
-                repo.Stage(relativePathConflict);
+                Commands.Stage(repo, relativePathConflict);
 
                 repo.Commit("2nd commit of conflict.txt and update.txt on master branch", Constants.Signature, Constants.Signature);
 
@@ -478,14 +478,14 @@ namespace LibGit2Sharp.Tests
 
                 // Make alternate edits to conflict.txt and update.txt
                 Touch(repo.Info.WorkingDirectory, relativePathUpdated, "updated file text CCC");
-                repo.Stage(relativePathUpdated);
+                Commands.Stage(repo, relativePathUpdated);
                 Touch(repo.Info.WorkingDirectory, relativePathConflict, "conflict file text CCC");
-                repo.Stage(relativePathConflict);
+                Commands.Stage(repo, relativePathConflict);
                 repo.Commit("2nd commit of conflict.txt and update.txt on newbranch", Constants.Signature, Constants.Signature);
 
                 // make conflicting change to conflict.txt
                 Touch(repo.Info.WorkingDirectory, relativePathConflict, "conflict file text DDDD");
-                repo.Stage(relativePathConflict);
+                Commands.Stage(repo, relativePathConflict);
 
                 // Create ignored change
                 string relativePathIgnore = Path.Combine("bin", "ignored.txt");
@@ -596,7 +596,7 @@ namespace LibGit2Sharp.Tests
 
                 // Generate a staged change.
                 string fullPathFileA = Touch(repo.Info.WorkingDirectory, originalFilePath, alternateFileContent);
-                repo.Stage(fullPathFileA);
+                Commands.Stage(repo, fullPathFileA);
 
                 // Verify that there is a staged entry.
                 Assert.Equal(1, repo.RetrieveStatus().Staged.Count());
@@ -680,7 +680,7 @@ namespace LibGit2Sharp.Tests
 
                 // Add commit to master
                 string fullPath = Touch(repo.Info.WorkingDirectory, originalFilePath, "Update : hello from master branch!\n");
-                repo.Stage(fullPath);
+                Commands.Stage(repo, fullPath);
                 repo.Commit("2nd commit", Constants.Signature, Constants.Signature);
 
                 Assert.False(repo.Info.IsHeadDetached);
@@ -1038,10 +1038,10 @@ namespace LibGit2Sharp.Tests
         {
             // Generate a .gitignore file.
             string gitIgnoreFilePath = Touch(repo.Info.WorkingDirectory, ".gitignore", "bin");
-            repo.Stage(gitIgnoreFilePath);
+            Commands.Stage(repo, gitIgnoreFilePath);
 
             string fullPathFileA = Touch(repo.Info.WorkingDirectory, originalFilePath, originalFileContent);
-            repo.Stage(fullPathFileA);
+            Commands.Stage(repo, fullPathFileA);
 
             repo.Commit("Initial commit", Constants.Signature, Constants.Signature);
 

--- a/LibGit2Sharp.Tests/CherryPickFixture.cs
+++ b/LibGit2Sharp.Tests/CherryPickFixture.cs
@@ -130,7 +130,7 @@ namespace LibGit2Sharp.Tests
         {
             Touch(repository.Info.WorkingDirectory, filename, content);
 
-            repository.Stage(filename);
+            Commands.Stage(repository, filename);
 
             return repository.Commit("New commit", Constants.Signature, Constants.Signature);
         }

--- a/LibGit2Sharp.Tests/CommitFixture.cs
+++ b/LibGit2Sharp.Tests/CommitFixture.cs
@@ -552,10 +552,10 @@ namespace LibGit2Sharp.Tests
 
                 const string relativeFilepath = "new.txt";
                 string filePath = Touch(repo.Info.WorkingDirectory, relativeFilepath, "null");
-                repo.Stage(relativeFilepath);
+                Commands.Stage(repo, relativeFilepath);
 
                 File.AppendAllText(filePath, "token\n");
-                repo.Stage(relativeFilepath);
+                Commands.Stage(repo, relativeFilepath);
 
                 Assert.Null(repo.Head[relativeFilepath]);
 
@@ -614,7 +614,7 @@ namespace LibGit2Sharp.Tests
 
                 const string relativeFilepath = "new.txt";
                 Touch(repo.Info.WorkingDirectory, relativeFilepath, "this is a new file");
-                repo.Stage(relativeFilepath);
+                Commands.Stage(repo, relativeFilepath);
 
                 string mergeHeadPath = Touch(repo.Info.Path, "MERGE_HEAD", "abcdefabcdefabcdefabcdefabcdefabcdefabcd");
                 string mergeMsgPath = Touch(repo.Info.Path, "MERGE_MSG", "This is a dummy merge.\n");
@@ -651,9 +651,9 @@ namespace LibGit2Sharp.Tests
 
                 const string relativeFilepath = "new.txt";
                 string filePath = Touch(repo.Info.WorkingDirectory, relativeFilepath, "null");
-                repo.Stage(relativeFilepath);
+                Commands.Stage(repo, relativeFilepath);
                 File.AppendAllText(filePath, "token\n");
-                repo.Stage(relativeFilepath);
+                Commands.Stage(repo, relativeFilepath);
 
                 Assert.Null(repo.Head[relativeFilepath]);
 
@@ -692,7 +692,7 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(commit.Id, repo.Refs.Log(targetCanonicalName).First().To);
 
                 File.WriteAllText(filePath, "nulltoken commits!\n");
-                repo.Stage(relativeFilepath);
+                Commands.Stage(repo, relativeFilepath);
 
                 var author2 = new Signature(author.Name, author.Email, author.When.AddSeconds(5));
                 Commit commit2 = repo.Commit("Are you trying to fork me?", author2, author2);
@@ -713,7 +713,7 @@ namespace LibGit2Sharp.Tests
                 File.WriteAllText(filePath, "davidfowl commits!\n");
 
                 var author3 = new Signature("David Fowler", "david.fowler@microsoft.com", author.When.AddSeconds(2));
-                repo.Stage(relativeFilepath);
+                Commands.Stage(repo, relativeFilepath);
 
                 Commit commit3 = repo.Commit("I'm going to branch you backwards in time!", author3, author3);
 
@@ -739,7 +739,7 @@ namespace LibGit2Sharp.Tests
             {
                 const string relativeFilepath = "test.txt";
                 Touch(repo.Info.WorkingDirectory, relativeFilepath, "test\n");
-                repo.Stage(relativeFilepath);
+                Commands.Stage(repo, relativeFilepath);
 
                 var author = new Signature("nulltoken", "emeric.fermas@gmail.com", DateTimeOffset.Parse("Wed, Dec 14 2011 08:29:03 +0100"));
                 repo.Commit("Initial commit", author, author);
@@ -825,7 +825,7 @@ namespace LibGit2Sharp.Tests
         {
             string relativeFilepath = string.Format("new-file-{0}.txt", Path.GetRandomFileName());
             Touch(repo.Info.WorkingDirectory, relativeFilepath, "brand new content\n");
-            repo.Stage(relativeFilepath);
+            Commands.Stage(repo, relativeFilepath);
         }
 
         private static void AssertCommitHasBeenAmended(IRepository repo, Commit amendedCommit, Commit originalCommit)
@@ -914,7 +914,7 @@ namespace LibGit2Sharp.Tests
 
                 const string relativeFilepath = "test.txt";
                 Touch(repo.Info.WorkingDirectory, relativeFilepath, "test\n");
-                repo.Stage(relativeFilepath);
+                Commands.Stage(repo, relativeFilepath);
 
                 repo.Commit("Initial commit", Constants.Signature, Constants.Signature);
                 Assert.Equal(1, repo.Head.Commits.Count());
@@ -1030,12 +1030,12 @@ namespace LibGit2Sharp.Tests
             using (var repo = new Repository(repoPath))
             {
                 Touch(repo.Info.WorkingDirectory, "test.txt", "test\n");
-                repo.Stage("test.txt");
+                Commands.Stage(repo, "test.txt");
 
                 repo.Commit("Initial commit", Constants.Signature, Constants.Signature);
 
                 Touch(repo.Info.WorkingDirectory, "new.txt", "content\n");
-                repo.Stage("new.txt");
+                Commands.Stage(repo, "new.txt");
 
                 repo.Commit("One commit", Constants.Signature, Constants.Signature);
 

--- a/LibGit2Sharp.Tests/CommitFixture.cs
+++ b/LibGit2Sharp.Tests/CommitFixture.cs
@@ -1039,7 +1039,7 @@ namespace LibGit2Sharp.Tests
 
                 repo.Commit("One commit", Constants.Signature, Constants.Signature);
 
-                repo.Remove("new.txt");
+                Commands.Remove(repo, "new.txt");
 
                 Assert.Throws<EmptyCommitException>(() => repo.Commit("Oops", Constants.Signature, Constants.Signature,
                     new CommitOptions { AmendPreviousCommit = true }));

--- a/LibGit2Sharp.Tests/ConflictFixture.cs
+++ b/LibGit2Sharp.Tests/ConflictFixture.cs
@@ -77,7 +77,7 @@ namespace LibGit2Sharp.Tests
                 Assert.NotNull(repo.Index.Conflicts[filename]);
                 Assert.Equal(0, repo.Index.Conflicts.ResolvedConflicts.Count());
 
-                repo.Remove(filename, removeFromWorkdir);
+                Commands.Remove(repo, filename, removeFromWorkdir);
 
                 Assert.Null(repo.Index.Conflicts[filename]);
                 Assert.Equal(count - removedIndexEntries, repo.Index.Count);

--- a/LibGit2Sharp.Tests/DiffTreeToTargetFixture.cs
+++ b/LibGit2Sharp.Tests/DiffTreeToTargetFixture.cs
@@ -12,12 +12,12 @@ namespace LibGit2Sharp.Tests
         {
             var fullpath = Touch(repo.Info.WorkingDirectory, "file.txt", "hello\n");
 
-            repo.Stage(fullpath);
+            Commands.Stage(repo, fullpath);
             repo.Commit("Initial commit", Constants.Signature, Constants.Signature);
 
             File.AppendAllText(fullpath, "world\n");
 
-            repo.Stage(fullpath);
+            Commands.Stage(repo,fullpath);
 
             File.AppendAllText(fullpath, "!!!\n");
         }
@@ -159,7 +159,7 @@ namespace LibGit2Sharp.Tests
 
                 var fullpath = Path.Combine(repo.Info.WorkingDirectory, "file.txt");
                 File.Move(fullpath, fullpath + ".bak");
-                repo.Stage(fullpath);
+                Commands.Stage(repo, fullpath);
                 File.Move(fullpath + ".bak", fullpath);
 
                 FileStatus state = repo.RetrieveStatus("file.txt");
@@ -378,11 +378,11 @@ namespace LibGit2Sharp.Tests
             {
                 var fullpath = Touch(repo.Info.WorkingDirectory, "file.txt", "a");
 
-                repo.Stage("file.txt");
+                Commands.Stage(repo, "file.txt");
                 repo.Commit("Add file without line ending", Constants.Signature, Constants.Signature);
 
                 File.AppendAllText(fullpath, "\n");
-                repo.Stage("file.txt");
+                Commands.Stage(repo, "file.txt");
 
                 var changes = repo.Diff.Compare<TreeChanges>(repo.Head.Tip.Tree, DiffTargets.Index);
                 Assert.Equal(1, changes.Modified.Count());

--- a/LibGit2Sharp.Tests/DiffTreeToTreeFixture.cs
+++ b/LibGit2Sharp.Tests/DiffTreeToTreeFixture.cs
@@ -133,7 +133,7 @@ namespace LibGit2Sharp.Tests
                 var patch = repo.Diff.Compare<Patch>(commit.Tree, DiffTargets.WorkingDirectory, new [] {filename});
                 Assert.True(patch[filename].IsBinaryComparison);
 
-                repo.Remove(filename);
+                Commands.Remove(repo, filename);
                 var commit2 = repo.Commit("Delete binary file", Constants.Signature, Constants.Signature);
 
                 var patch2 = repo.Diff.Compare<Patch>(commit.Tree, commit2.Tree, new[] { filename });

--- a/LibGit2Sharp.Tests/DiffTreeToTreeFixture.cs
+++ b/LibGit2Sharp.Tests/DiffTreeToTreeFixture.cs
@@ -293,7 +293,7 @@ namespace LibGit2Sharp.Tests
 
                 Commit old = repo.Commit("Initial", Constants.Signature, Constants.Signature);
 
-                repo.Move(originalPath, renamedPath);
+                Commands.Move(repo, originalPath, renamedPath);
 
                 Commit @new = repo.Commit("Updated", Constants.Signature, Constants.Signature);
 
@@ -331,7 +331,7 @@ namespace LibGit2Sharp.Tests
                 // 8 lines, 50% are from original file
                 Touch(repo.Info.WorkingDirectory, originalPath, "a\nb\nc\nd\ne\nf\ng\nh\n");
                 Commands.Stage(repo, originalPath);
-                repo.Move(originalPath, renamedPath);
+                Commands.Move(repo, originalPath, renamedPath);
 
                 Commit @new = repo.Commit("Updated", Constants.Signature, Constants.Signature);
 
@@ -369,7 +369,7 @@ namespace LibGit2Sharp.Tests
 
                 Commit old = repo.Commit("Initial", Constants.Signature, Constants.Signature);
 
-                repo.Move(originalPath, renamedPath);
+                Commands.Move(repo, originalPath, renamedPath);
 
                 Commit @new = repo.Commit("Updated", Constants.Signature, Constants.Signature);
 
@@ -434,7 +434,7 @@ namespace LibGit2Sharp.Tests
 
                 Commit old = repo.Commit("Initial", Constants.Signature, Constants.Signature);
 
-                repo.Move(originalPath, renamedPath);
+                Commands.Move(repo, originalPath, renamedPath);
                 File.AppendAllText(Path.Combine(repo.Info.WorkingDirectory, renamedPath), "e\nf\n");
                 Commands.Stage(repo, renamedPath);
 
@@ -508,7 +508,7 @@ namespace LibGit2Sharp.Tests
 
                 Commit old = repo.Commit("Initial", Constants.Signature, Constants.Signature);
 
-                repo.Move(originalPath, renamedPath);
+                Commands.Move(repo, originalPath, renamedPath);
 
                 Commit @new = repo.Commit("Updated", Constants.Signature, Constants.Signature);
 
@@ -725,7 +725,7 @@ namespace LibGit2Sharp.Tests
                 Commands.Stage(repo, originalPath3);
                 Commands.Stage(repo, copiedPath1);
                 Commands.Stage(repo, copiedPath2);
-                repo.Move(originalPath, renamedPath);
+                Commands.Move(repo, originalPath, renamedPath);
 
                 Commit @new = repo.Commit("Updated", Constants.Signature, Constants.Signature);
 

--- a/LibGit2Sharp.Tests/DiffTreeToTreeFixture.cs
+++ b/LibGit2Sharp.Tests/DiffTreeToTreeFixture.cs
@@ -99,7 +99,7 @@ namespace LibGit2Sharp.Tests
 
                 CreateBinaryFile(filepath);
 
-                repo.Stage(filename);
+                Commands.Stage(repo, filename);
                 var commit = repo.Commit("Add binary file", Constants.Signature, Constants.Signature);
 
                 File.AppendAllText(filepath, "abcdef");
@@ -107,7 +107,7 @@ namespace LibGit2Sharp.Tests
                 var patch = repo.Diff.Compare<Patch>(commit.Tree, DiffTargets.WorkingDirectory, new[] { filename });
                 Assert.True(patch[filename].IsBinaryComparison);
 
-                repo.Stage(filename);
+                Commands.Stage(repo, filename);
                 var commit2 = repo.Commit("Update binary file", Constants.Signature, Constants.Signature);
 
                 var patch2 = repo.Diff.Compare<Patch>(commit.Tree, commit2.Tree, new[] { filename });
@@ -125,7 +125,7 @@ namespace LibGit2Sharp.Tests
 
                 CreateBinaryFile(filepath);
 
-                repo.Stage(filename);
+                Commands.Stage(repo, filename);
                 var commit = repo.Commit("Add binary file", Constants.Signature, Constants.Signature);
 
                 File.Delete(filepath);
@@ -289,7 +289,7 @@ namespace LibGit2Sharp.Tests
 
                 Touch(repo.Info.WorkingDirectory, originalPath, "a\nb\nc\nd\n");
 
-                repo.Stage(originalPath);
+                Commands.Stage(repo, originalPath);
 
                 Commit old = repo.Commit("Initial", Constants.Signature, Constants.Signature);
 
@@ -324,13 +324,13 @@ namespace LibGit2Sharp.Tests
 
                 // 4 lines
                 Touch(repo.Info.WorkingDirectory, originalPath, "a\nb\nc\nd\n");
-                repo.Stage(originalPath);
+                Commands.Stage(repo, originalPath);
 
                 Commit old = repo.Commit("Initial", Constants.Signature, Constants.Signature);
 
                 // 8 lines, 50% are from original file
                 Touch(repo.Info.WorkingDirectory, originalPath, "a\nb\nc\nd\ne\nf\ng\nh\n");
-                repo.Stage(originalPath);
+                Commands.Stage(repo, originalPath);
                 repo.Move(originalPath, renamedPath);
 
                 Commit @new = repo.Commit("Updated", Constants.Signature, Constants.Signature);
@@ -365,7 +365,7 @@ namespace LibGit2Sharp.Tests
 
                 Touch(repo.Info.WorkingDirectory, originalPath, "a\nb\nc\nd\n");
 
-                repo.Stage(originalPath);
+                Commands.Stage(repo, originalPath);
 
                 Commit old = repo.Commit("Initial", Constants.Signature, Constants.Signature);
 
@@ -399,11 +399,11 @@ namespace LibGit2Sharp.Tests
                 var copiedFullPath = Path.Combine(repo.Info.WorkingDirectory, copiedPath);
 
                 Touch(repo.Info.WorkingDirectory, originalPath, "a\nb\nc\nd\n");
-                repo.Stage(originalPath);
+                Commands.Stage(repo, originalPath);
                 Commit old = repo.Commit("Initial", Constants.Signature, Constants.Signature);
 
                 File.Copy(originalFullPath, copiedFullPath);
-                repo.Stage(copiedPath);
+                Commands.Stage(repo, copiedPath);
 
                 Commit @new = repo.Commit("Updated", Constants.Signature, Constants.Signature);
 
@@ -430,13 +430,13 @@ namespace LibGit2Sharp.Tests
 
                 Touch(repo.Info.WorkingDirectory, originalPath, "a\nb\nc\nd\n");
 
-                repo.Stage(originalPath);
+                Commands.Stage(repo, originalPath);
 
                 Commit old = repo.Commit("Initial", Constants.Signature, Constants.Signature);
 
                 repo.Move(originalPath, renamedPath);
                 File.AppendAllText(Path.Combine(repo.Info.WorkingDirectory, renamedPath), "e\nf\n");
-                repo.Stage(renamedPath);
+                Commands.Stage(repo, renamedPath);
 
                 Commit @new = repo.Commit("Updated", Constants.Signature, Constants.Signature);
 
@@ -467,12 +467,12 @@ namespace LibGit2Sharp.Tests
 
                 Touch(repo.Info.WorkingDirectory, originalPath, "a\nb\nc\nd\n");
 
-                repo.Stage(originalPath);
+                Commands.Stage(repo, originalPath);
 
                 Commit old = repo.Commit("Initial", Constants.Signature, Constants.Signature);
 
                 File.Copy(originalFullPath, copiedFullPath);
-                repo.Stage(copiedPath);
+                Commands.Stage(repo, copiedPath);
 
                 Commit @new = repo.Commit("Updated", Constants.Signature, Constants.Signature);
 
@@ -504,7 +504,7 @@ namespace LibGit2Sharp.Tests
 
                 Touch(repo.Info.WorkingDirectory, originalPath, "a\nb\nc\nd\n");
 
-                repo.Stage(originalPath);
+                Commands.Stage(repo, originalPath);
 
                 Commit old = repo.Commit("Initial", Constants.Signature, Constants.Signature);
 
@@ -538,12 +538,12 @@ namespace LibGit2Sharp.Tests
 
                 Touch(repo.Info.WorkingDirectory, originalPath, "a\nb\nc\nd\n");
 
-                repo.Stage(originalPath);
+                Commands.Stage(repo, originalPath);
 
                 Commit old = repo.Commit("Initial", Constants.Signature, Constants.Signature);
 
                 File.Copy(originalFullPath, copiedFullPath);
-                repo.Stage(copiedPath);
+                Commands.Stage(repo, copiedPath);
 
                 Commit @new = repo.Commit("Updated", Constants.Signature, Constants.Signature);
 
@@ -575,12 +575,12 @@ namespace LibGit2Sharp.Tests
 
                 Touch(repo.Info.WorkingDirectory, originalPath, "a\nb\nc\nd\n");
 
-                repo.Stage(originalPath);
+                Commands.Stage(repo, originalPath);
 
                 Commit old = repo.Commit("Initial", Constants.Signature, Constants.Signature);
 
                 File.Copy(originalFullPath, copiedFullPath);
-                repo.Stage(copiedPath);
+                Commands.Stage(repo, copiedPath);
 
                 Commit @new = repo.Commit("Updated", Constants.Signature, Constants.Signature);
 
@@ -605,15 +605,15 @@ namespace LibGit2Sharp.Tests
 
                 Touch(repo.Info.WorkingDirectory, originalPath, "a\nb\nc\nd\n");
 
-                repo.Stage(originalPath);
+                Commands.Stage(repo, originalPath);
 
                 Commit old = repo.Commit("Initial", Constants.Signature, Constants.Signature);
 
                 File.Copy(originalFullPath, copiedFullPath);
                 Touch(repo.Info.WorkingDirectory, originalPath, "e\n");
 
-                repo.Stage(originalPath);
-                repo.Stage(copiedPath);
+                Commands.Stage(repo, originalPath);
+                Commands.Stage(repo, copiedPath);
 
                 Commit @new = repo.Commit("Updated", Constants.Signature, Constants.Signature);
 
@@ -645,15 +645,15 @@ namespace LibGit2Sharp.Tests
 
                 Touch(repo.Info.WorkingDirectory, originalPath, "a\nb\nc\nd\n");
 
-                repo.Stage(originalPath);
+                Commands.Stage(repo, originalPath);
 
                 Commit old = repo.Commit("Initial", Constants.Signature, Constants.Signature);
 
                 File.Copy(originalFullPath, copiedFullPath);
                 File.AppendAllText(originalFullPath, "e\n");
 
-                repo.Stage(originalPath);
-                repo.Stage(copiedPath);
+                Commands.Stage(repo, originalPath);
+                Commands.Stage(repo, copiedPath);
 
                 Commit @new = repo.Commit("Updated", Constants.Signature, Constants.Signature);
 
@@ -674,11 +674,11 @@ namespace LibGit2Sharp.Tests
                 Touch(repo.Info.WorkingDirectory, "a.txt", "abc\ndef\n");
                 Touch(repo.Info.WorkingDirectory, "b.txt", "abc\ndef\n");
 
-                repo.Stage(new[] {"a.txt", "b.txt"});
+                Commands.Stage(repo, new[] {"a.txt", "b.txt"});
                 Commit old = repo.Commit("Initial", Constants.Signature, Constants.Signature);
 
                 File.AppendAllText(Path.Combine(repo.Info.WorkingDirectory, "b.txt"), "ghi\njkl\n");
-                repo.Stage("b.txt");
+                Commands.Stage(repo, "b.txt");
                 Commit @new = repo.Commit("Updated", Constants.Signature, Constants.Signature);
 
                 var changes = repo.Diff.Compare<TreeChanges>(old.Tree, @new.Tree,
@@ -708,9 +708,9 @@ namespace LibGit2Sharp.Tests
                 Touch(repo.Info.WorkingDirectory, originalPath2, "1\n2\n3\n4\n");
                 Touch(repo.Info.WorkingDirectory, originalPath3, "5\n6\n7\n8\n");
 
-                repo.Stage(originalPath);
-                repo.Stage(originalPath2);
-                repo.Stage(originalPath3);
+                Commands.Stage(repo, originalPath);
+                Commands.Stage(repo, originalPath2);
+                Commands.Stage(repo, originalPath3);
 
                 Commit old = repo.Commit("Initial", Constants.Signature, Constants.Signature);
 
@@ -722,9 +722,9 @@ namespace LibGit2Sharp.Tests
                 File.Copy(originalFullPath3, copiedFullPath2);
                 File.AppendAllText(originalFullPath3, "9\n");
 
-                repo.Stage(originalPath3);
-                repo.Stage(copiedPath1);
-                repo.Stage(copiedPath2);
+                Commands.Stage(repo, originalPath3);
+                Commands.Stage(repo, copiedPath1);
+                Commands.Stage(repo, copiedPath2);
                 repo.Move(originalPath, renamedPath);
 
                 Commit @new = repo.Commit("Updated", Constants.Signature, Constants.Signature);

--- a/LibGit2Sharp.Tests/FileHistoryFixture.cs
+++ b/LibGit2Sharp.Tests/FileHistoryFixture.cs
@@ -365,7 +365,7 @@ namespace LibGit2Sharp.Tests
             string message = null)
         {
             Touch(repoPath, path, text);
-            repo.Stage(path);
+            Commands.Stage(repo, path);
 
             var commitSignature = GetNextSignature();
             return repo.Commit(message ?? "Changed " + path, commitSignature, commitSignature);

--- a/LibGit2Sharp.Tests/FileHistoryFixture.cs
+++ b/LibGit2Sharp.Tests/FileHistoryFixture.cs
@@ -152,7 +152,7 @@ namespace LibGit2Sharp.Tests
 
                 // Move the first file to a new directory.
                 var newPath1 = Path.Combine(SubFolderPath1, path1);
-                repo.Move(path1, newPath1);
+                Commands.Move(repo, path1, newPath1);
                 var commit3 = repo.Commit("Moved " + path1 + " to " + newPath1,
                     Constants.Signature, Constants.Signature);
 

--- a/LibGit2Sharp.Tests/FilterFixture.cs
+++ b/LibGit2Sharp.Tests/FilterFixture.cs
@@ -280,8 +280,8 @@ namespace LibGit2Sharp.Tests
                 {
                     CreateConfigurationWithDummyUser(repo, Constants.Identity);
                     File.WriteAllText(attributesPath, "*.blob filter=test");
-                    repo.Stage(attributesFile.Name);
-                    repo.Stage(contentFile.Name);
+                    Commands.Stage(repo, attributesFile.Name);
+                    Commands.Stage(repo, contentFile.Name);
                     repo.Commit("test", Constants.Signature, Constants.Signature);
                     contentFile.Delete();
                     repo.Checkout("HEAD", new CheckoutOptions() { CheckoutModifiers = CheckoutModifiers.Force });
@@ -413,7 +413,7 @@ namespace LibGit2Sharp.Tests
         {
             string newFilePath = Touch(repo.Info.WorkingDirectory, Guid.NewGuid() + ".txt", contents);
             var stageNewFile = new FileInfo(newFilePath);
-            repo.Stage(newFilePath);
+            Commands.Stage(repo, newFilePath);
             return stageNewFile;
         }
 

--- a/LibGit2Sharp.Tests/FilterSubstitutionCipherFixture.cs
+++ b/LibGit2Sharp.Tests/FilterSubstitutionCipherFixture.cs
@@ -197,14 +197,14 @@ namespace LibGit2Sharp.Tests
         private static void DeleteFile(Repository repo, string fileName)
         {
             File.Delete(Path.Combine(repo.Info.WorkingDirectory, fileName));
-            repo.Stage(fileName);
+            Commands.Stage(repo, fileName);
             repo.Commit("remove file", Constants.Signature, Constants.Signature);
         }
 
         private static Blob CommitOnBranchAndReturnDatabaseBlob(Repository repo, string fileName, string input)
         {
             Touch(repo.Info.WorkingDirectory, fileName, input);
-            repo.Stage(fileName);
+            Commands.Stage(repo, fileName);
 
             var commit = repo.Commit("new file", Constants.Signature, Constants.Signature);
 

--- a/LibGit2Sharp.Tests/IgnoreFixture.cs
+++ b/LibGit2Sharp.Tests/IgnoreFixture.cs
@@ -95,7 +95,7 @@ namespace LibGit2Sharp.Tests
                 var gitIgnoreFile = string.Format("deeply{0}nested{0}.gitignore", pd);
                 Touch(repo.Info.WorkingDirectory, gitIgnoreFile, "SmtCounters.h");
 
-                repo.Stage(gitIgnoreFile);
+                Commands.Stage(repo, gitIgnoreFile);
                 repo.Commit("Add .gitignore", Constants.Signature, Constants.Signature);
 
                 Assert.False(repo.RetrieveStatus().IsDirty);

--- a/LibGit2Sharp.Tests/IndexFixture.cs
+++ b/LibGit2Sharp.Tests/IndexFixture.cs
@@ -120,7 +120,7 @@ namespace LibGit2Sharp.Tests
 
                 const string newName = "being.frakking.polite.txt";
 
-                repo.Move(oldName, newName);
+                Commands.Move(repo, oldName, newName);
                 Assert.Equal(FileStatus.DeletedFromIndex, repo.RetrieveStatus(oldName));
                 Assert.Equal(FileStatus.NewInIndex, repo.RetrieveStatus(newName));
 
@@ -150,7 +150,7 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(sourceStatus, repo.RetrieveStatus(sourcePath));
                 Assert.Equal(destStatus, repo.RetrieveStatus(destPath));
 
-                repo.Move(sourcePath, destPath);
+                Commands.Move(repo, sourcePath, destPath);
 
                 Assert.Equal(sourcePostStatus, repo.RetrieveStatus(sourcePath));
                 Assert.Equal(destPostStatus, repo.RetrieveStatus(destPath));
@@ -193,7 +193,7 @@ namespace LibGit2Sharp.Tests
                 foreach (var destPath in destPaths)
                 {
                     string path = destPath;
-                    Assert.Throws<LibGit2SharpException>(() => repo.Move(sourcePath, path));
+                    Assert.Throws<LibGit2SharpException>(() => Commands.Move(repo, sourcePath, path));
                 }
             }
         }

--- a/LibGit2Sharp.Tests/MergeFixture.cs
+++ b/LibGit2Sharp.Tests/MergeFixture.cs
@@ -751,7 +751,7 @@ namespace LibGit2Sharp.Tests
                 foreach(var entry in repo.RetrieveStatus())
                 {
                     Commands.Unstage(repo, entry.FilePath);
-                    repo.Remove(entry.FilePath, true);
+                    Commands.Remove(repo, entry.FilePath, true);
                 }
 
                 // Assert that we have an empty working directory.

--- a/LibGit2Sharp.Tests/MergeFixture.cs
+++ b/LibGit2Sharp.Tests/MergeFixture.cs
@@ -611,7 +611,7 @@ namespace LibGit2Sharp.Tests
 
                 if (shouldStage)
                 {
-                    repo.Stage("b.txt");
+                    Commands.Stage(repo, "b.txt");
                 }
 
                 Assert.Throws<CheckoutConflictException>(() => repo.Merge(committishToMerge, Constants.Signature, new MergeOptions() { FastForwardStrategy = strategy }));
@@ -750,7 +750,7 @@ namespace LibGit2Sharp.Tests
                 // Remove entries from the working directory
                 foreach(var entry in repo.RetrieveStatus())
                 {
-                    repo.Unstage(entry.FilePath);
+                    Commands.Unstage(repo, entry.FilePath);
                     repo.Remove(entry.FilePath, true);
                 }
 
@@ -790,7 +790,7 @@ namespace LibGit2Sharp.Tests
 
                 Touch(repo.Info.WorkingDirectory, "README", "Yeah!\n");
                 repo.Index.Clear();
-                repo.Stage("README");
+                Commands.Stage(repo, "README");
 
                 repo.Commit("A new world, free of the burden of the history", Constants.Signature, Constants.Signature);
 
@@ -869,7 +869,7 @@ namespace LibGit2Sharp.Tests
         {
             Touch(repository.Info.WorkingDirectory, filename, content);
 
-            repository.Stage(filename);
+            Commands.Stage(repository, filename);
 
             return repository.Commit("New commit", Constants.Signature, Constants.Signature);
         }

--- a/LibGit2Sharp.Tests/ObjectDatabaseFixture.cs
+++ b/LibGit2Sharp.Tests/ObjectDatabaseFixture.cs
@@ -676,7 +676,7 @@ namespace LibGit2Sharp.Tests
 
                 Touch(repo.Info.WorkingDirectory, "README", "Yeah!\n");
                 repo.Index.Clear();
-                repo.Stage("README");
+                Commands.Stage(repo, "README");
 
                 repo.Commit("A new world, free of the burden of the history", Constants.Signature, Constants.Signature);
 

--- a/LibGit2Sharp.Tests/OdbBackendFixture.cs
+++ b/LibGit2Sharp.Tests/OdbBackendFixture.cs
@@ -16,7 +16,7 @@ namespace LibGit2Sharp.Tests
         {
             string relativeFilepath = "test.txt";
             Touch(repo.Info.WorkingDirectory, relativeFilepath, content);
-            repo.Stage(relativeFilepath);
+            Commands.Stage(repo, relativeFilepath);
 
             var ie = repo.Index[relativeFilepath];
             Assert.NotNull(ie);
@@ -28,7 +28,7 @@ namespace LibGit2Sharp.Tests
             relativeFilepath = "big.txt";
             var zeros = new string('0', 32*1024 + 3);
             Touch(repo.Info.WorkingDirectory, relativeFilepath, zeros);
-            repo.Stage(relativeFilepath);
+            Commands.Stage(repo, relativeFilepath);
 
             ie = repo.Index[relativeFilepath];
             Assert.NotNull(ie);

--- a/LibGit2Sharp.Tests/PushFixture.cs
+++ b/LibGit2Sharp.Tests/PushFixture.cs
@@ -38,7 +38,7 @@ namespace LibGit2Sharp.Tests
                 // Change local state (commit)
                 const string relativeFilepath = "new_file.txt";
                 Touch(clonedRepo.Info.WorkingDirectory, relativeFilepath, "__content__");
-                clonedRepo.Stage(relativeFilepath);
+                Commands.Stage(clonedRepo, relativeFilepath);
                 clonedRepo.Commit("__commit_message__", Constants.Signature, Constants.Signature);
 
                 // Assert local state has changed
@@ -228,7 +228,7 @@ namespace LibGit2Sharp.Tests
 
             Touch(repository.Info.WorkingDirectory, filename, random);
 
-            repository.Stage(filename);
+            Commands.Stage(repository, filename);
 
             return repository.Commit("New commit", Constants.Signature, Constants.Signature);
         }

--- a/LibGit2Sharp.Tests/RebaseFixture.cs
+++ b/LibGit2Sharp.Tests/RebaseFixture.cs
@@ -338,7 +338,7 @@ namespace LibGit2Sharp.Tests
                     Touch(repo.Info.WorkingDirectory,
                           conflict.Theirs.Path,
                           repo.Lookup<Blob>(conflict.Theirs.Id).GetContentText(new FilteringOptions(conflict.Theirs.Path)));
-                    repo.Stage(conflict.Theirs.Path);
+                    Commands.Stage(repo, conflict.Theirs.Path);
                 }
 
                 Assert.True(repo.Index.IsFullyMerged);
@@ -396,7 +396,7 @@ namespace LibGit2Sharp.Tests
                     Touch(repo.Info.WorkingDirectory,
                           conflict.Theirs.Path,
                           repo.Lookup<Blob>(conflict.Theirs.Id).GetContentText(new FilteringOptions(conflict.Theirs.Path)));
-                    repo.Stage(conflict.Theirs.Path);
+                    Commands.Stage(repo, conflict.Theirs.Path);
                 }
 
                 Touch(repo.Info.WorkingDirectory,
@@ -618,7 +618,7 @@ namespace LibGit2Sharp.Tests
 
                 string newFileRelativePath = "new_file.txt";
                 Touch(repo.Info.WorkingDirectory, newFileRelativePath, "New Content");
-                repo.Stage(newFileRelativePath);
+                Commands.Stage(repo, newFileRelativePath);
                 Commit commit = repo.Commit("new commit 1", Constants.Signature, Constants.Signature, new CommitOptions());
 
                 repo.Checkout(topicBranch1Prime);
@@ -627,7 +627,7 @@ namespace LibGit2Sharp.Tests
 
                 string newFileRelativePath2 = "new_file_2.txt";
                 Touch(repo.Info.WorkingDirectory, newFileRelativePath2, "New Content for path 2");
-                repo.Stage(newFileRelativePath2);
+                Commands.Stage(repo, newFileRelativePath2);
                 repo.Commit("new commit 2", Constants.Signature, Constants.Signature, new CommitOptions());
 
                 Branch upstreamBranch = repo.Branches[topicBranch1Name];
@@ -714,69 +714,69 @@ namespace LibGit2Sharp.Tests
 
             CreateAttributesFile(repo, attributes);
 
-            repo.Stage(".gitattributes");
+            Commands.Stage(repo, ".gitattributes");
             commit = repo.Commit("setup", Constants.Signature, Constants.Signature, new CommitOptions());
 
             Touch(workdir, filePathA, fileContentA1);
-            repo.Stage(filePathA);
+            Commands.Stage(repo, filePathA);
             commit = repo.Commit("commit 1", Constants.Signature, Constants.Signature, new CommitOptions());
 
             Touch(workdir, filePathB, fileContentB1);
-            repo.Stage(filePathB);
+            Commands.Stage(repo, filePathB);
             commit = repo.Commit("commit 2", Constants.Signature, Constants.Signature, new CommitOptions());
 
             Touch(workdir, filePathC, fileContentC1);
-            repo.Stage(filePathC);
+            Commands.Stage(repo, filePathC);
             commit = repo.Commit("commit 3", Constants.Signature, Constants.Signature, new CommitOptions());
 
             Branch masterBranch1 = repo.CreateBranch(masterBranch1Name, commit);
 
             Touch(workdir, filePathB, string.Join(lineEnding, fileContentB1, fileContentB2));
-            repo.Stage(filePathB);
+            Commands.Stage(repo, filePathB);
             commit = repo.Commit("commit 4", Constants.Signature, Constants.Signature, new CommitOptions());
 
             Touch(workdir, filePathB, string.Join(lineEnding, fileContentB1, fileContentB2, fileContentB3));
-            repo.Stage(filePathB);
+            Commands.Stage(repo, filePathB);
             commit = repo.Commit("commit 5", Constants.Signature, Constants.Signature, new CommitOptions());
 
             Touch(workdir, filePathB, string.Join(lineEnding, fileContentB1, fileContentB2, fileContentB3, fileContentB4));
-            repo.Stage(filePathB);
+            Commands.Stage(repo, filePathB);
             commit = repo.Commit("commit 6", Constants.Signature, Constants.Signature, new CommitOptions());
 
             repo.CreateBranch(topicBranch1Name, commit);
 
             Touch(workdir, filePathC, string.Join(lineEnding, fileContentC1, fileContentC2));
-            repo.Stage(filePathC);
+            Commands.Stage(repo, filePathC);
             commit = repo.Commit("commit 7", Constants.Signature, Constants.Signature, new CommitOptions());
 
             Touch(workdir, filePathC, string.Join(lineEnding, fileContentC1, fileContentC2, fileContentC3));
-            repo.Stage(filePathC);
+            Commands.Stage(repo, filePathC);
             commit = repo.Commit("commit 8", Constants.Signature, Constants.Signature, new CommitOptions());
 
             Touch(workdir, filePathC, string.Join(lineEnding, fileContentC1, fileContentC2, fileContentC3, fileContentC4));
-            repo.Stage(filePathC);
+            Commands.Stage(repo, filePathC);
             commit = repo.Commit("commit 9", Constants.Signature, Constants.Signature, new CommitOptions());
 
             repo.CreateBranch(topicBranch2Name, commit);
 
             repo.Checkout(masterBranch1.Tip);
             Touch(workdir, filePathD, fileContentD1);
-            repo.Stage(filePathD);
+            Commands.Stage(repo, filePathD);
             commit = repo.Commit("commit 10", Constants.Signature, Constants.Signature, new CommitOptions());
 
             Touch(workdir, filePathD, string.Join(lineEnding, fileContentD1, fileContentD2));
-            repo.Stage(filePathD);
+            Commands.Stage(repo, filePathD);
             commit = repo.Commit("commit 11", Constants.Signature, Constants.Signature, new CommitOptions());
 
             Touch(workdir, filePathD, string.Join(lineEnding, fileContentD1, fileContentD2, fileContentD3));
-            repo.Stage(filePathD);
+            Commands.Stage(repo, filePathD);
             commit = repo.Commit("commit 12", Constants.Signature, Constants.Signature, new CommitOptions());
 
             repo.CreateBranch(masterBranch2Name, commit);
 
             // Create commit / branch that conflicts with T1 and T2
             Touch(workdir, filePathB, string.Join(lineEnding, fileContentB1, fileContentB2 + fileContentB3 + fileContentB4));
-            repo.Stage(filePathB);
+            Commands.Stage(repo, filePathB);
             commit = repo.Commit("commit 13", Constants.Signature, Constants.Signature, new CommitOptions());
             repo.CreateBranch(conflictBranch1Name, commit);
         }

--- a/LibGit2Sharp.Tests/ReflogFixture.cs
+++ b/LibGit2Sharp.Tests/ReflogFixture.cs
@@ -68,7 +68,7 @@ namespace LibGit2Sharp.Tests
 
                 const string relativeFilepath = "new.txt";
                 Touch(repo.Info.WorkingDirectory, relativeFilepath, "content\n");
-                repo.Stage(relativeFilepath);
+                Commands.Stage(repo, relativeFilepath);
 
                 var author = Constants.Signature;
                 const string commitMessage = "Hope reflog behaves as it should";
@@ -116,7 +116,7 @@ namespace LibGit2Sharp.Tests
             {
                 const string relativeFilepath = "new.txt";
                 Touch(repo.Info.WorkingDirectory, relativeFilepath, "content\n");
-                repo.Stage(relativeFilepath);
+                Commands.Stage(repo, relativeFilepath);
 
                 var author = Constants.Signature;
                 const string commitMessage = "First commit should be logged as initial";
@@ -145,7 +145,7 @@ namespace LibGit2Sharp.Tests
 
                 const string relativeFilepath = "new.txt";
                 Touch(repo.Info.WorkingDirectory, relativeFilepath, "content\n");
-                repo.Stage(relativeFilepath);
+                Commands.Stage(repo, relativeFilepath);
 
                 var author = Constants.Signature;
                 const string commitMessage = "Commit on detached head";

--- a/LibGit2Sharp.Tests/RemoveFixture.cs
+++ b/LibGit2Sharp.Tests/RemoveFixture.cs
@@ -59,12 +59,12 @@ namespace LibGit2Sharp.Tests
 
                 if (throws)
                 {
-                    Assert.Throws<RemoveFromIndexException>(() => repo.Remove(filename, removeFromWorkdir));
+                    Assert.Throws<RemoveFromIndexException>(() => Commands.Remove(repo, filename, removeFromWorkdir));
                     Assert.Equal(count, repo.Index.Count);
                 }
                 else
                 {
-                    repo.Remove(filename, removeFromWorkdir);
+                    Commands.Remove(repo, filename, removeFromWorkdir);
 
                     Assert.Equal(count - 1, repo.Index.Count);
                     Assert.Equal(existsAfterRemove, File.Exists(fullpath));
@@ -93,8 +93,8 @@ namespace LibGit2Sharp.Tests
                 File.AppendAllText(fullpath, "additional content");
                 Assert.Equal(FileStatus.ModifiedInIndex | FileStatus.ModifiedInWorkdir, repo.RetrieveStatus(filename));
 
-                Assert.Throws<RemoveFromIndexException>(() => repo.Remove(filename));
-                Assert.Throws<RemoveFromIndexException>(() => repo.Remove(filename, false));
+                Assert.Throws<RemoveFromIndexException>(() => Commands.Remove(repo, filename));
+                Assert.Throws<RemoveFromIndexException>(() => Commands.Remove(repo, filename, false));
             }
         }
 
@@ -113,7 +113,7 @@ namespace LibGit2Sharp.Tests
                 int count = repo.Index.Count;
 
                 Assert.True(Directory.Exists(Path.Combine(repo.Info.WorkingDirectory, "2")));
-                repo.Remove("2", false);
+                Commands.Remove(repo, "2", false);
 
                 Assert.Equal(count - 5, repo.Index.Count);
             }
@@ -128,7 +128,7 @@ namespace LibGit2Sharp.Tests
                 int count = repo.Index.Count;
 
                 Assert.True(Directory.Exists(Path.Combine(repo.Info.WorkingDirectory, "1")));
-                repo.Remove("1");
+                Commands.Remove(repo, "1");
 
                 Assert.False(Directory.Exists(Path.Combine(repo.Info.WorkingDirectory, "1")));
                 Assert.Equal(count - 1, repo.Index.Count);
@@ -148,8 +148,8 @@ namespace LibGit2Sharp.Tests
                     Assert.Null(repo.Index[relativePath]);
                     Assert.Equal(status, repo.RetrieveStatus(relativePath));
 
-                    repo.Remove(relativePath, i % 2 == 0);
-                    repo.Remove(relativePath, i % 2 == 0,
+                    Commands.Remove(repo, relativePath, i % 2 == 0);
+                    Commands.Remove(repo, relativePath, i % 2 == 0,
                                       new ExplicitPathsOptions {ShouldFailOnUnmatchedPath = false});
                 }
             }
@@ -169,7 +169,7 @@ namespace LibGit2Sharp.Tests
                     Assert.Equal(status, repo.RetrieveStatus(relativePath));
 
                     Assert.Throws<UnmatchedPathException>(
-                        () => repo.Remove(relativePath, i%2 == 0, new ExplicitPathsOptions()));
+                        () => Commands.Remove(repo, relativePath, i%2 == 0, new ExplicitPathsOptions()));
                 }
             }
         }
@@ -180,10 +180,10 @@ namespace LibGit2Sharp.Tests
             var path = SandboxStandardTestRepoGitDir();
             using (var repo = new Repository(path))
             {
-                Assert.Throws<ArgumentException>(() => repo.Remove(string.Empty));
-                Assert.Throws<ArgumentNullException>(() => repo.Remove((string)null));
-                Assert.Throws<ArgumentException>(() => repo.Remove(new string[] { }));
-                Assert.Throws<ArgumentNullException>(() => repo.Remove(new string[] { null }));
+                Assert.Throws<ArgumentException>(() => Commands.Remove(repo, string.Empty));
+                Assert.Throws<ArgumentNullException>(() => Commands.Remove(repo, (string)null));
+                Assert.Throws<ArgumentException>(() => Commands.Remove(repo, new string[] { }));
+                Assert.Throws<ArgumentNullException>(() => Commands.Remove(repo, new string[] { null }));
             }
         }
     }

--- a/LibGit2Sharp.Tests/RemoveFixture.cs
+++ b/LibGit2Sharp.Tests/RemoveFixture.cs
@@ -104,11 +104,11 @@ namespace LibGit2Sharp.Tests
             string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
-                repo.Stage(Touch(repo.Info.WorkingDirectory, "2/subdir1/2.txt", "whone"));
-                repo.Stage(Touch(repo.Info.WorkingDirectory, "2/subdir1/3.txt", "too"));
-                repo.Stage(Touch(repo.Info.WorkingDirectory, "2/subdir2/4.txt", "tree"));
-                repo.Stage(Touch(repo.Info.WorkingDirectory, "2/5.txt", "for"));
-                repo.Stage(Touch(repo.Info.WorkingDirectory, "2/6.txt", "fyve"));
+                Commands.Stage(repo, Touch(repo.Info.WorkingDirectory, "2/subdir1/2.txt", "whone"));
+                Commands.Stage(repo, Touch(repo.Info.WorkingDirectory, "2/subdir1/3.txt", "too"));
+                Commands.Stage(repo, Touch(repo.Info.WorkingDirectory, "2/subdir2/4.txt", "tree"));
+                Commands.Stage(repo, Touch(repo.Info.WorkingDirectory, "2/5.txt", "for"));
+                Commands.Stage(repo, Touch(repo.Info.WorkingDirectory, "2/6.txt", "fyve"));
 
                 int count = repo.Index.Count;
 

--- a/LibGit2Sharp.Tests/RepositoryFixture.cs
+++ b/LibGit2Sharp.Tests/RepositoryFixture.cs
@@ -443,7 +443,7 @@ namespace LibGit2Sharp.Tests
             {
                 const string filename = "new.txt";
                 Touch(repo.Info.WorkingDirectory, filename, "one ");
-                repo.Stage(filename);
+                Commands.Stage(repo, filename);
 
                 Signature author = Constants.Signature;
                 Commit commit = repo.Commit("Initial commit", author, author);

--- a/LibGit2Sharp.Tests/RepositoryOptionsFixture.cs
+++ b/LibGit2Sharp.Tests/RepositoryOptionsFixture.cs
@@ -90,7 +90,7 @@ namespace LibGit2Sharp.Tests
             {
                 Assert.Equal(FileStatus.NewInWorkdir, repo.RetrieveStatus("new_untracked_file.txt"));
 
-                repo.Stage("new_untracked_file.txt");
+                Commands.Stage(repo, "new_untracked_file.txt");
 
                 Assert.Equal(FileStatus.NewInIndex, repo.RetrieveStatus("new_untracked_file.txt"));
 
@@ -148,7 +148,7 @@ namespace LibGit2Sharp.Tests
                 const string filename = "zomg.txt";
                 Touch(sneakyRepo.Info.WorkingDirectory, filename, "I'm being sneaked in!\n");
 
-                sneakyRepo.Stage(filename);
+                Commands.Stage(sneakyRepo, filename);
                 return sneakyRepo.Commit("Tadaaaa!", Constants.Signature, Constants.Signature).Sha;
             }
         }
@@ -210,7 +210,7 @@ namespace LibGit2Sharp.Tests
             {
                 const string relativeFilepath = "test.txt";
                 Touch(repo.Info.WorkingDirectory, relativeFilepath, "test\n");
-                repo.Stage(relativeFilepath);
+                Commands.Stage(repo, relativeFilepath);
 
                 Assert.NotNull(repo.Commit("Initial commit", Constants.Signature, Constants.Signature));
                 Assert.Equal(1, repo.Head.Commits.Count());

--- a/LibGit2Sharp.Tests/ResetHeadFixture.cs
+++ b/LibGit2Sharp.Tests/ResetHeadFixture.cs
@@ -163,12 +163,12 @@ namespace LibGit2Sharp.Tests
         private static void FeedTheRepository(IRepository repo)
         {
             string fullPath = Touch(repo.Info.WorkingDirectory, "a.txt", "Hello\n");
-            repo.Stage(fullPath);
+            Commands.Stage(repo, fullPath);
             repo.Commit("Initial commit", Constants.Signature, Constants.Signature);
             repo.ApplyTag("mytag");
 
             File.AppendAllText(fullPath, "World\n");
-            repo.Stage(fullPath);
+            Commands.Stage(repo, fullPath);
 
             Signature shiftedSignature = Constants.Signature.TimeShift(TimeSpan.FromMinutes(1));
             repo.Commit("Update file", shiftedSignature, shiftedSignature);

--- a/LibGit2Sharp.Tests/ResetIndexFixture.cs
+++ b/LibGit2Sharp.Tests/ResetIndexFixture.cs
@@ -116,7 +116,7 @@ namespace LibGit2Sharp.Tests
         {
             using (var repo = new Repository(SandboxStandardTestRepo()))
             {
-                repo.Move("branch_file.txt", "renamed_branch_file.txt");
+                Commands.Move(repo, "branch_file.txt", "renamed_branch_file.txt");
                 repo.Index.Replace(repo.Lookup<Commit>("32eab9c"));
 
                 RepositoryStatus status = repo.RetrieveStatus();
@@ -129,7 +129,7 @@ namespace LibGit2Sharp.Tests
         {
             using (var repo = new Repository(SandboxStandardTestRepo()))
             {
-                repo.Move("branch_file.txt", "renamed_branch_file.txt");
+                Commands.Move(repo, "branch_file.txt", "renamed_branch_file.txt");
 
                 RepositoryStatus oldStatus = repo.RetrieveStatus();
                 Assert.Equal(1, oldStatus.RenamedInIndex.Count());
@@ -150,7 +150,7 @@ namespace LibGit2Sharp.Tests
         {
             using (var repo = new Repository(SandboxStandardTestRepo()))
             {
-                repo.Move("branch_file.txt", "renamed_branch_file.txt");
+                Commands.Move(repo, "branch_file.txt", "renamed_branch_file.txt");
 
                 RepositoryStatus oldStatus = repo.RetrieveStatus();
                 Assert.Equal(1, oldStatus.RenamedInIndex.Count());

--- a/LibGit2Sharp.Tests/StageFixture.cs
+++ b/LibGit2Sharp.Tests/StageFixture.cs
@@ -25,7 +25,7 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(doesCurrentlyExistInTheIndex, (repo.Index[relativePath] != null));
                 Assert.Equal(currentStatus, repo.RetrieveStatus(relativePath));
 
-                repo.Stage(relativePath);
+                Commands.Stage(repo, relativePath);
 
                 Assert.Equal(count + expectedIndexCountVariation, repo.Index.Count);
                 Assert.Equal(doesExistInTheIndexOnceStaged, (repo.Index[relativePath] != null));
@@ -48,7 +48,7 @@ namespace LibGit2Sharp.Tests
                 Touch(repo.Info.WorkingDirectory, filename, "brand new content");
                 Assert.Equal(FileStatus.NewInIndex | FileStatus.ModifiedInWorkdir, repo.RetrieveStatus(filename));
 
-                repo.Stage(filename);
+                Commands.Stage(repo, filename);
                 IndexEntry newBlob = repo.Index[filename];
 
                 Assert.Equal(count, repo.Index.Count);
@@ -68,7 +68,7 @@ namespace LibGit2Sharp.Tests
                 Assert.Null(repo.Index[relativePath]);
                 Assert.Equal(status, repo.RetrieveStatus(relativePath));
 
-                Assert.Throws<UnmatchedPathException>(() => repo.Stage(relativePath, new StageOptions { ExplicitPathsOptions = new ExplicitPathsOptions() }));
+                Assert.Throws<UnmatchedPathException>(() => Commands.Stage(repo, relativePath, new StageOptions { ExplicitPathsOptions = new ExplicitPathsOptions() }));
             }
         }
 
@@ -83,8 +83,8 @@ namespace LibGit2Sharp.Tests
                 Assert.Null(repo.Index[relativePath]);
                 Assert.Equal(status, repo.RetrieveStatus(relativePath));
 
-                Assert.DoesNotThrow(() => repo.Stage(relativePath));
-                Assert.DoesNotThrow(() => repo.Stage(relativePath, new StageOptions { ExplicitPathsOptions = new ExplicitPathsOptions { ShouldFailOnUnmatchedPath = false } }));
+                Assert.DoesNotThrow(() => Commands.Stage(repo, relativePath));
+                Assert.DoesNotThrow(() => Commands.Stage(repo, relativePath, new StageOptions { ExplicitPathsOptions = new ExplicitPathsOptions { ShouldFailOnUnmatchedPath = false } }));
 
                 Assert.Equal(status, repo.RetrieveStatus(relativePath));
             }
@@ -101,8 +101,8 @@ namespace LibGit2Sharp.Tests
                 Assert.Null(repo.Index[relativePath]);
                 Assert.Equal(status, repo.RetrieveStatus(relativePath));
 
-                repo.Stage(relativePath);
-                repo.Stage(relativePath, new StageOptions { ExplicitPathsOptions = new ExplicitPathsOptions { ShouldFailOnUnmatchedPath = false } });
+                Commands.Stage(repo, relativePath);
+                Commands.Stage(repo, relativePath, new StageOptions { ExplicitPathsOptions = new ExplicitPathsOptions { ShouldFailOnUnmatchedPath = false } });
             }
         }
 
@@ -121,7 +121,7 @@ namespace LibGit2Sharp.Tests
                 File.Delete(Path.Combine(repo.Info.WorkingDirectory, filename));
                 Assert.Equal(FileStatus.NewInIndex | FileStatus.DeletedFromWorkdir, repo.RetrieveStatus(filename));
 
-                repo.Stage(filename);
+                Commands.Stage(repo, filename);
                 Assert.Null(repo.Index[filename]);
 
                 Assert.Equal(count - 1, repo.Index.Count);
@@ -145,7 +145,7 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(FileStatus.NewInWorkdir, repo.RetrieveStatus(filename));
                 Assert.Null(repo.Index[filename]);
 
-                repo.Stage(filename);
+                Commands.Stage(repo, filename);
                 Assert.NotNull(repo.Index[filename]);
                 Assert.Equal(FileStatus.NewInIndex, repo.RetrieveStatus(filename));
             }
@@ -193,7 +193,7 @@ namespace LibGit2Sharp.Tests
         {
             try
             {
-                repo.Stage(path);
+                Commands.Stage(repo, path);
                 Assert.Equal(FileStatus.NewInIndex, repo.RetrieveStatus(path));
                 repo.Index.Replace(repo.Head.Tip);
                 Assert.Equal(FileStatus.NewInWorkdir, repo.RetrieveStatus(path));
@@ -216,7 +216,7 @@ namespace LibGit2Sharp.Tests
 
                 Touch(repo.Info.WorkingDirectory, file, "With backward slash on Windows!");
 
-                repo.Stage(file);
+                Commands.Stage(repo, file);
 
                 Assert.Equal(count + 1, repo.Index.Count);
 
@@ -235,7 +235,7 @@ namespace LibGit2Sharp.Tests
             {
                 string fullPath = Touch(scd.RootedDirectoryPath, "unit_test.txt", "some contents");
 
-                Assert.Throws<ArgumentException>(() => repo.Stage(fullPath));
+                Assert.Throws<ArgumentException>(() => Commands.Stage(repo, fullPath));
             }
         }
 
@@ -245,10 +245,10 @@ namespace LibGit2Sharp.Tests
             var path = SandboxStandardTestRepoGitDir();
             using (var repo = new Repository(path))
             {
-                Assert.Throws<ArgumentException>(() => repo.Stage(string.Empty));
-                Assert.Throws<ArgumentNullException>(() => repo.Stage((string)null));
-                Assert.Throws<ArgumentException>(() => repo.Stage(new string[] { }));
-                Assert.Throws<ArgumentException>(() => repo.Stage(new string[] { null }));
+                Assert.Throws<ArgumentException>(() => Commands.Stage(repo, string.Empty));
+                Assert.Throws<ArgumentNullException>(() => Commands.Stage(repo, (string)null));
+                Assert.Throws<ArgumentException>(() => Commands.Stage(repo, new string[] { }));
+                Assert.Throws<ArgumentException>(() => Commands.Stage(repo, new string[] { null }));
             }
         }
 
@@ -284,7 +284,7 @@ namespace LibGit2Sharp.Tests
             {
                 int count = repo.Index.Count;
 
-                repo.Stage(relativePath);
+                Commands.Stage(repo, relativePath);
 
                 Assert.Equal(count + expectedIndexCountVariation, repo.Index.Count);
             }
@@ -297,7 +297,7 @@ namespace LibGit2Sharp.Tests
             {
                 int count = repo.Index.Count;
 
-                repo.Stage(new string[] { "*", "u*" });
+                Commands.Stage(repo, new string[] { "*", "u*" });
 
                 Assert.Equal(count, repo.Index.Count);  // 1 added file, 1 deleted file, so same count
             }
@@ -314,7 +314,7 @@ namespace LibGit2Sharp.Tests
                 Touch(repo.Info.WorkingDirectory, path, "This file is ignored.");
 
                 Assert.Equal(FileStatus.Ignored, repo.RetrieveStatus(path));
-                repo.Stage("*");
+                Commands.Stage(repo, "*");
                 Assert.Equal(FileStatus.Ignored, repo.RetrieveStatus(path));
             }
         }
@@ -330,7 +330,7 @@ namespace LibGit2Sharp.Tests
                 Touch(repo.Info.WorkingDirectory, path, "This file is ignored.");
 
                 Assert.Equal(FileStatus.Ignored, repo.RetrieveStatus(path));
-                repo.Stage(path, new StageOptions { IncludeIgnored = true });
+                Commands.Stage(repo, path, new StageOptions { IncludeIgnored = true });
                 Assert.Equal(FileStatus.NewInIndex, repo.RetrieveStatus(path));
             }
         }
@@ -346,7 +346,7 @@ namespace LibGit2Sharp.Tests
                 File.WriteAllText(Path.Combine(repo.Info.WorkingDirectory, ".gitignore"),
                     String.Format("{0}\n", filename));
 
-                repo.Stage(filename);
+                Commands.Stage(repo, filename);
                 Assert.Equal(expected, repo.RetrieveStatus(filename));
             }
         }
@@ -368,7 +368,7 @@ namespace LibGit2Sharp.Tests
                 File.WriteAllText(Path.Combine(repo.Info.WorkingDirectory, ".gitignore"),
                     String.Format("{0}\n", filename));
 
-                repo.Stage(filename);
+                Commands.Stage(repo, filename);
                 Assert.Equal(expected, repo.RetrieveStatus(filename));
             }
         }
@@ -385,7 +385,7 @@ namespace LibGit2Sharp.Tests
                     Touch(repo.Info.WorkingDirectory, "test.txt",
                                Guid.NewGuid().ToString());
 
-                    repo.Stage("test.txt");
+                    Commands.Stage(repo, "test.txt");
 
                     Assert.DoesNotThrow(() => repo.Commit(
                                 "Commit", Constants.Signature, Constants.Signature));

--- a/LibGit2Sharp.Tests/StashFixture.cs
+++ b/LibGit2Sharp.Tests/StashFixture.cs
@@ -139,7 +139,7 @@ namespace LibGit2Sharp.Tests
 
                 const string staged = "staged_file_path.txt";
                 Touch(repo.Info.WorkingDirectory, staged, "I'm staged\n");
-                repo.Stage(staged);
+                Commands.Stage(repo, staged);
 
                 Stash stash = repo.Stashes.Add(stasher, "Stash with default options", StashModifiers.Default);
 
@@ -165,7 +165,7 @@ namespace LibGit2Sharp.Tests
 
                 const string filename = "staged_file_path.txt";
                 Touch(repo.Info.WorkingDirectory, filename, "I'm staged\n");
-                repo.Stage(filename);
+                Commands.Stage(repo, filename);
 
                 Stash stash = repo.Stashes.Add(stasher, "This stash will keep index", StashModifiers.KeepIndex);
 
@@ -186,7 +186,7 @@ namespace LibGit2Sharp.Tests
                 const string ignoredFilename = "ignored_file.txt";
 
                 Touch(repo.Info.WorkingDirectory, gitIgnore, ignoredFilename);
-                repo.Stage(gitIgnore);
+                Commands.Stage(repo, gitIgnore);
                 repo.Commit("Modify gitignore", Constants.Signature, Constants.Signature);
 
                 Touch(repo.Info.WorkingDirectory, ignoredFilename, "I'm ignored\n");
@@ -214,7 +214,7 @@ namespace LibGit2Sharp.Tests
 
                 const string filename = "staged_file_path.txt";
                 Touch(repo.Info.WorkingDirectory, filename, "I'm staged\n");
-                repo.Stage(filename);
+                Commands.Stage(repo, filename);
 
                 repo.Stashes.Add(stasher, "This stash with default options");
                 Assert.Equal(StashApplyStatus.Applied, repo.Stashes.Apply(0));
@@ -222,7 +222,7 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(FileStatus.NewInIndex, repo.RetrieveStatus(filename));
                 Assert.Equal(1, repo.Stashes.Count());
 
-                repo.Stage(filename);
+                Commands.Stage(repo, filename);
 
                 repo.Stashes.Add(stasher, "This stash with default options");
                 Assert.Equal(StashApplyStatus.Applied, repo.Stashes.Apply(
@@ -250,7 +250,7 @@ namespace LibGit2Sharp.Tests
                 const string filename = "staged_file_path.txt";
                 const string contents = "I'm staged";
                 Touch(repo.Info.WorkingDirectory, filename, contents);
-                repo.Stage(filename);
+                Commands.Stage(repo, filename);
 
                 repo.Stashes.Add(stasher, "This stash with default options");
                 Assert.Equal(1, repo.Stashes.Count());
@@ -277,13 +277,13 @@ namespace LibGit2Sharp.Tests
                 const string newContents = "I'm post-stash.";
 
                 Touch(repo.Info.WorkingDirectory, filename, originalContents);
-                repo.Stage(filename);
+                Commands.Stage(repo, filename);
                 Touch(repo.Info.WorkingDirectory, filename2, originalContents);
 
                 repo.Stashes.Add(stasher, "This stash with default options");
 
                 Touch(repo.Info.WorkingDirectory, filename, newContents);
-                repo.Stage(filename);
+                Commands.Stage(repo, filename);
                 Touch(repo.Info.WorkingDirectory, filename2, newContents);
 
                 Assert.Equal(StashApplyStatus.UncommittedChanges, repo.Stashes.Pop(0, new StashApplyOptions
@@ -310,7 +310,7 @@ namespace LibGit2Sharp.Tests
                 const string originalContents = "I'm pre-stash.";
 
                 Touch(repo.Info.WorkingDirectory, filename, originalContents);
-                repo.Stage(filename);
+                Commands.Stage(repo, filename);
                 Touch(repo.Info.WorkingDirectory, filename2, originalContents);
 
                 repo.Stashes.Add(stasher, "This stash with default options");

--- a/LibGit2Sharp.Tests/StatusFixture.cs
+++ b/LibGit2Sharp.Tests/StatusFixture.cs
@@ -49,7 +49,7 @@ namespace LibGit2Sharp.Tests
             using (var repo = new Repository(clone))
             {
                 Touch(repo.Info.WorkingDirectory, "file.txt", "content");
-                repo.Stage("file.txt");
+                Commands.Stage(repo, "file.txt");
 
                 RepositoryStatus status = repo.RetrieveStatus(new StatusOptions() { Show = show });
                 Assert.Equal(expected, status["file.txt"].State);
@@ -161,7 +161,7 @@ namespace LibGit2Sharp.Tests
                     "This is a file with enough data to trigger similarity matching.\r\n" +
                     "This is a file with enough data to trigger similarity matching.\r\n");
 
-                repo.Stage("old_name.txt");
+                Commands.Stage(repo, "old_name.txt");
 
                 File.Move(Path.Combine(repo.Info.WorkingDirectory, "old_name.txt"),
                     Path.Combine(repo.Info.WorkingDirectory, "rename_target.txt"));
@@ -188,8 +188,8 @@ namespace LibGit2Sharp.Tests
                     Path.Combine(repo.Info.WorkingDirectory, "1.txt"),
                     Path.Combine(repo.Info.WorkingDirectory, "rename_target.txt"));
 
-                repo.Stage("1.txt");
-                repo.Stage("rename_target.txt");
+                Commands.Stage(repo, "1.txt");
+                Commands.Stage(repo, "rename_target.txt");
 
                 RepositoryStatus status = repo.RetrieveStatus();
 
@@ -210,7 +210,7 @@ namespace LibGit2Sharp.Tests
                     "This is a file with enough data to trigger similarity matching.\r\n" +
                     "This is a file with enough data to trigger similarity matching.\r\n");
 
-                repo.Stage("file.txt");
+                Commands.Stage(repo, "file.txt");
                 repo.Commit("Initial commit", Constants.Signature, Constants.Signature);
 
                 File.Move(Path.Combine(repo.Info.WorkingDirectory, "file.txt"),
@@ -227,8 +227,8 @@ namespace LibGit2Sharp.Tests
                 // This passes as expected
                 Assert.Equal(FileStatus.RenamedInWorkdir, status.Single().State);
 
-                repo.Stage("file.txt");
-                repo.Stage("renamed.txt");
+                Commands.Stage(repo, "file.txt");
+                Commands.Stage(repo, "renamed.txt");
 
                 status = repo.RetrieveStatus(opts);
 
@@ -281,7 +281,7 @@ namespace LibGit2Sharp.Tests
                 Touch(repo.Info.WorkingDirectory, relFilePath, "Anybody out there?");
 
                 // Add the file to the index
-                repo.Stage(relFilePath);
+                Commands.Stage(repo, relFilePath);
 
                 // Get the repository status
                 RepositoryStatus repoStatus = repo.RetrieveStatus();
@@ -427,7 +427,7 @@ namespace LibGit2Sharp.Tests
 
                 lowerCasedPath = Touch(repo.Info.WorkingDirectory, lowercasedFilename);
 
-                repo.Stage(lowercasedFilename);
+                Commands.Stage(repo, lowercasedFilename);
                 repo.Commit("initial", Constants.Signature, Constants.Signature);
             }
 

--- a/LibGit2Sharp.Tests/SubmoduleFixture.cs
+++ b/LibGit2Sharp.Tests/SubmoduleFixture.cs
@@ -148,7 +148,7 @@ namespace LibGit2Sharp.Tests
                 var statusBefore = submodule.RetrieveStatus();
                 Assert.Equal(SubmoduleStatus.WorkDirModified, statusBefore & SubmoduleStatus.WorkDirModified);
 
-                repo.Stage(submodulePath);
+                Commands.Stage(repo, submodulePath);
 
                 var statusAfter = submodule.RetrieveStatus();
                 Assert.Equal(SubmoduleStatus.IndexModified, statusAfter & SubmoduleStatus.IndexModified);
@@ -173,7 +173,7 @@ namespace LibGit2Sharp.Tests
 
                 Touch(repo.Info.WorkingDirectory, "new-file.txt");
 
-                repo.Stage(new[] { "new-file.txt", submodulePath, "does-not-exist.txt" });
+                Commands.Stage(repo, new[] { "new-file.txt", submodulePath, "does-not-exist.txt" });
 
                 var statusAfter = submodule.RetrieveStatus();
                 Assert.Equal(SubmoduleStatus.IndexModified, statusAfter & SubmoduleStatus.IndexModified);

--- a/LibGit2Sharp.Tests/UnstageFixture.cs
+++ b/LibGit2Sharp.Tests/UnstageFixture.cs
@@ -25,12 +25,12 @@ namespace LibGit2Sharp.Tests
                 string fullpath = Path.Combine(repo.Info.WorkingDirectory, filename);
 
                 File.AppendAllText(fullpath, "Is there there anybody out there?");
-                repo.Stage(filename);
+                Commands.Stage(repo, filename);
 
                 Assert.Equal(count, repo.Index.Count);
                 Assert.NotEqual((blobId), repo.Index[posixifiedFileName].Id);
 
-                repo.Unstage(posixifiedFileName);
+                Commands.Unstage(repo, posixifiedFileName);
 
                 Assert.Equal(count, repo.Index.Count);
                 Assert.Equal(blobId, repo.Index[posixifiedFileName].Id);
@@ -50,10 +50,10 @@ namespace LibGit2Sharp.Tests
 
                 Assert.Equal(FileStatus.Ignored, repo.RetrieveStatus(relativePath));
 
-                repo.Stage(relativePath, new StageOptions { IncludeIgnored = true });
+                Commands.Stage(repo, relativePath, new StageOptions { IncludeIgnored = true });
                 Assert.Equal(FileStatus.NewInIndex, repo.RetrieveStatus(relativePath));
 
-                repo.Unstage(relativePath);
+                Commands.Unstage(repo, relativePath);
                 Assert.Equal(FileStatus.Ignored, repo.RetrieveStatus(relativePath));
             }
         }
@@ -76,7 +76,7 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(doesCurrentlyExistInTheIndex, (repo.Index[relativePath] != null));
                 Assert.Equal(currentStatus, repo.RetrieveStatus(relativePath));
 
-                repo.Unstage(relativePath);
+                Commands.Unstage(repo, relativePath);
 
                 Assert.Equal(count + expectedIndexCountVariation, repo.Index.Count);
                 Assert.Equal(doesExistInTheIndexOnceStaged, (repo.Index[relativePath] != null));
@@ -93,7 +93,7 @@ namespace LibGit2Sharp.Tests
             {
                 Assert.Equal(currentStatus, repo.RetrieveStatus(relativePath));
 
-                Assert.Throws<UnmatchedPathException>(() => repo.Unstage(relativePath, new ExplicitPathsOptions()));
+                Assert.Throws<UnmatchedPathException>(() => Commands.Unstage(repo, relativePath, new ExplicitPathsOptions()));
             }
         }
 
@@ -106,7 +106,7 @@ namespace LibGit2Sharp.Tests
             {
                 Assert.Equal(currentStatus, repo.RetrieveStatus(relativePath));
 
-                Assert.DoesNotThrow(() => repo.Unstage(relativePath, new ExplicitPathsOptions() { ShouldFailOnUnmatchedPath = false }));
+                Assert.DoesNotThrow(() => Commands.Unstage(repo, relativePath, new ExplicitPathsOptions() { ShouldFailOnUnmatchedPath = false }));
                 Assert.Equal(currentStatus, repo.RetrieveStatus(relativePath));
             }
         }
@@ -126,7 +126,7 @@ namespace LibGit2Sharp.Tests
 
                 Assert.Equal(FileStatus.DeletedFromIndex, repo.RetrieveStatus(filename));
 
-                repo.Unstage(filename);
+                Commands.Unstage(repo, filename);
                 Assert.Equal(count + 1, repo.Index.Count);
 
                 Assert.Equal(FileStatus.DeletedFromWorkdir, repo.RetrieveStatus(filename));
@@ -143,14 +143,14 @@ namespace LibGit2Sharp.Tests
                 const string relativePath = "a.txt";
                 Touch(repo.Info.WorkingDirectory, relativePath, "hello test file\n");
 
-                repo.Stage(relativePath);
+                Commands.Stage(repo, relativePath);
 
-                repo.Unstage(relativePath);
+                Commands.Unstage(repo, relativePath);
                 RepositoryStatus status = repo.RetrieveStatus();
                 Assert.Equal(0, status.Staged.Count());
                 Assert.Equal(1, status.Untracked.Count());
 
-                Assert.Throws<UnmatchedPathException>(() => repo.Unstage("i-dont-exist", new ExplicitPathsOptions()));
+                Assert.Throws<UnmatchedPathException>(() => Commands.Unstage(repo, "i-dont-exist", new ExplicitPathsOptions()));
             }
         }
 
@@ -166,7 +166,7 @@ namespace LibGit2Sharp.Tests
 
                 Assert.Equal(currentStatus, repo.RetrieveStatus(relativePath));
 
-                Assert.Throws<UnmatchedPathException>(() => repo.Unstage(relativePath, new ExplicitPathsOptions()));
+                Assert.Throws<UnmatchedPathException>(() => Commands.Unstage(repo, relativePath, new ExplicitPathsOptions()));
             }
         }
 
@@ -182,8 +182,8 @@ namespace LibGit2Sharp.Tests
 
                 Assert.Equal(currentStatus, repo.RetrieveStatus(relativePath));
 
-                Assert.DoesNotThrow(() => repo.Unstage(relativePath));
-                Assert.DoesNotThrow(() => repo.Unstage(relativePath, new ExplicitPathsOptions { ShouldFailOnUnmatchedPath = false }));
+                Assert.DoesNotThrow(() => Commands.Unstage(repo, relativePath));
+                Assert.DoesNotThrow(() => Commands.Unstage(repo, relativePath, new ExplicitPathsOptions { ShouldFailOnUnmatchedPath = false }));
                 Assert.Equal(currentStatus, repo.RetrieveStatus(relativePath));
             }
         }
@@ -200,7 +200,7 @@ namespace LibGit2Sharp.Tests
                 const string filename = "unit_test.txt";
                 string fullPath = Touch(di.FullName, filename, "some contents");
 
-                Assert.Throws<ArgumentException>(() => repo.Unstage(fullPath));
+                Assert.Throws<ArgumentException>(() => Commands.Unstage(repo, fullPath));
             }
         }
 
@@ -218,7 +218,7 @@ namespace LibGit2Sharp.Tests
                 const string filename = "unit_test.txt";
                 string fullPath = Touch(di.FullName, filename, "some contents");
 
-                Assert.Throws<ArgumentException>(() => repo.Unstage(fullPath));
+                Assert.Throws<ArgumentException>(() => Commands.Unstage(repo, fullPath));
             }
         }
 
@@ -228,10 +228,10 @@ namespace LibGit2Sharp.Tests
             var path = SandboxStandardTestRepoGitDir();
             using (var repo = new Repository(path))
             {
-                Assert.Throws<ArgumentException>(() => repo.Unstage(string.Empty));
-                Assert.Throws<ArgumentNullException>(() => repo.Unstage((string)null));
-                Assert.Throws<ArgumentException>(() => repo.Unstage(new string[] { }));
-                Assert.Throws<ArgumentException>(() => repo.Unstage(new string[] { null }));
+                Assert.Throws<ArgumentException>(() => Commands.Unstage(repo, string.Empty));
+                Assert.Throws<ArgumentNullException>(() => Commands.Unstage(repo, (string)null));
+                Assert.Throws<ArgumentException>(() => Commands.Unstage(repo, new string[] { }));
+                Assert.Throws<ArgumentException>(() => Commands.Unstage(repo, new string[] { null }));
             }
         }
 
@@ -247,7 +247,7 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(FileStatus.Nonexistent, oldStatus["branch_file.txt"].State);
                 Assert.Equal(FileStatus.RenamedInIndex, oldStatus["renamed_branch_file.txt"].State);
 
-                repo.Unstage(new string[] { "branch_file.txt" });
+                Commands.Unstage(repo, new string[] { "branch_file.txt" });
 
                 RepositoryStatus newStatus = repo.RetrieveStatus();
                 Assert.Equal(0, newStatus.RenamedInIndex.Count());
@@ -267,7 +267,7 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(1, oldStatus.RenamedInIndex.Count());
                 Assert.Equal(FileStatus.RenamedInIndex, oldStatus["renamed_branch_file.txt"].State);
 
-                repo.Unstage(new string[] { "renamed_branch_file.txt" });
+                Commands.Unstage(repo, new string[] { "renamed_branch_file.txt" });
 
                 RepositoryStatus newStatus = repo.RetrieveStatus();
                 Assert.Equal(0, newStatus.RenamedInIndex.Count());
@@ -282,7 +282,7 @@ namespace LibGit2Sharp.Tests
             using (var repo = new Repository(SandboxStandardTestRepo()))
             {
                 repo.Move("branch_file.txt", "renamed_branch_file.txt");
-                repo.Unstage(new string[] { "branch_file.txt", "renamed_branch_file.txt" });
+                Commands.Unstage(repo, new string[] { "branch_file.txt", "renamed_branch_file.txt" });
 
                 RepositoryStatus status = repo.RetrieveStatus();
                 Assert.Equal(FileStatus.DeletedFromWorkdir, status["branch_file.txt"].State);

--- a/LibGit2Sharp.Tests/UnstageFixture.cs
+++ b/LibGit2Sharp.Tests/UnstageFixture.cs
@@ -240,7 +240,7 @@ namespace LibGit2Sharp.Tests
         {
             using (var repo = new Repository(SandboxStandardTestRepo()))
             {
-                repo.Move("branch_file.txt", "renamed_branch_file.txt");
+                Commands.Move(repo, "branch_file.txt", "renamed_branch_file.txt");
 
                 RepositoryStatus oldStatus = repo.RetrieveStatus();
                 Assert.Equal(1, oldStatus.RenamedInIndex.Count());
@@ -261,7 +261,7 @@ namespace LibGit2Sharp.Tests
         {
             using (var repo = new Repository(SandboxStandardTestRepo()))
             {
-                repo.Move("branch_file.txt", "renamed_branch_file.txt");
+                Commands.Move(repo, "branch_file.txt", "renamed_branch_file.txt");
 
                 RepositoryStatus oldStatus = repo.RetrieveStatus();
                 Assert.Equal(1, oldStatus.RenamedInIndex.Count());
@@ -281,7 +281,7 @@ namespace LibGit2Sharp.Tests
         {
             using (var repo = new Repository(SandboxStandardTestRepo()))
             {
-                repo.Move("branch_file.txt", "renamed_branch_file.txt");
+                Commands.Move(repo, "branch_file.txt", "renamed_branch_file.txt");
                 Commands.Unstage(repo, new string[] { "branch_file.txt", "renamed_branch_file.txt" });
 
                 RepositoryStatus status = repo.RetrieveStatus();

--- a/LibGit2Sharp/Commands/Remove.cs
+++ b/LibGit2Sharp/Commands/Remove.cs
@@ -1,0 +1,240 @@
+﻿using System.Linq;
+using System.IO;
+using System.Collections.Generic;
+using LibGit2Sharp;
+using LibGit2Sharp.Core;
+
+namespace LibGit2Sharp
+{
+    public static partial class Commands
+    {
+
+        /// <summary>
+        /// Removes a file from the staging area, and optionally removes it from the working directory as well.
+        /// <para>
+        ///   If the file has already been deleted from the working directory, this method will only deal
+        ///   with promoting the removal to the staging area.
+        /// </para>
+        /// <para>
+        ///   The default behavior is to remove the file from the working directory as well.
+        /// </para>
+        /// </summary>
+        /// <param name="repository">The <see cref="IRepository"/> being worked with.</param>
+        /// <param name="path">The path of the file within the working directory.</param>
+        public static void Remove(IRepository repository, string path)
+        {
+            Remove(repository, path, true, null);
+        }
+
+        /// <summary>
+        /// Removes a file from the staging area, and optionally removes it from the working directory as well.
+        /// <para>
+        ///   If the file has already been deleted from the working directory, this method will only deal
+        ///   with promoting the removal to the staging area.
+        /// </para>
+        /// <para>
+        ///   The default behavior is to remove the file from the working directory as well.
+        /// </para>
+        /// </summary>
+        /// <param name="repository">The <see cref="IRepository"/> being worked with.</param>
+        /// <param name="path">The path of the file within the working directory.</param>
+        /// <param name="removeFromWorkingDirectory">True to remove the file from the working directory, False otherwise.</param>
+        public static void Remove(IRepository repository, string path, bool removeFromWorkingDirectory)
+        {
+            Remove(repository, path, removeFromWorkingDirectory, null);
+        }
+
+
+        /// <summary>
+        /// Removes a file from the staging area, and optionally removes it from the working directory as well.
+        /// <para>
+        ///   If the file has already been deleted from the working directory, this method will only deal
+        ///   with promoting the removal to the staging area.
+        /// </para>
+        /// <para>
+        ///   The default behavior is to remove the file from the working directory as well.
+        /// </para>
+        /// <para>
+        ///   When not passing a <paramref name="explicitPathsOptions"/>, the passed path will be treated as
+        ///   a pathspec. You can for example use it to pass the relative path to a folder inside the working directory,
+        ///   so that all files beneath this folders, and the folder itself, will be removed.
+        /// </para>
+        /// </summary>
+        /// <param name="repository">The repository in which to operate</param>
+        /// <param name="path">The path of the file within the working directory.</param>
+        /// <param name="removeFromWorkingDirectory">True to remove the file from the working directory, False otherwise.</param>
+        /// <param name="explicitPathsOptions">
+        /// The passed <paramref name="path"/> will be treated as an explicit path.
+        /// Use these options to determine how unmatched explicit paths should be handled.
+        /// </param>
+        public static void Remove(IRepository repository, string path, bool removeFromWorkingDirectory, ExplicitPathsOptions explicitPathsOptions)
+        {
+            Ensure.ArgumentNotNull(repository, "repository");
+            Ensure.ArgumentNotNull(path, "path");
+
+            Remove(repository, new[] { path }, removeFromWorkingDirectory, explicitPathsOptions);
+        }
+
+        /// <summary>
+        /// Removes a collection of fileS from the staging, and optionally removes them from the working directory as well.
+        /// <para>
+        ///   If a file has already been deleted from the working directory, this method will only deal
+        ///   with promoting the removal to the staging area.
+        /// </para>
+        /// <para>
+        ///   The default behavior is to remove the files from the working directory as well.
+        /// </para>
+        /// </summary>
+        /// <param name="repository">The <see cref="IRepository"/> being worked with.</param>
+        /// <param name="paths">The collection of paths of the files within the working directory.</param>
+        public static void Remove(IRepository repository, IEnumerable<string> paths)
+        {
+            Remove(repository, paths, true, null);
+        }
+
+        /// <summary>
+        /// Removes a collection of fileS from the staging, and optionally removes them from the working directory as well.
+        /// <para>
+        ///   If a file has already been deleted from the working directory, this method will only deal
+        ///   with promoting the removal to the staging area.
+        /// </para>
+        /// <para>
+        ///   The default behavior is to remove the files from the working directory as well.
+        /// </para>
+        /// <para>
+        ///   When not passing a <paramref name="explicitPathsOptions"/>, the passed paths will be treated as
+        ///   a pathspec. You can for example use it to pass the relative paths to folders inside the working directory,
+        ///   so that all files beneath these folders, and the folders themselves, will be removed.
+        /// </para>
+        /// </summary>
+        /// <param name="repository">The repository in which to operate</param>
+        /// <param name="paths">The collection of paths of the files within the working directory.</param>
+        /// <param name="removeFromWorkingDirectory">True to remove the files from the working directory, False otherwise.</param>
+        /// <param name="explicitPathsOptions">
+        /// The passed <paramref name="paths"/> will be treated as explicit paths.
+        /// Use these options to determine how unmatched explicit paths should be handled.
+        /// </param>
+        public static void Remove(IRepository repository, IEnumerable<string> paths, bool removeFromWorkingDirectory, ExplicitPathsOptions explicitPathsOptions)
+        {
+            Ensure.ArgumentNotNull(repository, "repository");
+            Ensure.ArgumentNotNullOrEmptyEnumerable<string>(paths, "paths");
+
+            var pathsToDelete = paths.Where(p => Directory.Exists(Path.Combine(repository.Info.WorkingDirectory, p))).ToList();
+            var notConflictedPaths = new List<string>();
+            var index = repository.Index;
+
+            foreach (var path in paths)
+            {
+                Ensure.ArgumentNotNullOrEmptyString(path, "path");
+
+                var conflict = index.Conflicts[path];
+
+                if (conflict != null)
+                {
+                    index.Remove(path);
+                    pathsToDelete.Add(path);
+                }
+                else
+                {
+                    notConflictedPaths.Add(path);
+                }
+            }
+
+            // Make sure status will see the changes from before this
+            index.Write();
+
+            if (notConflictedPaths.Count > 0)
+            {
+                pathsToDelete.AddRange(RemoveStagedItems(repository, notConflictedPaths, removeFromWorkingDirectory, explicitPathsOptions));
+            }
+
+            if (removeFromWorkingDirectory)
+            {
+                RemoveFilesAndFolders(repository, pathsToDelete);
+            }
+
+            index.Write();
+        }
+
+        private static void RemoveFilesAndFolders(IRepository repository, IEnumerable<string> pathsList)
+        {
+            string wd = repository.Info.WorkingDirectory;
+
+            foreach (string path in pathsList)
+            {
+                string fileName = Path.Combine(wd, path);
+
+                if (Directory.Exists(fileName))
+                {
+                    Directory.Delete(fileName, true);
+                    continue;
+                }
+
+                if (!File.Exists(fileName))
+                {
+                    continue;
+                }
+
+                File.Delete(fileName);
+            }
+        }
+
+        private static IEnumerable<string> RemoveStagedItems(IRepository repository, IEnumerable<string> paths, bool removeFromWorkingDirectory = true, ExplicitPathsOptions explicitPathsOptions = null)
+        {
+            var removed = new List<string>();
+            var changes = repository.Diff.Compare<TreeChanges>(DiffModifiers.IncludeUnmodified | DiffModifiers.IncludeUntracked, paths, explicitPathsOptions);
+            var index = repository.Index;
+
+            foreach (var treeEntryChanges in changes)
+            {
+                var status = repository.RetrieveStatus(treeEntryChanges.Path);
+
+                switch (treeEntryChanges.Status)
+                {
+                    case ChangeKind.Added:
+                    case ChangeKind.Deleted:
+                        removed.Add(treeEntryChanges.Path);
+                        index.Remove(treeEntryChanges.Path);
+                        break;
+
+                    case ChangeKind.Unmodified:
+                        if (removeFromWorkingDirectory && (
+                            status.HasFlag(FileStatus.ModifiedInIndex) ||
+                            status.HasFlag(FileStatus.NewInIndex)))
+                        {
+                            throw new RemoveFromIndexException("Unable to remove file '{0}', as it has changes staged in the index. You can call the Remove() method with removeFromWorkingDirectory=false if you want to remove it from the index only.",
+                                treeEntryChanges.Path);
+                        }
+                        removed.Add(treeEntryChanges.Path);
+                        index.Remove(treeEntryChanges.Path);
+                        continue;
+
+                    case ChangeKind.Modified:
+                        if (status.HasFlag(FileStatus.ModifiedInWorkdir) && status.HasFlag(FileStatus.ModifiedInIndex))
+                        {
+                            throw new RemoveFromIndexException("Unable to remove file '{0}', as it has staged content different from both the working directory and the HEAD.",
+                                treeEntryChanges.Path);
+                        }
+                        if (removeFromWorkingDirectory)
+                        {
+                            throw new RemoveFromIndexException("Unable to remove file '{0}', as it has local modifications. You can call the Remove() method with removeFromWorkingDirectory=false if you want to remove it from the index only.",
+                                treeEntryChanges.Path);
+                        }
+                        removed.Add(treeEntryChanges.Path);
+                        index.Remove(treeEntryChanges.Path);
+                        continue;
+
+                    default:
+                        throw new RemoveFromIndexException("Unable to remove file '{0}'. Its current status is '{1}'.",
+                            treeEntryChanges.Path,
+                            treeEntryChanges.Status);
+                }
+            }
+
+            index.Write();
+
+            return removed;
+        }
+    }
+}
+

--- a/LibGit2Sharp/Commands/Stage.cs
+++ b/LibGit2Sharp/Commands/Stage.cs
@@ -1,0 +1,204 @@
+﻿using System;
+using System.Linq;
+using System.Globalization;
+using System.Collections.Generic;
+using LibGit2Sharp;
+using LibGit2Sharp.Core;
+
+namespace LibGit2Sharp
+{
+    public static partial class Commands
+    {
+        /// <summary>
+        /// Promotes to the staging area the latest modifications of a file in the working directory (addition, updation or removal).
+        ///
+        /// If this path is ignored by configuration then it will not be staged unless <see cref="StageOptions.IncludeIgnored"/> is unset.
+        /// </summary>
+        /// <param name="repository">The repository in which to act</param>
+        /// <param name="path">The path of the file within the working directory.</param>
+        public static void Stage(IRepository repository, string path)
+        {
+            Ensure.ArgumentNotNull(repository, "repository");
+            Ensure.ArgumentNotNull(path, "path");
+
+            Stage(repository, new[] { path }, null);
+        }
+
+        /// <summary>
+        /// Promotes to the staging area the latest modifications of a file in the working directory (addition, updation or removal).
+        ///
+        /// If this path is ignored by configuration then it will not be staged unless <see cref="StageOptions.IncludeIgnored"/> is unset.
+        /// </summary>
+        /// <param name="repository">The repository in which to act</param>
+        /// <param name="path">The path of the file within the working directory.</param>
+        /// <param name="stageOptions">Determines how paths will be staged.</param>
+        public static void Stage(IRepository repository, string path, StageOptions stageOptions)
+        {
+            Ensure.ArgumentNotNull(repository, "repository");
+            Ensure.ArgumentNotNull(path, "path");
+
+            Stage(repository, new[] { path }, stageOptions);
+        }
+
+        /// <summary>
+        /// Promotes to the staging area the latest modifications of a collection of files in the working directory (addition, updation or removal).
+        ///
+        /// Any paths (even those listed explicitly) that are ignored by configuration will not be staged unless <see cref="StageOptions.IncludeIgnored"/> is unset.
+        /// </summary>
+        /// <param name="repository">The repository in which to act</param>
+        /// <param name="paths">The collection of paths of the files within the working directory.</param>
+        public static void Stage(IRepository repository, IEnumerable<string> paths)
+        {
+            Stage(repository, paths, null);
+        }
+
+        /// <summary>
+        /// Promotes to the staging area the latest modifications of a collection of files in the working directory (addition, updation or removal).
+        ///
+        /// Any paths (even those listed explicitly) that are ignored by configuration will not be staged unless <see cref="StageOptions.IncludeIgnored"/> is unset.
+        /// </summary>
+        /// <param name="repository">The repository in which to act</param>
+        /// <param name="paths">The collection of paths of the files within the working directory.</param>
+        /// <param name="stageOptions">Determines how paths will be staged.</param>
+        public static void Stage(IRepository repository, IEnumerable<string> paths, StageOptions stageOptions)
+        {
+            Ensure.ArgumentNotNull(repository, "repository");
+            Ensure.ArgumentNotNull(paths, "paths");
+
+            DiffModifiers diffModifiers = DiffModifiers.IncludeUntracked;
+            ExplicitPathsOptions explicitPathsOptions = stageOptions != null ? stageOptions.ExplicitPathsOptions : null;
+
+            if (stageOptions != null && stageOptions.IncludeIgnored)
+            {
+                diffModifiers |= DiffModifiers.IncludeIgnored;
+            }
+
+            var changes = repository.Diff.Compare<TreeChanges>(diffModifiers, paths, explicitPathsOptions,
+                new CompareOptions { Similarity = SimilarityOptions.None });
+
+            var unexpectedTypesOfChanges = changes
+                .Where(
+                    tec => tec.Status != ChangeKind.Added &&
+                    tec.Status != ChangeKind.Modified &&
+                    tec.Status != ChangeKind.Conflicted &&
+                    tec.Status != ChangeKind.Unmodified &&
+                    tec.Status != ChangeKind.Deleted).ToList();
+
+            if (unexpectedTypesOfChanges.Count > 0)
+            {
+                throw new InvalidOperationException(
+                    string.Format(CultureInfo.InvariantCulture,
+                        "Entry '{0}' bears an unexpected ChangeKind '{1}'",
+                        unexpectedTypesOfChanges[0].Path, unexpectedTypesOfChanges[0].Status));
+            }
+
+            /* Remove files from the index that don't exist on disk */
+            foreach (TreeEntryChanges treeEntryChanges in changes)
+            {
+                switch (treeEntryChanges.Status)
+                {
+                    case ChangeKind.Conflicted:
+                        if (!treeEntryChanges.Exists)
+                        {
+                            repository.Index.Remove(treeEntryChanges.Path);
+                        }
+                        break;
+
+                    case ChangeKind.Deleted:
+                        repository.Index.Remove(treeEntryChanges.Path);
+                        break;
+
+                    default:
+                        continue;
+                }
+            }
+
+            foreach (TreeEntryChanges treeEntryChanges in changes)
+            {
+                switch (treeEntryChanges.Status)
+                {
+                    case ChangeKind.Added:
+                    case ChangeKind.Modified:
+                        repository.Index.Add(treeEntryChanges.Path);
+                        break;
+
+                    case ChangeKind.Conflicted:
+                        if (treeEntryChanges.Exists)
+                        {
+                            repository.Index.Add(treeEntryChanges.Path);
+                        }
+                        break;
+
+                    default:
+                        continue;
+                }
+            }
+
+            repository.Index.Write();
+        }
+
+        /// <summary>
+        /// Removes from the staging area all the modifications of a file since the latest commit (addition, updation or removal).
+        /// </summary>
+        /// <param name="repository">The repository in which to act</param>
+        /// <param name="path">The path of the file within the working directory.</param>
+        public static void Unstage(IRepository repository, string path)
+        {
+            Unstage(repository, path, null);
+        }
+
+        /// <summary>
+        /// Removes from the staging area all the modifications of a file since the latest commit (addition, updation or removal).
+        /// </summary>
+        /// <param name="repository">The repository in which to act</param>
+        /// <param name="path">The path of the file within the working directory.</param>
+        /// <param name="explicitPathsOptions">
+        /// The passed <paramref name="path"/> will be treated as explicit paths.
+        /// Use these options to determine how unmatched explicit paths should be handled.
+        /// </param>
+        public static void Unstage(IRepository repository, string path, ExplicitPathsOptions explicitPathsOptions)
+        {
+            Ensure.ArgumentNotNull(repository, "repository");
+            Ensure.ArgumentNotNull(path, "path");
+
+            Unstage(repository, new[] { path }, explicitPathsOptions);
+        }
+
+        /// <summary>
+        /// Removes from the staging area all the modifications of a collection of file since the latest commit (addition, updation or removal).
+        /// </summary>
+        /// <param name="repository">The repository in which to act</param>
+        /// <param name="paths">The collection of paths of the files within the working directory.</param>
+        public static void Unstage(IRepository repository, IEnumerable<string> paths)
+        {
+            Unstage(repository, paths, null);
+        }
+
+        /// <summary>
+        /// Removes from the staging area all the modifications of a collection of file since the latest commit (addition, updation or removal).
+        /// </summary>
+        /// <param name="repository">The repository in which to act</param>
+        /// <param name="paths">The collection of paths of the files within the working directory.</param>
+        /// <param name="explicitPathsOptions">
+        /// The passed <paramref name="paths"/> will be treated as explicit paths.
+        /// Use these options to determine how unmatched explicit paths should be handled.
+        /// </param>
+        public static void Unstage(IRepository repository, IEnumerable<string> paths, ExplicitPathsOptions explicitPathsOptions)
+        {
+            Ensure.ArgumentNotNull(repository, "repository");
+            Ensure.ArgumentNotNull(paths, "paths");
+
+            if (repository.Info.IsHeadUnborn)
+            {
+                var changes = repository.Diff.Compare<TreeChanges>(null, DiffTargets.Index, paths, explicitPathsOptions, new CompareOptions { Similarity = SimilarityOptions.None });
+
+                repository.Index.Replace(changes);
+            }
+            else
+            {
+                repository.Index.Replace(repository.Head.Tip, paths, explicitPathsOptions);
+            }
+        }
+    }
+}
+

--- a/LibGit2Sharp/IRepository.cs
+++ b/LibGit2Sharp/IRepository.cs
@@ -341,6 +341,7 @@ namespace LibGit2Sharp
         /// The passed <paramref name="path"/> will be treated as an explicit path.
         /// Use these options to determine how unmatched explicit paths should be handled.
         /// </param>
+        [Obsolete("This method is deprecated. Please use LibGit2Sharp.Commands.Remove()")]
         void Remove(string path, bool removeFromWorkingDirectory, ExplicitPathsOptions explicitPathsOptions);
 
         /// <summary>
@@ -364,6 +365,7 @@ namespace LibGit2Sharp
         /// The passed <paramref name="paths"/> will be treated as explicit paths.
         /// Use these options to determine how unmatched explicit paths should be handled.
         /// </param>
+        [Obsolete("This method is deprecated. Please use LibGit2Sharp.Commands.Unstage()")]
         void Remove(IEnumerable<string> paths, bool removeFromWorkingDirectory, ExplicitPathsOptions explicitPathsOptions);
 
         /// <summary>

--- a/LibGit2Sharp/IRepository.cs
+++ b/LibGit2Sharp/IRepository.cs
@@ -271,6 +271,7 @@ namespace LibGit2Sharp
         /// </summary>
         /// <param name="path">The path of the file within the working directory.</param>
         /// <param name="stageOptions">Determines how paths will be staged.</param>
+        [Obsolete("This method is deprecated. Please use LibGit2Sharp.Commands.Stage()")]
         void Stage(string path, StageOptions stageOptions);
 
         /// <summary>
@@ -280,6 +281,7 @@ namespace LibGit2Sharp
         /// </summary>
         /// <param name="paths">The collection of paths of the files within the working directory.</param>
         /// <param name="stageOptions">Determines how paths will be staged.</param>
+        [Obsolete("This method is deprecated. Please use LibGit2Sharp.Commands.Stage()")]
         void Stage(IEnumerable<string> paths, StageOptions stageOptions);
 
         /// <summary>
@@ -290,6 +292,7 @@ namespace LibGit2Sharp
         /// The passed <paramref name="path"/> will be treated as explicit paths.
         /// Use these options to determine how unmatched explicit paths should be handled.
         /// </param>
+        [Obsolete("This method is deprecated. Please use LibGit2Sharp.Commands.Unstage()")]
         void Unstage(string path, ExplicitPathsOptions explicitPathsOptions);
 
         /// <summary>
@@ -300,6 +303,7 @@ namespace LibGit2Sharp
         /// The passed <paramref name="paths"/> will be treated as explicit paths.
         /// Use these options to determine how unmatched explicit paths should be handled.
         /// </param>
+        [Obsolete("This method is deprecated. Please use LibGit2Sharp.Commands.Unstage()")]
         void Unstage(IEnumerable<string> paths, ExplicitPathsOptions explicitPathsOptions);
 
         /// <summary>

--- a/LibGit2Sharp/IRepository.cs
+++ b/LibGit2Sharp/IRepository.cs
@@ -311,6 +311,7 @@ namespace LibGit2Sharp
         /// </summary>
         /// <param name="sourcePath">The path of the file within the working directory which has to be moved/renamed.</param>
         /// <param name="destinationPath">The target path of the file within the working directory.</param>
+        [Obsolete("This method is deprecatd. Please use LibGit2Sharp.Commands.Move()")]
         void Move(string sourcePath, string destinationPath);
 
         /// <summary>
@@ -318,6 +319,7 @@ namespace LibGit2Sharp
         /// </summary>
         /// <param name="sourcePaths">The paths of the files within the working directory which have to be moved/renamed.</param>
         /// <param name="destinationPaths">The target paths of the files within the working directory.</param>
+        [Obsolete("This method is deprecatd. Please use LibGit2Sharp.Commands.Move()")]
         void Move(IEnumerable<string> sourcePaths, IEnumerable<string> destinationPaths);
 
         /// <summary>

--- a/LibGit2Sharp/Index.cs
+++ b/LibGit2Sharp/Index.cs
@@ -139,8 +139,6 @@ namespace LibGit2Sharp
             {
                 Proxy.git_index_read_fromtree(this, obj.ObjectPtr);
             }
-
-            UpdatePhysicalIndex();
         }
 
         /// <summary>
@@ -153,7 +151,6 @@ namespace LibGit2Sharp
         public virtual void Clear()
         {
             Proxy.git_index_clear(this);
-            UpdatePhysicalIndex();
         }
 
         private void RemoveFromIndex(string relativePath)
@@ -167,14 +164,8 @@ namespace LibGit2Sharp
         /// <param name="indexEntryPath">The path of the <see cref="Index"/> entry to be removed.</param>
         public virtual void Remove(string indexEntryPath)
         {
-            if (indexEntryPath == null)
-            {
-                throw new ArgumentNullException("indexEntryPath");
-            }
-
+            Ensure.ArgumentNotNull(indexEntryPath, "indexEntryPath");
             RemoveFromIndex(indexEntryPath);
-
-            UpdatePhysicalIndex();
         }
 
         /// <summary>
@@ -187,14 +178,8 @@ namespace LibGit2Sharp
         /// <param name="pathInTheWorkdir">The path, in the working directory, of the file to be added.</param>
         public virtual void Add(string pathInTheWorkdir)
         {
-            if (pathInTheWorkdir == null)
-            {
-                throw new ArgumentNullException("pathInTheWorkdir");
-            }
-
+            Ensure.ArgumentNotNull(pathInTheWorkdir, "pathInTheWorkdir");
             Proxy.git_index_add_bypath(handle, pathInTheWorkdir);
-
-            UpdatePhysicalIndex();
         }
 
         /// <summary>
@@ -211,25 +196,9 @@ namespace LibGit2Sharp
         public virtual void Add(Blob blob, string indexEntryPath, Mode indexEntryMode)
         {
             Ensure.ArgumentConformsTo(indexEntryMode, m => m.HasAny(TreeEntryDefinition.BlobModes), "indexEntryMode");
-
-            if (blob == null)
-            {
-                throw new ArgumentNullException("blob");
-            }
-
-            if (indexEntryPath == null)
-            {
-                throw new ArgumentNullException("indexEntryPath");
-            }
-
+            Ensure.ArgumentNotNull(blob, "blob");
+            Ensure.ArgumentNotNull(indexEntryPath, "indexEntryPath");
             AddEntryToTheIndex(indexEntryPath, blob.Id, indexEntryMode);
-
-            UpdatePhysicalIndex();
-        }
-
-        private void UpdatePhysicalIndex()
-        {
-            Proxy.git_index_write(handle);
         }
 
         internal void Replace(TreeChanges changes)
@@ -259,8 +228,6 @@ namespace LibGit2Sharp
                                                                           treeEntryChanges.Status));
                 }
             }
-
-            UpdatePhysicalIndex();
         }
 
         /// <summary>
@@ -327,6 +294,14 @@ namespace LibGit2Sharp
 
             var changes = repo.Diff.Compare<TreeChanges>(commit.Tree, DiffTargets.Index, paths, explicitPathsOptions, new CompareOptions { Similarity = SimilarityOptions.None });
             Replace(changes);
+        }
+
+        /// <summary>
+        /// Write the contents of this <see cref="Index"/> to disk
+        /// </summary>
+        public virtual void Write()
+        {
+            Proxy.git_index_write(handle);
         }
     }
 }

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -353,6 +353,7 @@
     <Compile Include="Commands\Pull.cs" />
     <Compile Include="Commands\Fetch.cs" />
     <Compile Include="Commands\Stage.cs" />
+    <Compile Include="Commands\Remove.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="CustomDictionary.xml" />

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\LibGit2Sharp.NativeBinaries.1.0.132\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.132\build\LibGit2Sharp.NativeBinaries.props')" />
   <PropertyGroup>
@@ -352,6 +352,7 @@
     <Compile Include="Core\GitCredentialUserpass.cs" />
     <Compile Include="Commands\Pull.cs" />
     <Compile Include="Commands\Fetch.cs" />
+    <Compile Include="Commands\Stage.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="CustomDictionary.xml" />

--- a/LibGit2Sharp/Repository.cs
+++ b/LibGit2Sharp/Repository.cs
@@ -1644,11 +1644,6 @@ namespace LibGit2Sharp
             get { return pathCase.Value.Comparer; }
         }
 
-        internal bool PathStartsWith(string path, string value)
-        {
-            return pathCase.Value.StartsWith(path, value);
-        }
-
         internal FilePath[] ToFilePaths(IEnumerable<string> paths)
         {
             if (paths == null)
@@ -1735,9 +1730,10 @@ namespace LibGit2Sharp
         /// </summary>
         /// <param name="sourcePath">The path of the file within the working directory which has to be moved/renamed.</param>
         /// <param name="destinationPath">The target path of the file within the working directory.</param>
+        [Obsolete("This method is deprecatd. Please use LibGit2Sharp.Commands.Move()")]
         public void Move(string sourcePath, string destinationPath)
         {
-            Move(new[] { sourcePath }, new[] { destinationPath });
+            Commands.Move(this, sourcePath, destinationPath);
         }
 
          /// <summary>
@@ -1745,66 +1741,10 @@ namespace LibGit2Sharp
         /// </summary>
         /// <param name="sourcePaths">The paths of the files within the working directory which have to be moved/renamed.</param>
         /// <param name="destinationPaths">The target paths of the files within the working directory.</param>
+        [Obsolete("This method is deprecatd. Please use LibGit2Sharp.Commands.Move()")]
         public void Move(IEnumerable<string> sourcePaths, IEnumerable<string> destinationPaths)
         {
-            Ensure.ArgumentNotNull(sourcePaths, "sourcePaths");
-            Ensure.ArgumentNotNull(destinationPaths, "destinationPaths");
-
-            //TODO: Move() should support following use cases:
-            // - Moving a file under a directory ('file' and 'dir' -> 'dir/file')
-            // - Moving a directory (and its content) under another directory ('dir1' and 'dir2' -> 'dir2/dir1/*')
-
-            //TODO: Move() should throw when:
-            // - Moving a directory under a file
-
-            IDictionary<Tuple<string, FileStatus>, Tuple<string, FileStatus>> batch = PrepareBatch(sourcePaths, destinationPaths);
-
-            if (batch.Count == 0)
-            {
-                throw new ArgumentNullException("sourcePaths");
-            }
-
-            foreach (KeyValuePair<Tuple<string, FileStatus>, Tuple<string, FileStatus>> keyValuePair in batch)
-            {
-                string sourcePath = keyValuePair.Key.Item1;
-                string destPath = keyValuePair.Value.Item1;
-
-                if (Directory.Exists(sourcePath) || Directory.Exists(destPath))
-                {
-                    throw new NotImplementedException();
-                }
-
-                FileStatus sourceStatus = keyValuePair.Key.Item2;
-                if (sourceStatus.HasAny(new Enum[] { FileStatus.Nonexistent, FileStatus.DeletedFromIndex, FileStatus.NewInWorkdir, FileStatus.DeletedFromWorkdir }))
-                {
-                    throw new LibGit2SharpException("Unable to move file '{0}'. Its current status is '{1}'.",
-                                                    sourcePath,
-                                                    sourceStatus);
-                }
-
-                FileStatus desStatus = keyValuePair.Value.Item2;
-                if (desStatus.HasAny(new Enum[] { FileStatus.Nonexistent, FileStatus.DeletedFromWorkdir }))
-                {
-                    continue;
-                }
-
-                throw new LibGit2SharpException("Unable to overwrite file '{0}'. Its current status is '{1}'.",
-                                                destPath,
-                                                desStatus);
-            }
-
-            string wd = Info.WorkingDirectory;
-            foreach (KeyValuePair<Tuple<string, FileStatus>, Tuple<string, FileStatus>> keyValuePair in batch)
-            {
-                string from = keyValuePair.Key.Item1;
-                string to = keyValuePair.Value.Item1;
-
-                RemoveFromIndex(from);
-                File.Move(Path.Combine(wd, from), Path.Combine(wd, to));
-                AddToIndex(to);
-            }
-
-            UpdatePhysicalIndex();
+            Commands.Move(this, sourcePaths, destinationPaths);
         }
 
         /// <summary>
@@ -1910,42 +1850,6 @@ namespace LibGit2Sharp
         internal void UpdatePhysicalIndex()
         {
             Proxy.git_index_write(Index.Handle);
-        }
-
-        private Tuple<string, FileStatus> BuildFrom(string path)
-        {
-            string relativePath = this.BuildRelativePathFrom(path);
-            return new Tuple<string, FileStatus>(relativePath, RetrieveStatus(relativePath));
-        }
-
-        private static bool Enumerate(IEnumerator<string> leftEnum, IEnumerator<string> rightEnum)
-        {
-            bool isLeftEoF = leftEnum.MoveNext();
-            bool isRightEoF = rightEnum.MoveNext();
-
-            if (isLeftEoF == isRightEoF)
-            {
-                return isLeftEoF;
-            }
-
-            throw new ArgumentException("The collection of paths are of different lengths.");
-        }
-
-        private IDictionary<Tuple<string, FileStatus>, Tuple<string, FileStatus>> PrepareBatch(IEnumerable<string> leftPaths, IEnumerable<string> rightPaths)
-        {
-            IDictionary<Tuple<string, FileStatus>, Tuple<string, FileStatus>> dic = new Dictionary<Tuple<string, FileStatus>, Tuple<string, FileStatus>>();
-
-            IEnumerator<string> leftEnum = leftPaths.GetEnumerator();
-            IEnumerator<string> rightEnum = rightPaths.GetEnumerator();
-
-            while (Enumerate(leftEnum, rightEnum))
-            {
-                Tuple<string, FileStatus> from = BuildFrom(leftEnum.Current);
-                Tuple<string, FileStatus> to = BuildFrom(rightEnum.Current);
-                dic.Add(from, to);
-            }
-
-            return dic;
         }
 
         /// <summary>

--- a/LibGit2Sharp/RepositoryExtensions.cs
+++ b/LibGit2Sharp/RepositoryExtensions.cs
@@ -560,6 +560,7 @@ namespace LibGit2Sharp
         /// </summary>
         /// <param name="repository">The <see cref="IRepository"/> being worked with.</param>
         /// <param name="path">The path of the file within the working directory.</param>
+        [Obsolete("This method is deprecated. Please use LibGit2Sharp.Commands.Stage()")]
         public static void Stage(this IRepository repository, string path)
         {
             repository.Stage(path, null);
@@ -570,6 +571,7 @@ namespace LibGit2Sharp
         /// </summary>
         /// <param name="repository">The <see cref="IRepository"/> being worked with.</param>
         /// <param name="paths">The collection of paths of the files within the working directory.</param>
+        [Obsolete("This method is deprecated. Please use LibGit2Sharp.Commands.Stage()")]
         public static void Stage(this IRepository repository, IEnumerable<string> paths)
         {
             repository.Stage(paths, null);
@@ -580,6 +582,7 @@ namespace LibGit2Sharp
         /// </summary>
         /// <param name="repository">The <see cref="IRepository"/> being worked with.</param>
         /// <param name="path">The path of the file within the working directory.</param>
+        [Obsolete("This method is deprecated. Please use LibGit2Sharp.Commands.Unstage()")]
         public static void Unstage(this IRepository repository, string path)
         {
             repository.Unstage(path, null);
@@ -590,6 +593,7 @@ namespace LibGit2Sharp
         /// </summary>
         /// <param name="repository">The <see cref="IRepository"/> being worked with.</param>
         /// <param name="paths">The collection of paths of the files within the working directory.</param>
+        [Obsolete("This method is deprecated. Please use LibGit2Sharp.Commands.Unstage()")]
         public static void Unstage(this IRepository repository, IEnumerable<string> paths)
         {
             repository.Unstage(paths, null);

--- a/LibGit2Sharp/RepositoryExtensions.cs
+++ b/LibGit2Sharp/RepositoryExtensions.cs
@@ -611,9 +611,10 @@ namespace LibGit2Sharp
         /// </summary>
         /// <param name="repository">The <see cref="IRepository"/> being worked with.</param>
         /// <param name="path">The path of the file within the working directory.</param>
+        [Obsolete("This method is deprecated. Please use LibGit2Sharp.Commands.Remove")]
         public static void Remove(this IRepository repository, string path)
         {
-            repository.Remove(path, true, null);
+            Commands.Remove(repository, path, true, null);
         }
 
         /// <summary>
@@ -629,9 +630,10 @@ namespace LibGit2Sharp
         /// <param name="repository">The <see cref="IRepository"/> being worked with.</param>
         /// <param name="path">The path of the file within the working directory.</param>
         /// <param name="removeFromWorkingDirectory">True to remove the file from the working directory, False otherwise.</param>
+        [Obsolete("This method is deprecated. Please use LibGit2Sharp.Commands.Remove")]
         public static void Remove(this IRepository repository, string path, bool removeFromWorkingDirectory)
         {
-            repository.Remove(path, removeFromWorkingDirectory, null);
+            Commands.Remove(repository, path, removeFromWorkingDirectory, null);
         }
 
         /// <summary>
@@ -646,9 +648,10 @@ namespace LibGit2Sharp
         /// </summary>
         /// <param name="repository">The <see cref="IRepository"/> being worked with.</param>
         /// <param name="paths">The collection of paths of the files within the working directory.</param>
+        [Obsolete("This method is deprecated. Please use LibGit2Sharp.Commands.Remove")]
         public static void Remove(this IRepository repository, IEnumerable<string> paths)
         {
-            repository.Remove(paths, true, null);
+            Commands.Remove(repository, paths, true, null);
         }
 
         /// <summary>
@@ -664,6 +667,7 @@ namespace LibGit2Sharp
         /// <param name="repository">The <see cref="IRepository"/> being worked with.</param>
         /// <param name="paths">The collection of paths of the files within the working directory.</param>
         /// <param name="removeFromWorkingDirectory">True to remove the files from the working directory, False otherwise.</param>
+        [Obsolete("This method is deprecated. Please use LibGit2Sharp.Commands.Remove")]
         public static void Remove(this IRepository repository, IEnumerable<string> paths, bool removeFromWorkingDirectory)
         {
             repository.Remove(paths, removeFromWorkingDirectory, null);

--- a/LibGit2Sharp/RepositoryExtensions.cs
+++ b/LibGit2Sharp/RepositoryExtensions.cs
@@ -272,7 +272,7 @@ namespace LibGit2Sharp
             return repository.Checkout(commit, options);
         }
 
-        internal static string BuildRelativePathFrom(this Repository repo, string path)
+        internal static string BuildRelativePathFrom(this IRepository repo, string path)
         {
             //TODO: To be removed when libgit2 natively implements this
             if (!Path.IsPathRooted(path))
@@ -282,7 +282,7 @@ namespace LibGit2Sharp
 
             string normalizedPath = Path.GetFullPath(path);
 
-            if (!repo.PathStartsWith(normalizedPath, repo.Info.WorkingDirectory))
+            if (!PathStartsWith(repo, normalizedPath, repo.Info.WorkingDirectory))
             {
                 throw new ArgumentException(string.Format(CultureInfo.InvariantCulture,
                                                           "Unable to process file '{0}'. This file is not located under the working directory of the repository ('{1}').",
@@ -291,6 +291,12 @@ namespace LibGit2Sharp
             }
 
             return normalizedPath.Substring(repo.Info.WorkingDirectory.Length);
+        }
+
+        internal static bool PathStartsWith(IRepository repository, string path, string value)
+        {
+            var pathCase = new PathCase(repository);
+            return pathCase.StartsWith(path, value);
         }
 
         private static ObjectId DereferenceToCommit(Repository repo, string identifier)


### PR DESCRIPTION
Similarly to the other PRs, let's move away from having these in the repository. Making this external also means it'll work for more situations than it used to since now it expects to work against an `IRepository` instead of from inside a `Repository`.

This also has us make the `Index` not write itself to disk on every single operation, so we end up doing less I/O while we build up the index we do want to keep.

I think this would be something you use @niik so do you have thoughts?