### PR TITLE
Move some versions of Checkout to Commands

### DIFF
--- a/LibGit2Sharp.Tests/BranchFixture.cs
+++ b/LibGit2Sharp.Tests/BranchFixture.cs
@@ -121,7 +121,7 @@ namespace LibGit2Sharp.Tests
             {
                 EnableRefLog(repo);
 
-                repo.Checkout(headCommitOrBranchSpec);
+                Commands.Checkout(repo, headCommitOrBranchSpec);
 
                 const string name = "unit_test";
 
@@ -154,7 +154,7 @@ namespace LibGit2Sharp.Tests
             {
                 EnableRefLog(repo);
 
-                repo.Checkout(headCommitOrBranchSpec);
+                Commands.Checkout(repo, headCommitOrBranchSpec);
 
                 const string name = "unit_test";
 
@@ -1092,7 +1092,7 @@ namespace LibGit2Sharp.Tests
                 repo.RemoveUntrackedFiles();
 
                 string headSha = repo.Head.Tip.Sha;
-                repo.Checkout(headSha);
+                Commands.Checkout(repo, headSha);
 
                 Assert.False(repo.Head.IsTracking);
                 Assert.Null(repo.Head.TrackedBranch);

--- a/LibGit2Sharp.Tests/CheckoutFixture.cs
+++ b/LibGit2Sharp.Tests/CheckoutFixture.cs
@@ -34,7 +34,7 @@ namespace LibGit2Sharp.Tests
                 Assert.NotNull(branch);
                 AssertBelongsToARepository(repo, branch);
 
-                Branch test = repo.Checkout(branch);
+                Branch test = Commands.Checkout(repo, branch);
                 Assert.False(repo.Info.IsHeadDetached);
                 AssertBelongsToARepository(repo, test);
 
@@ -73,7 +73,7 @@ namespace LibGit2Sharp.Tests
 
                 Assert.False(repo.RetrieveStatus().IsDirty);
 
-                Branch test = repo.Checkout(branchName);
+                Branch test = Commands.Checkout(repo, branchName);
                 Assert.False(repo.Info.IsHeadDetached);
 
                 Assert.False(test.IsRemote);
@@ -118,7 +118,7 @@ namespace LibGit2Sharp.Tests
                 var commit = repo.Lookup<Commit>(commitPointer);
                 AssertBelongsToARepository(repo, commit);
 
-                Branch detachedHead = checkoutByCommitOrBranchSpec ? repo.Checkout(commitPointer) : repo.Checkout(commit);
+                Branch detachedHead = checkoutByCommitOrBranchSpec ? Commands.Checkout(repo, commitPointer) : Commands.Checkout(repo, commit);
 
                 Assert.Equal(repo.Head, detachedHead);
                 Assert.Equal(commit.Sha, detachedHead.Tip.Sha);
@@ -162,7 +162,7 @@ namespace LibGit2Sharp.Tests
                 // Checkout other_branch
                 Branch otherBranch = repo.Branches[otherBranchName];
                 Assert.NotNull(otherBranch);
-                repo.Checkout(otherBranch);
+                Commands.Checkout(repo, otherBranch);
 
                 // Verify working directory is updated
                 Assert.False(repo.RetrieveStatus().IsDirty);
@@ -190,7 +190,7 @@ namespace LibGit2Sharp.Tests
                 // Checkout other_branch
                 Branch otherBranch = repo.Branches[otherBranchName];
                 Assert.NotNull(otherBranch);
-                repo.Checkout(otherBranch);
+                Commands.Checkout(repo, otherBranch);
 
                 // Verify working directory is updated
                 Assert.False(repo.RetrieveStatus().IsDirty);
@@ -218,7 +218,7 @@ namespace LibGit2Sharp.Tests
                 // Checkout other_branch
                 Branch otherBranch = repo.Branches[otherBranchName];
                 Assert.NotNull(otherBranch);
-                repo.Checkout(otherBranch);
+                Commands.Checkout(repo, otherBranch);
 
                 // Verify working directory is updated
                 Assert.False(repo.RetrieveStatus().IsDirty);
@@ -258,7 +258,7 @@ namespace LibGit2Sharp.Tests
                 repo.Commit("change in master", Constants.Signature, Constants.Signature);
 
                 // Checkout otherBranch.
-                repo.Checkout(otherBranchName);
+                Commands.Checkout(repo, otherBranchName);
 
                 // Add change to otherBranch.
                 Touch(repo.Info.WorkingDirectory, originalFilePath, alternateFileContent);
@@ -266,10 +266,10 @@ namespace LibGit2Sharp.Tests
 
                 // Assert that normal checkout throws exception
                 // for the conflict.
-                Assert.Throws<CheckoutConflictException>(() => repo.Checkout(master.CanonicalName));
+                Assert.Throws<CheckoutConflictException>(() => Commands.Checkout(repo, master.CanonicalName));
 
                 // Checkout with force option should succeed.
-                repo.Checkout(master.CanonicalName, new CheckoutOptions() { CheckoutModifiers = CheckoutModifiers.Force});
+                Commands.Checkout(repo, master.CanonicalName, new CheckoutOptions() { CheckoutModifiers = CheckoutModifiers.Force});
 
                 // Assert that master branch is checked out.
                 Assert.True(repo.Branches["master"].IsCurrentRepositoryHead);
@@ -299,16 +299,16 @@ namespace LibGit2Sharp.Tests
                 repo.Commit("2nd commit", Constants.Signature, Constants.Signature);
 
                 // Checkout branch2
-                repo.Checkout("branch2");
+                Commands.Checkout(repo, "branch2");
                 Touch(repo.Info.WorkingDirectory, originalFilePath, "Hello From branch2!\n");
 
                 // Assert that checking out master throws
                 // when there are unstaged commits
-                Assert.Throws<CheckoutConflictException>(() => repo.Checkout("master"));
+                Assert.Throws<CheckoutConflictException>(() => Commands.Checkout(repo, "master"));
 
                 // And when there are staged commits
                 Commands.Stage(repo, originalFilePath);
-                Assert.Throws<CheckoutConflictException>(() => repo.Checkout("master"));
+                Assert.Throws<CheckoutConflictException>(() => Commands.Checkout(repo, "master"));
             }
         }
 
@@ -334,7 +334,7 @@ namespace LibGit2Sharp.Tests
                 repo.Commit("2nd commit", Constants.Signature, Constants.Signature);
 
                 // Checkout branch2
-                repo.Checkout("branch2");
+                Commands.Checkout(repo, "branch2");
 
                 // Update the context of a.txt - a.txt will then conflict between branch2 and master.
                 Touch(repo.Info.WorkingDirectory, relativePath, "Hello From branch2!\n");
@@ -348,7 +348,7 @@ namespace LibGit2Sharp.Tests
                     CheckoutNotifyFlags = CheckoutNotifyFlags.Conflict,
                 };
 
-                Assert.Throws<UserCancelledException>(() => repo.Checkout("master", options));
+                Assert.Throws<UserCancelledException>(() => Commands.Checkout(repo, "master", options));
                 Assert.Equal(relativePath, conflictPath);
             }
         }
@@ -359,8 +359,8 @@ namespace LibGit2Sharp.Tests
             string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
-                Assert.Throws<BareRepositoryException>(() => repo.Checkout(repo.Branches["refs/heads/test"]));
-                Assert.Throws<BareRepositoryException>(() => repo.Checkout("refs/heads/test"));
+                Assert.Throws<BareRepositoryException>(() => Commands.Checkout(repo, repo.Branches["refs/heads/test"]));
+                Assert.Throws<BareRepositoryException>(() => Commands.Checkout(repo, "refs/heads/test"));
             }
         }
 
@@ -373,7 +373,7 @@ namespace LibGit2Sharp.Tests
             {
                 Assert.True(repo.Info.IsHeadUnborn);
 
-                Assert.Throws<UnbornBranchException>(() => repo.Checkout(repo.Head));
+                Assert.Throws<UnbornBranchException>(() => Commands.Checkout(repo, repo.Head));
             }
         }
 
@@ -383,7 +383,7 @@ namespace LibGit2Sharp.Tests
             string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
-                Assert.Throws<NotFoundException>(() => repo.Checkout("i-do-not-exist"));
+                Assert.Throws<NotFoundException>(() => Commands.Checkout(repo, "i-do-not-exist"));
             }
         }
 
@@ -393,9 +393,9 @@ namespace LibGit2Sharp.Tests
             string path = SandboxBareTestRepo();
             using (var repo = new Repository(path))
             {
-                Assert.Throws<ArgumentException>(() => repo.Checkout(string.Empty));
-                Assert.Throws<ArgumentNullException>(() => repo.Checkout(default(Branch)));
-                Assert.Throws<ArgumentNullException>(() => repo.Checkout(default(string)));
+                Assert.Throws<ArgumentException>(() => Commands.Checkout(repo, string.Empty));
+                Assert.Throws<ArgumentNullException>(() => Commands.Checkout(repo, default(Branch)));
+                Assert.Throws<ArgumentNullException>(() => Commands.Checkout(repo, default(string)));
             }
         }
 
@@ -410,7 +410,7 @@ namespace LibGit2Sharp.Tests
                 bool wasCalled = false;
 
                 Branch branch = repo.Branches[otherBranchName];
-                repo.Checkout(branch,
+                Commands.Checkout(repo, branch,
                     new CheckoutOptions { OnCheckoutProgress = (path, completed, total) => wasCalled = true});
 
                 Assert.True(wasCalled);
@@ -427,7 +427,7 @@ namespace LibGit2Sharp.Tests
                 PopulateBasicRepository(repo);
                 bool wasCalled = false;
 
-                repo.Checkout(otherBranchName, new CheckoutOptions() { OnCheckoutProgress = (path, completed, total) => wasCalled = true});
+                Commands.Checkout(repo, otherBranchName, new CheckoutOptions() { OnCheckoutProgress = (path, completed, total) => wasCalled = true});
 
                 Assert.True(wasCalled);
             }
@@ -474,7 +474,7 @@ namespace LibGit2Sharp.Tests
                 repo.Commit("2nd commit of conflict.txt and update.txt on master branch", Constants.Signature, Constants.Signature);
 
                 // Checkout other branch
-                repo.Checkout("newbranch");
+                Commands.Checkout(repo, "newbranch");
 
                 // Make alternate edits to conflict.txt and update.txt
                 Touch(repo.Info.WorkingDirectory, relativePathUpdated, "updated file text CCC");
@@ -505,7 +505,7 @@ namespace LibGit2Sharp.Tests
                     CheckoutNotifyFlags = notifyFlags,
                 };
 
-                Assert.Throws<CheckoutConflictException>(() => repo.Checkout("master", options));
+                Assert.Throws<CheckoutConflictException>(() => Commands.Checkout(repo, "master", options));
 
                 Assert.True(wasCalled);
                 Assert.Equal(expectedNotificationPath, actualNotificationPath);
@@ -529,7 +529,7 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(1, repo.RetrieveStatus().Untracked.Count());
                 Assert.Equal(FileStatus.NewInWorkdir, repo.RetrieveStatus(fullPathFileB));
 
-                repo.Checkout(otherBranchName);
+                Commands.Checkout(repo, otherBranchName);
 
                 // Verify untracked entry still exists.
                 Assert.Equal(1, repo.RetrieveStatus().Untracked.Count());
@@ -553,7 +553,7 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(1, repo.RetrieveStatus().Untracked.Count());
                 Assert.Equal(FileStatus.NewInWorkdir, repo.RetrieveStatus(fullPathFileB));
 
-                repo.Checkout(otherBranchName, new CheckoutOptions() { CheckoutModifiers = CheckoutModifiers.Force });
+                Commands.Checkout(repo, otherBranchName, new CheckoutOptions() { CheckoutModifiers = CheckoutModifiers.Force });
 
                 // Verify untracked entry still exists.
                 Assert.Equal(1, repo.RetrieveStatus().Untracked.Count());
@@ -577,7 +577,7 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(1, repo.RetrieveStatus().Modified.Count());
                 Assert.Equal(FileStatus.ModifiedInWorkdir, repo.RetrieveStatus(fullPathFileA));
 
-                repo.Checkout(otherBranchName);
+                Commands.Checkout(repo, otherBranchName);
 
                 // Verify modified entry still exists.
                 Assert.Equal(1, repo.RetrieveStatus().Modified.Count());
@@ -602,7 +602,7 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(1, repo.RetrieveStatus().Staged.Count());
                 Assert.Equal(FileStatus.ModifiedInIndex, repo.RetrieveStatus(fullPathFileA));
 
-                repo.Checkout(otherBranchName);
+                Commands.Checkout(repo, otherBranchName);
 
                 // Verify staged entry still exists.
                 Assert.Equal(1, repo.RetrieveStatus().Staged.Count());
@@ -629,7 +629,7 @@ namespace LibGit2Sharp.Tests
 
                 Assert.Equal(FileStatus.Ignored, repo.RetrieveStatus(ignoredFilePath));
 
-                repo.Checkout(otherBranchName);
+                Commands.Checkout(repo, otherBranchName);
 
                 // Verify that the ignored file still exists.
                 Assert.Equal(FileStatus.Ignored, repo.RetrieveStatus(ignoredFilePath));
@@ -656,7 +656,7 @@ namespace LibGit2Sharp.Tests
 
                 Assert.Equal(FileStatus.Ignored, repo.RetrieveStatus(ignoredFilePath));
 
-                repo.Checkout(otherBranchName, new CheckoutOptions() { CheckoutModifiers = CheckoutModifiers.Force });
+                Commands.Checkout(repo, otherBranchName, new CheckoutOptions() { CheckoutModifiers = CheckoutModifiers.Force });
 
                 // Verify that the ignored file still exists.
                 Assert.Equal(FileStatus.Ignored, repo.RetrieveStatus(ignoredFilePath));
@@ -685,7 +685,7 @@ namespace LibGit2Sharp.Tests
 
                 Assert.False(repo.Info.IsHeadDetached);
 
-                repo.Checkout(initial);
+                Commands.Checkout(repo, initial);
 
                 // Head should point at initial commit.
                 Assert.Equal(repo.Head.Tip, initialCommit);
@@ -712,7 +712,7 @@ namespace LibGit2Sharp.Tests
                 // Set the working directory to the current head
                 ResetAndCleanWorkingDirectory(repo);
 
-                repo.Checkout(remoteBranchSpec);
+                Commands.Checkout(repo, remoteBranchSpec);
 
                 // Verify that HEAD is detached.
                 Assert.Equal(repo.Refs["HEAD"].TargetIdentifier, repo.Branches["origin/master"].Tip.Sha);
@@ -733,7 +733,7 @@ namespace LibGit2Sharp.Tests
                 // The blob actually exists in the object database with the correct Sha
                 Assert.Equal(expectedSha, repo.Lookup<Blob>(expectedSha).Sha);
 
-                repo.Checkout("refs/heads/logo", new CheckoutOptions() { CheckoutModifiers = CheckoutModifiers.Force });
+                Commands.Checkout(repo, "refs/heads/logo", new CheckoutOptions() { CheckoutModifiers = CheckoutModifiers.Force });
 
                 // The Index has been updated as well with the blob
                 Assert.Equal(expectedSha, repo.Index["square-logo.png"].Id.Sha);
@@ -761,9 +761,9 @@ namespace LibGit2Sharp.Tests
 
                 var commitSha = repo.Lookup(commitPointer).Sha;
 
-                Branch initialHead = repo.Checkout("6dcf9bf");
+                Branch initialHead = Commands.Checkout(repo, "6dcf9bf");
 
-                repo.Checkout(commitPointer);
+                Commands.Checkout(repo, commitPointer);
 
                 // Assert reflog entry is created
                 var reflogEntry = repo.Refs.Log(repo.Refs.Head).First();
@@ -785,13 +785,13 @@ namespace LibGit2Sharp.Tests
                 ResetAndCleanWorkingDirectory(repo);
                 Assert.False(repo.RetrieveStatus().IsDirty);
 
-                Branch initialHead = repo.Checkout("6dcf9bf");
+                Branch initialHead = Commands.Checkout(repo, "6dcf9bf");
 
                 Assert.True(repo.Info.IsHeadDetached);
 
                 var before = DateTimeOffset.Now.TruncateMilliseconds();
 
-                Branch newHead = repo.Checkout(repo.Branches["master"]);
+                Branch newHead = Commands.Checkout(repo, repo.Branches["master"]);
 
                 // Assert reflog entry is created
                 AssertRefLogEntry(repo, "HEAD",
@@ -812,10 +812,10 @@ namespace LibGit2Sharp.Tests
                 ResetAndCleanWorkingDirectory(repo);
                 Assert.False(repo.RetrieveStatus().IsDirty);
 
-                repo.Checkout("6dcf9bf");
+                Commands.Checkout(repo, "6dcf9bf");
                 Assert.True(repo.Info.IsHeadDetached);
 
-                var branch = repo.Checkout(shortBranchName);
+                var branch = Commands.Checkout(repo, shortBranchName);
 
                 Assert.False(repo.Info.IsHeadDetached);
                 Assert.Equal(referenceName, repo.Head.CanonicalName);
@@ -833,11 +833,11 @@ namespace LibGit2Sharp.Tests
                 ResetAndCleanWorkingDirectory(repo);
                 Assert.False(repo.RetrieveStatus().IsDirty);
 
-                Branch previousHead = repo.Checkout("i-do-numbers");
-                repo.Checkout("diff-test-cases");
+                Branch previousHead = Commands.Checkout(repo, "i-do-numbers");
+                Commands.Checkout(repo, "diff-test-cases");
 
                 //Go back to previous branch checked out
-                var branch = repo.Checkout(@"@{-1}");
+                var branch = Commands.Checkout(repo, @"@{-1}");
 
                 Assert.False(repo.Info.IsHeadDetached);
                 Assert.Equal(previousHead.CanonicalName, repo.Head.CanonicalName);
@@ -860,14 +860,14 @@ namespace LibGit2Sharp.Tests
                 var reflogEntriesCount = repo.Refs.Log(repo.Refs.Head).Count();
 
                 // Checkout branch
-                repo.Checkout(master);
+                Commands.Checkout(repo, master);
 
                 Assert.Equal(reflogEntriesCount, repo.Refs.Log(repo.Refs.Head).Count());
 
                 var before = DateTimeOffset.Now.TruncateMilliseconds();
 
                 // Checkout in detached mode
-                repo.Checkout(master.Tip.Sha);
+                Commands.Checkout(repo, master.Tip.Sha);
 
                 Assert.True(repo.Info.IsHeadDetached);
                 AssertRefLogEntry(repo, "HEAD",
@@ -877,19 +877,19 @@ namespace LibGit2Sharp.Tests
                 // Checkout detached "HEAD" => nothing should happen
                 reflogEntriesCount = repo.Refs.Log(repo.Refs.Head).Count();
 
-                repo.Checkout(repo.Head);
+                Commands.Checkout(repo, repo.Head);
 
                 Assert.Equal(reflogEntriesCount, repo.Refs.Log(repo.Refs.Head).Count());
 
                 // Checkout attached "HEAD" => nothing should happen
-                repo.Checkout("master");
+                Commands.Checkout(repo, "master");
                 reflogEntriesCount = repo.Refs.Log(repo.Refs.Head).Count();
 
-                repo.Checkout(repo.Head);
+                Commands.Checkout(repo, repo.Head);
 
                 Assert.Equal(reflogEntriesCount, repo.Refs.Log(repo.Refs.Head).Count());
 
-                repo.Checkout("HEAD");
+                Commands.Checkout(repo, "HEAD");
 
                 Assert.Equal(reflogEntriesCount, repo.Refs.Log(repo.Refs.Head).Count());
             }
@@ -901,7 +901,7 @@ namespace LibGit2Sharp.Tests
             string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
-                Assert.Throws<NotFoundException>(() => repo.Checkout("head"));
+                Assert.Throws<NotFoundException>(() => Commands.Checkout(repo, "head"));
             }
         }
 
@@ -913,10 +913,10 @@ namespace LibGit2Sharp.Tests
             {
                 Assert.False(repo.Info.IsHeadDetached);
 
-                repo.Checkout(repo.Head);
+                Commands.Checkout(repo, repo.Head);
                 Assert.False(repo.Info.IsHeadDetached);
 
-                repo.Checkout("HEAD");
+                Commands.Checkout(repo, "HEAD");
                 Assert.False(repo.Info.IsHeadDetached);
             }
         }
@@ -927,14 +927,14 @@ namespace LibGit2Sharp.Tests
             string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
-                repo.Checkout(repo.Head.Tip.Sha);
+                Commands.Checkout(repo, repo.Head.Tip.Sha);
 
                 Assert.True(repo.Info.IsHeadDetached);
 
-                repo.Checkout(repo.Head);
+                Commands.Checkout(repo, repo.Head);
                 Assert.True(repo.Info.IsHeadDetached);
 
-                repo.Checkout("HEAD");
+                Commands.Checkout(repo, "HEAD");
                 Assert.True(repo.Info.IsHeadDetached);
             }
         }
@@ -952,7 +952,7 @@ namespace LibGit2Sharp.Tests
                 // Set the working directory to the current head
                 ResetAndCleanWorkingDirectory(repo);
 
-                repo.Checkout(originalBranch);
+                Commands.Checkout(repo, originalBranch);
                 Assert.False(repo.RetrieveStatus().IsDirty);
 
                 repo.CheckoutPaths(checkoutFrom, new[] { path });

--- a/LibGit2Sharp.Tests/CherryPickFixture.cs
+++ b/LibGit2Sharp.Tests/CherryPickFixture.cs
@@ -19,7 +19,7 @@ namespace LibGit2Sharp.Tests
             {
                 if (fromDetachedHead)
                 {
-                    repo.Checkout(repo.Head.Tip.Id.Sha);
+                    Commands.Checkout(repo, repo.Head.Tip.Id.Sha);
                 }
 
                 Commit commitToMerge = repo.Branches["fast_forward"].Tip;
@@ -46,7 +46,7 @@ namespace LibGit2Sharp.Tests
             using (var repo = new Repository(path))
             {
                 var firstBranch = repo.CreateBranch("FirstBranch");
-                repo.Checkout(firstBranch);
+                Commands.Checkout(repo, firstBranch);
 
                 // Commit with ONE new file to both first & second branch (SecondBranch is created on this commit).
                 AddFileCommitToRepo(repo, sharedBranchFileName);
@@ -56,7 +56,7 @@ namespace LibGit2Sharp.Tests
                 AddFileCommitToRepo(repo, firstBranchFileName);
                 AddFileCommitToRepo(repo, sharedBranchFileName, "The first branches comment");  // Change file in first branch
 
-                repo.Checkout(secondBranch);
+                Commands.Checkout(repo, secondBranch);
                 // Commit with ONE new file to second branch (FirstBranch and SecondBranch now point to separate commits that both have the same parent commit).
                 AddFileCommitToRepo(repo, secondBranchFileName);
                 AddFileCommitToRepo(repo, sharedBranchFileName, "The second branches comment");  // Change file in second branch

--- a/LibGit2Sharp.Tests/CommitFixture.cs
+++ b/LibGit2Sharp.Tests/CommitFixture.cs
@@ -34,11 +34,11 @@ namespace LibGit2Sharp.Tests
                 repo.Reset(ResetMode.Hard);
                 repo.RemoveUntrackedFiles();
 
-                repo.Checkout("test");
+                Commands.Checkout(repo, "test");
                 Assert.Equal(2, repo.Commits.Count());
                 Assert.Equal("e90810b8df3e80c413d903f631643c716887138d", repo.Commits.First().Id.Sha);
 
-                repo.Checkout("master");
+                Commands.Checkout(repo, "master");
                 Assert.Equal(9, repo.Commits.Count());
                 Assert.Equal("32eab9cb1f450b5fe7ab663462b77d7f4b703344", repo.Commits.First().Id.Sha);
             }
@@ -274,7 +274,7 @@ namespace LibGit2Sharp.Tests
                 repoClone.RemoveUntrackedFiles();
 
                 string headSha = repoClone.Head.Tip.Sha;
-                repoClone.Checkout(headSha);
+                Commands.Checkout(repoClone, headSha);
 
                 AssertEnumerationOfCommitsInRepo(repoClone,
                     repo => new CommitFilter { IncludeReachableFrom = repo.Head },
@@ -708,7 +708,7 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(reflogEntry.To, repo.Refs.Log("HEAD").First().From);
 
                 Branch firstCommitBranch = repo.CreateBranch("davidfowl-rules", commit);
-                repo.Checkout(firstCommitBranch);
+                Commands.Checkout(repo, firstCommitBranch);
 
                 File.WriteAllText(filePath, "davidfowl commits!\n");
 

--- a/LibGit2Sharp.Tests/DescribeFixture.cs
+++ b/LibGit2Sharp.Tests/DescribeFixture.cs
@@ -64,11 +64,11 @@ namespace LibGit2Sharp.Tests
                 repo.ApplyTag("firstParentTag");
 
                 // Make a later tag on branch
-                repo.Checkout(branch);
+                Commands.Checkout(repo, branch);
                 repo.Commit("B", Constants.Signature, Constants.Signature, new CommitOptions { AllowEmptyCommit = true });
                 repo.ApplyTag("mostRecentTag");
 
-                repo.Checkout("master");
+                Commands.Checkout(repo, "master");
                 repo.Commit("C", Constants.Signature, Constants.Signature, new CommitOptions { AllowEmptyCommit = true });
                 repo.Merge(branch, Constants.Signature, new MergeOptions() { FastForwardStrategy = FastForwardStrategy.NoFastForward });
 

--- a/LibGit2Sharp.Tests/FileHistoryFixture.cs
+++ b/LibGit2Sharp.Tests/FileHistoryFixture.cs
@@ -94,7 +94,7 @@ namespace LibGit2Sharp.Tests
                     dummy, master9);
 
                 repo.CreateBranch("master", master10);
-                repo.Checkout("master", new CheckoutOptions { CheckoutModifiers = CheckoutModifiers.Force });
+                Commands.Checkout(repo, "master", new CheckoutOptions { CheckoutModifiers = CheckoutModifiers.Force });
 
                 // Test --date-order.
                 var timeHistory = repo.Commits.QueryBy(path,

--- a/LibGit2Sharp.Tests/FilterFixture.cs
+++ b/LibGit2Sharp.Tests/FilterFixture.cs
@@ -284,7 +284,7 @@ namespace LibGit2Sharp.Tests
                     Commands.Stage(repo, contentFile.Name);
                     repo.Commit("test", Constants.Signature, Constants.Signature);
                     contentFile.Delete();
-                    repo.Checkout("HEAD", new CheckoutOptions() { CheckoutModifiers = CheckoutModifiers.Force });
+                    Commands.Checkout(repo, "HEAD", new CheckoutOptions() { CheckoutModifiers = CheckoutModifiers.Force });
                 }
 
                 contentFile = new FileInfo(filePath);
@@ -392,9 +392,9 @@ namespace LibGit2Sharp.Tests
 
                 expectedPath = CommitFileOnBranch(repo, branchName, content);
 
-                repo.Checkout("master");
+                Commands.Checkout(repo, "master");
 
-                repo.Checkout(branchName);
+                Commands.Checkout(repo, branchName);
             }
             return expectedPath;
         }
@@ -402,7 +402,7 @@ namespace LibGit2Sharp.Tests
         private static FileInfo CommitFileOnBranch(Repository repo, string branchName, String content)
         {
             var branch = repo.CreateBranch(branchName);
-            repo.Checkout(branch.FriendlyName);
+            Commands.Checkout(repo, branch.FriendlyName);
 
             FileInfo expectedPath = StageNewFile(repo, content);
             repo.Commit("Commit", Constants.Signature, Constants.Signature);

--- a/LibGit2Sharp.Tests/FilterSubstitutionCipherFixture.cs
+++ b/LibGit2Sharp.Tests/FilterSubstitutionCipherFixture.cs
@@ -34,11 +34,11 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(0, filter.SmudgeCalledCount);
 
                 var branch = repo.CreateBranch("delete-files");
-                repo.Checkout(branch.FriendlyName);
+                Commands.Checkout(repo, branch.FriendlyName);
 
                 DeleteFile(repo, fileName);
 
-                repo.Checkout("master");
+                Commands.Checkout(repo, "master");
 
                 var fileContents = ReadTextFromFile(repo, fileName);
                 Assert.Equal(1, filter.SmudgeCalledCount);
@@ -73,11 +73,11 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(0, filter.SmudgeCalledCount);
 
                 var branch = repo.CreateBranch("delete-files");
-                repo.Checkout(branch.FriendlyName);
+                Commands.Checkout(repo, branch.FriendlyName);
 
                 DeleteFile(repo, fileName);
 
-                repo.Checkout("master");
+                Commands.Checkout(repo, "master");
 
                 var fileContents = ReadTextFromFile(repo, fileName);
                 Assert.Equal(1, filter.SmudgeCalledCount);
@@ -176,11 +176,11 @@ namespace LibGit2Sharp.Tests
                 CommitOnBranchAndReturnDatabaseBlob(repo, fileName, decodedInput);
 
                 var branch = repo.CreateBranch("delete-files");
-                repo.Checkout(branch.FriendlyName);
+                Commands.Checkout(repo, branch.FriendlyName);
 
                 DeleteFile(repo, fileName);
 
-                repo.Checkout("master");
+                Commands.Checkout(repo, "master");
 
                 Assert.Equal(smudgeCount, filter.SmudgeCalledCount);
             }

--- a/LibGit2Sharp.Tests/MergeFixture.cs
+++ b/LibGit2Sharp.Tests/MergeFixture.cs
@@ -93,7 +93,7 @@ namespace LibGit2Sharp.Tests
             using (var repo = new Repository(path))
             {
                 var firstBranch = repo.CreateBranch("FirstBranch");
-                repo.Checkout(firstBranch);
+                Commands.Checkout(repo, firstBranch);
                 var originalTreeCount = firstBranch.Tip.Tree.Count;
 
                 // Commit with ONE new file to both first & second branch (SecondBranch is created on this commit).
@@ -106,11 +106,11 @@ namespace LibGit2Sharp.Tests
                 if (shouldMergeOccurInDetachedHeadState)
                 {
                     // Detaches HEAD
-                    repo.Checkout(secondBranch.Tip);
+                    Commands.Checkout(repo, secondBranch.Tip);
                 }
                 else
                 {
-                    repo.Checkout(secondBranch);
+                    Commands.Checkout(repo, secondBranch);
                 }
 
                 // Commit with ONE new file to second branch (FirstBranch and SecondBranch now point to separate commits that both have the same parent commit).
@@ -142,14 +142,14 @@ namespace LibGit2Sharp.Tests
             using (var repo = new Repository(path))
             {
                 var firstBranch = repo.CreateBranch("FirstBranch");
-                repo.Checkout(firstBranch);
+                Commands.Checkout(repo, firstBranch);
 
                 // Commit with ONE new file to both first & second branch (SecondBranch is created on this commit).
                 AddFileCommitToRepo(repo, sharedBranchFileName);
 
                 var secondBranch = repo.CreateBranch("SecondBranch");
 
-                repo.Checkout(secondBranch);
+                Commands.Checkout(repo, secondBranch);
 
                 MergeResult mergeResult = repo.Merge(repo.Branches["FirstBranch"].Tip, Constants.Signature);
 
@@ -175,7 +175,7 @@ namespace LibGit2Sharp.Tests
                 repo.RemoveUntrackedFiles();
 
                 var firstBranch = repo.CreateBranch("FirstBranch");
-                repo.Checkout(firstBranch);
+                Commands.Checkout(repo, firstBranch);
 
                 // Commit with ONE new file to both first & second branch (SecondBranch is created on this commit).
                 AddFileCommitToRepo(repo, sharedBranchFileName);
@@ -188,11 +188,11 @@ namespace LibGit2Sharp.Tests
                 if (shouldMergeOccurInDetachedHeadState)
                 {
                     // Detaches HEAD
-                    repo.Checkout(secondBranch.Tip);
+                    Commands.Checkout(repo, secondBranch.Tip);
                 }
                 else
                 {
-                    repo.Checkout(secondBranch);
+                    Commands.Checkout(repo, secondBranch);
                 }
 
                 Assert.Equal(shouldMergeOccurInDetachedHeadState, repo.Info.IsHeadDetached);
@@ -226,7 +226,7 @@ namespace LibGit2Sharp.Tests
             using (var repo = new Repository(path))
             {
                 var firstBranch = repo.CreateBranch("FirstBranch");
-                repo.Checkout(firstBranch);
+                Commands.Checkout(repo, firstBranch);
 
                 // Commit with ONE new file to both first & second branch (SecondBranch is created on this commit).
                 AddFileCommitToRepo(repo, sharedBranchFileName);
@@ -236,7 +236,7 @@ namespace LibGit2Sharp.Tests
                 AddFileCommitToRepo(repo, firstBranchFileName);
                 AddFileCommitToRepo(repo, sharedBranchFileName, "The first branches comment");  // Change file in first branch
 
-                repo.Checkout(secondBranch);
+                Commands.Checkout(repo, secondBranch);
                 // Commit with ONE new file to second branch (FirstBranch and SecondBranch now point to separate commits that both have the same parent commit).
                 AddFileCommitToRepo(repo, secondBranchFileName);
                 AddFileCommitToRepo(repo, sharedBranchFileName, "The second branches comment");  // Change file in second branch
@@ -266,7 +266,7 @@ namespace LibGit2Sharp.Tests
             using (var repo = new Repository(path))
             {
                 var firstBranch = repo.CreateBranch("FirstBranch");
-                repo.Checkout(firstBranch);
+                Commands.Checkout(repo, firstBranch);
 
                 // Commit with ONE new file to both first & second branch (SecondBranch is created on this commit).
                 AddFileCommitToRepo(repo, sharedBranchFileName);
@@ -276,7 +276,7 @@ namespace LibGit2Sharp.Tests
                 AddFileCommitToRepo(repo, firstBranchFileName);
                 AddFileCommitToRepo(repo, sharedBranchFileName, "\0The first branches comment\0");  // Change file in first branch
 
-                repo.Checkout(secondBranch);
+                Commands.Checkout(repo, secondBranch);
                 // Commit with ONE new file to second branch (FirstBranch and SecondBranch now point to separate commits that both have the same parent commit).
                 AddFileCommitToRepo(repo, secondBranchFileName);
                 AddFileCommitToRepo(repo, sharedBranchFileName, "\0The second branches comment\0");  // Change file in second branch
@@ -325,7 +325,7 @@ namespace LibGit2Sharp.Tests
             {
                 if(fromDetachedHead)
                 {
-                    repo.Checkout(repo.Head.Tip.Id.Sha);
+                    Commands.Checkout(repo, repo.Head.Tip.Id.Sha);
                 }
 
                 Commit commitToMerge = repo.Branches["fast_forward"].Tip;
@@ -351,7 +351,7 @@ namespace LibGit2Sharp.Tests
             {
                 if (fromDetachedHead)
                 {
-                    repo.Checkout(repo.Head.Tip.Id.Sha);
+                    Commands.Checkout(repo, repo.Head.Tip.Id.Sha);
                 }
 
                 Commit commitToMerge = repo.Branches["normal_merge"].Tip;
@@ -469,7 +469,7 @@ namespace LibGit2Sharp.Tests
             string repoPath = SandboxMergeTestRepo();
             using (var repo = new Repository(repoPath))
             {
-                Branch currentBranch = repo.Checkout("rename_source");
+                Branch currentBranch = Commands.Checkout(repo, "rename_source");
                 Assert.NotNull(currentBranch);
 
                 Branch branchToMerge = repo.Branches["rename"];

--- a/LibGit2Sharp.Tests/RebaseFixture.cs
+++ b/LibGit2Sharp.Tests/RebaseFixture.cs
@@ -40,7 +40,7 @@ namespace LibGit2Sharp.Tests
             {
                 ConstructRebaseTestRepository(repo);
 
-                repo.Checkout(initialBranchName);
+                Commands.Checkout(repo, initialBranchName);
                 Assert.False(repo.RetrieveStatus().IsDirty);
 
                 Branch branch = (branchName == null) ? null : repo.Branches[branchName];
@@ -127,7 +127,7 @@ namespace LibGit2Sharp.Tests
             using (Repository repo = new Repository(path))
             {
                 ConstructRebaseTestRepository(repo);
-                repo.Checkout(topicBranch2Name);
+                Commands.Checkout(repo, topicBranch2Name);
                 Branch b = repo.Branches[topicBranch2Name];
 
                 RebaseResult result = repo.Rebase.Start(b, b, null, Constants.Identity, new RebaseOptions());
@@ -209,7 +209,7 @@ namespace LibGit2Sharp.Tests
                 Branch initialBranch = repo.Branches[topicBranch1Name];
                 Branch upstreamBranch = repo.Branches[masterBranch2Name];
 
-                repo.Checkout(initialBranch);
+                Commands.Checkout(repo, initialBranch);
                 Assert.False(repo.RetrieveStatus().IsDirty);
 
                 bool wasCheckoutProgressCalled = false;
@@ -296,7 +296,7 @@ namespace LibGit2Sharp.Tests
             {
                 ConstructRebaseTestRepository(repo);
 
-                repo.Checkout(topicBranch1Name);
+                Commands.Checkout(repo, topicBranch1Name);
                 Assert.False(repo.RetrieveStatus().IsDirty);
 
                 Branch branch = repo.Branches[topicBranch1Name];
@@ -370,7 +370,7 @@ namespace LibGit2Sharp.Tests
             {
                 ConstructRebaseTestRepository(repo);
 
-                repo.Checkout(topicBranch1Name);
+                Commands.Checkout(repo, topicBranch1Name);
                 Assert.False(repo.RetrieveStatus().IsDirty);
 
                 Branch branch = repo.Branches[topicBranch1Name];
@@ -419,7 +419,7 @@ namespace LibGit2Sharp.Tests
             {
                 ConstructRebaseTestRepository(repo);
 
-                repo.Checkout(topicBranch1Name);
+                Commands.Checkout(repo, topicBranch1Name);
                 Assert.False(repo.RetrieveStatus().IsDirty);
 
                 Branch branch = repo.Branches[topicBranch1Name];
@@ -466,7 +466,7 @@ namespace LibGit2Sharp.Tests
             {
                 ConstructRebaseTestRepository(repo);
 
-                repo.Checkout(topicBranch1Name);
+                Commands.Checkout(repo, topicBranch1Name);
                 Assert.False(repo.RetrieveStatus().IsDirty);
 
                 Branch branch = repo.Branches[topicBranch1Name];
@@ -499,7 +499,7 @@ namespace LibGit2Sharp.Tests
             {
                 ConstructRebaseTestRepository(repo);
 
-                repo.Checkout(topicBranch1Name);
+                Commands.Checkout(repo, topicBranch1Name);
                 Assert.False(repo.RetrieveStatus().IsDirty);
 
                 Branch branch = repo.Branches[topicBranch1Name];
@@ -545,7 +545,7 @@ namespace LibGit2Sharp.Tests
             {
                 ConstructRebaseTestRepository(repo);
 
-                repo.Checkout(topicBranch1Name);
+                Commands.Checkout(repo, topicBranch1Name);
                 Assert.False(repo.RetrieveStatus().IsDirty);
 
                 Branch branch = repo.Branches[topicBranch1Name];
@@ -573,7 +573,7 @@ namespace LibGit2Sharp.Tests
             {
                 ConstructRebaseTestRepository(repo);
 
-                repo.Checkout(topicBranch1Name);
+                Commands.Checkout(repo, topicBranch1Name);
 
                 Assert.Throws<NotFoundException>(() =>
                     repo.Rebase.Continue(Constants.Identity, new RebaseOptions()));
@@ -591,7 +591,7 @@ namespace LibGit2Sharp.Tests
             using (Repository repo = new Repository(path))
             {
                 ConstructRebaseTestRepository(repo);
-                repo.Checkout(topicBranch1Name);
+                Commands.Checkout(repo, topicBranch1Name);
 
                 Assert.Null(repo.Rebase.GetCurrentStepInfo());
             }
@@ -612,7 +612,7 @@ namespace LibGit2Sharp.Tests
             {
                 ConstructRebaseTestRepository(repo, attributes, lineEnding);
 
-                repo.Checkout(topicBranch1Name);
+                Commands.Checkout(repo, topicBranch1Name);
 
                 Branch topicBranch1Prime = repo.CreateBranch(topicBranch1PrimeName, masterBranch1Name);
 
@@ -621,7 +621,7 @@ namespace LibGit2Sharp.Tests
                 Commands.Stage(repo, newFileRelativePath);
                 Commit commit = repo.Commit("new commit 1", Constants.Signature, Constants.Signature, new CommitOptions());
 
-                repo.Checkout(topicBranch1Prime);
+                Commands.Checkout(repo, topicBranch1Prime);
                 var cherryPickResult = repo.CherryPick(commit, Constants.Signature2);
                 Assert.Equal(CherryPickStatus.CherryPicked, cherryPickResult.Status);
 
@@ -759,7 +759,7 @@ namespace LibGit2Sharp.Tests
 
             repo.CreateBranch(topicBranch2Name, commit);
 
-            repo.Checkout(masterBranch1.Tip);
+            Commands.Checkout(repo, masterBranch1.Tip);
             Touch(workdir, filePathD, fileContentD1);
             Commands.Stage(repo, filePathD);
             commit = repo.Commit("commit 10", Constants.Signature, Constants.Signature, new CommitOptions());

--- a/LibGit2Sharp.Tests/ReflogFixture.cs
+++ b/LibGit2Sharp.Tests/ReflogFixture.cs
@@ -140,7 +140,7 @@ namespace LibGit2Sharp.Tests
                 Assert.False(repo.Info.IsHeadDetached);
 
                 var parentCommit = repo.Head.Tip.Parents.First();
-                repo.Checkout(parentCommit.Sha);
+                Commands.Checkout(repo, parentCommit.Sha);
                 Assert.True(repo.Info.IsHeadDetached);
 
                 const string relativeFilepath = "new.txt";

--- a/LibGit2Sharp.Tests/RepositoryFixture.cs
+++ b/LibGit2Sharp.Tests/RepositoryFixture.cs
@@ -610,8 +610,10 @@ namespace LibGit2Sharp.Tests
             string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
-                repo.Checkout(repo.Head.Tip.Sha, new CheckoutOptions() { CheckoutModifiers = CheckoutModifiers.Force });
+                Console.WriteLine("head, {0}", repo.Head);
+                Commands.Checkout(repo, repo.Head.Tip.Sha, new CheckoutOptions() { CheckoutModifiers = CheckoutModifiers.Force });
                 Branch trackLocal = repo.Head;
+                Console.WriteLine("head, {0}", repo.Head);
                 Assert.Null(trackLocal.RemoteName);
             }
         }
@@ -718,7 +720,7 @@ namespace LibGit2Sharp.Tests
             using (var originalRepo = new Repository(originalRepoPath))
             {
                 detachedHeadSha = originalRepo.Head.Tip.Sha;
-                originalRepo.Checkout(detachedHeadSha);
+                Commands.Checkout(originalRepo, detachedHeadSha);
 
                 Assert.True(originalRepo.Info.IsHeadDetached);
             }

--- a/LibGit2Sharp.Tests/ResetHeadFixture.cs
+++ b/LibGit2Sharp.Tests/ResetHeadFixture.cs
@@ -102,7 +102,7 @@ namespace LibGit2Sharp.Tests
                 Branch branch = repo.Branches["mybranch"];
 
                 string branchIdentifier = branchIdentifierRetriever(branch);
-                repo.Checkout(branchIdentifier);
+                Commands.Checkout(repo, branchIdentifier);
                 var oldHeadId = repo.Head.Tip.Id;
                 Assert.Equal(shouldHeadBeDetached, repo.Info.IsHeadDetached);
 
@@ -174,7 +174,7 @@ namespace LibGit2Sharp.Tests
             repo.Commit("Update file", shiftedSignature, shiftedSignature);
             repo.CreateBranch("mybranch");
 
-            repo.Checkout("mybranch");
+            Commands.Checkout(repo, "mybranch");
 
             Assert.False(repo.RetrieveStatus().IsDirty);
         }

--- a/LibGit2Sharp.Tests/RevertFixture.cs
+++ b/LibGit2Sharp.Tests/RevertFixture.cs
@@ -21,7 +21,7 @@ namespace LibGit2Sharp.Tests
             using (var repo = new Repository(path))
             {
                 // Checkout the revert branch.
-                Branch branch = repo.Checkout(revertBranchName);
+                Branch branch = Commands.Checkout(repo, revertBranchName);
                 Assert.NotNull(branch);
 
                 // Revert tip commit.
@@ -68,7 +68,7 @@ namespace LibGit2Sharp.Tests
             using (var repo = new Repository(path))
             {
                 // Checkout the revert branch.
-                Branch branch = repo.Checkout(revertBranchName);
+                Branch branch = Commands.Checkout(repo, revertBranchName);
                 Assert.NotNull(branch);
 
                 // Revert tip commit.
@@ -110,7 +110,7 @@ namespace LibGit2Sharp.Tests
             using (var repo = new Repository(path))
             {
                 // Checkout the revert branch.
-                Branch branch = repo.Checkout(revertBranchName);
+                Branch branch = Commands.Checkout(repo, revertBranchName);
                 Assert.NotNull(branch);
 
                 // The commit to revert - we know that reverting this
@@ -148,7 +148,7 @@ namespace LibGit2Sharp.Tests
             using (var repo = new Repository(path))
             {
                 // Checkout the revert branch.
-                Branch branch = repo.Checkout(revertBranchName);
+                Branch branch = Commands.Checkout(repo, revertBranchName);
                 Assert.NotNull(branch);
 
                 // Specify FileConflictStrategy.
@@ -201,7 +201,7 @@ namespace LibGit2Sharp.Tests
             using (var repo = new Repository(repoPath))
             {
                 // Checkout the revert branch.
-                Branch branch = repo.Checkout(revertBranchName);
+                Branch branch = Commands.Checkout(repo, revertBranchName);
                 Assert.NotNull(branch);
 
                 bool wasCalled = false;
@@ -226,7 +226,7 @@ namespace LibGit2Sharp.Tests
             using (var repo = new Repository(repoPath))
             {
                 // Checkout the revert branch.
-                Branch branch = repo.Checkout(revertBranchName);
+                Branch branch = Commands.Checkout(repo, revertBranchName);
                 Assert.NotNull(branch);
 
                 bool wasCalled = false;
@@ -266,7 +266,7 @@ namespace LibGit2Sharp.Tests
             string repoPath = SandboxRevertTestRepo();
             using (var repo = new Repository(repoPath))
             {
-                Branch currentBranch = repo.Checkout(revertBranchName);
+                Branch currentBranch = Commands.Checkout(repo, revertBranchName);
                 Assert.NotNull(currentBranch);
 
                 Commit commitToRevert = repo.Lookup<Commit>(commitIdToRevert);
@@ -323,7 +323,7 @@ namespace LibGit2Sharp.Tests
             string repoPath = SandboxRevertTestRepo();
             using (var repo = new Repository(repoPath))
             {
-                Branch branch = repo.Checkout(revertBranchName);
+                Branch branch = Commands.Checkout(repo, revertBranchName);
                 Assert.NotNull(branch);
 
                 Commit commitToRevert = repo.Lookup<Commit>(commitIdToRevert);
@@ -382,7 +382,7 @@ namespace LibGit2Sharp.Tests
             string repoPath = SandboxRevertTestRepo();
             using (var repo = new Repository(repoPath))
             {
-                Branch branch = repo.Checkout(revertBranchName);
+                Branch branch = Commands.Checkout(repo, revertBranchName);
                 Assert.NotNull(branch);
 
                 var commitToRevert = repo.Lookup<Commit>(commitIdToRevert);
@@ -404,7 +404,7 @@ namespace LibGit2Sharp.Tests
             using (var repo = new Repository(path))
             {
                 // Checkout the revert branch.
-                Branch branch = repo.Checkout(revertBranchName);
+                Branch branch = Commands.Checkout(repo, revertBranchName);
                 Assert.NotNull(branch);
 
                 Commit commitToRevert = repo.Head.Tip;
@@ -445,7 +445,7 @@ namespace LibGit2Sharp.Tests
             using (var repo = new Repository(path))
             {
                 // Checkout the revert branch.
-                Branch branch = repo.Checkout(revertBranchName);
+                Branch branch = Commands.Checkout(repo, revertBranchName);
                 Assert.NotNull(branch);
 
                 Commit commitToRevert = repo.Head.Tip;

--- a/LibGit2Sharp.Tests/SubmoduleFixture.cs
+++ b/LibGit2Sharp.Tests/SubmoduleFixture.cs
@@ -29,12 +29,12 @@ namespace LibGit2Sharp.Tests
                 var submodule = repo.Submodules["sm_branch_only"];
                 Assert.Null(submodule);
 
-                repo.Checkout("dev", new CheckoutOptions { CheckoutModifiers = CheckoutModifiers.Force });
+                Commands.Checkout(repo, "dev", new CheckoutOptions { CheckoutModifiers = CheckoutModifiers.Force });
                 submodule = repo.Submodules["sm_branch_only"];
                 Assert.NotNull(submodule);
                 Assert.NotEqual(SubmoduleStatus.Unmodified, submodule.RetrieveStatus());
 
-                repo.Checkout("master", new CheckoutOptions { CheckoutModifiers = CheckoutModifiers.Force });
+                Commands.Checkout(repo, "master", new CheckoutOptions { CheckoutModifiers = CheckoutModifiers.Force });
                 submodule = repo.Submodules["sm_branch_only"];
                 Assert.Null(submodule);
             }
@@ -300,7 +300,7 @@ namespace LibGit2Sharp.Tests
 
                 Assert.True(submodule.RetrieveStatus().HasFlag(SubmoduleStatus.InWorkDir));
 
-                repo.Checkout("alternate");
+                Commands.Checkout(repo, "alternate");
                 Assert.True(submodule.RetrieveStatus().HasFlag(SubmoduleStatus.WorkDirModified));
 
                 submodule = repo.Submodules[submoduleName];

--- a/LibGit2Sharp.Tests/TagFixture.cs
+++ b/LibGit2Sharp.Tests/TagFixture.cs
@@ -297,7 +297,7 @@ namespace LibGit2Sharp.Tests
             string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
-                repo.Checkout(repo.Head.Tip);
+                Commands.Checkout(repo, repo.Head.Tip);
 
                 Assert.True(repo.Info.IsHeadDetached);
 

--- a/LibGit2Sharp/Commands/Checkout.cs
+++ b/LibGit2Sharp/Commands/Checkout.cs
@@ -1,0 +1,162 @@
+﻿using System;
+using LibGit2Sharp.Core;
+
+namespace LibGit2Sharp
+{
+    public static partial class Commands
+    {
+        /// <summary>
+        /// Checkout the specified <see cref="Branch"/>, reference or SHA.
+        /// <para>
+        ///   If the committishOrBranchSpec parameter resolves to a branch name, then the checked out HEAD will
+        ///   will point to the branch. Otherwise, the HEAD will be detached, pointing at the commit sha.
+        /// </para>
+        /// </summary>
+        /// <param name="repository">The repository to act on</param>
+        /// <param name="committishOrBranchSpec">A revparse spec for the commit or branch to checkout.</param>
+        /// <returns>The <see cref="Branch"/> that was checked out.</returns>
+        public static Branch Checkout(IRepository repository, string committishOrBranchSpec)
+        {
+            return Checkout(repository, committishOrBranchSpec, new CheckoutOptions());
+        }
+
+        /// <summary>
+        /// Checkout the specified <see cref="Branch"/>, reference or SHA.
+        /// <para>
+        ///   If the committishOrBranchSpec parameter resolves to a branch name, then the checked out HEAD will
+        ///   will point to the branch. Otherwise, the HEAD will be detached, pointing at the commit sha.
+        /// </para>
+        /// </summary>
+        /// <param name="repository">The repository to act on</param>
+        /// <param name="committishOrBranchSpec">A revparse spec for the commit or branch to checkout.</param>
+        /// <param name="options"><see cref="CheckoutOptions"/> controlling checkout behavior.</param>
+        /// <returns>The <see cref="Branch"/> that was checked out.</returns>
+        public static Branch Checkout(IRepository repository, string committishOrBranchSpec, CheckoutOptions options)
+        {
+            Ensure.ArgumentNotNull(repository, "repository");
+            Ensure.ArgumentNotNullOrEmptyString(committishOrBranchSpec, "committishOrBranchSpec");
+            Ensure.ArgumentNotNull(options, "options");
+
+            Reference reference;
+            GitObject obj;
+
+            Console.WriteLine("revparsing {0}", committishOrBranchSpec);
+            repository.RevParse(committishOrBranchSpec, out reference, out obj);
+            Console.WriteLine("grabbed ref {0}, obj {1}", reference, obj);
+            if (reference != null && reference.IsLocalBranch)
+            {
+                Branch branch = repository.Branches[reference.CanonicalName];
+                Console.WriteLine("grabbed branch {0}", branch);
+                return Checkout(repository, branch, options);
+            }
+
+            Commit commit = obj.DereferenceToCommit(true);
+            Console.WriteLine("dereferenced to commit {0}", commit);
+            Checkout(repository, commit.Tree,  options, committishOrBranchSpec);
+
+            return repository.Head;
+        }
+
+        /// <summary>
+        /// Checkout the tip commit of the specified <see cref="Branch"/> object. If this commit is the
+        /// current tip of the branch, will checkout the named branch. Otherwise, will checkout the tip commit
+        /// as a detached HEAD.
+        /// </summary>
+        /// <param name="repository">The repository to act on</param>
+        /// <param name="branch">The <see cref="Branch"/> to check out.</param>
+        /// <returns>The <see cref="Branch"/> that was checked out.</returns>
+        public static Branch Checkout(IRepository repository, Branch branch)
+        {
+            return Checkout(repository, branch, new CheckoutOptions());
+        }
+
+        /// <summary>
+        /// Checkout the tip commit of the specified <see cref="Branch"/> object. If this commit is the
+        /// current tip of the branch, will checkout the named branch. Otherwise, will checkout the tip commit
+        /// as a detached HEAD.
+        /// </summary>
+        /// <param name="repository">The repository to act on</param>
+        /// <param name="branch">The <see cref="Branch"/> to check out.</param>
+        /// <param name="options"><see cref="CheckoutOptions"/> controlling checkout behavior.</param>
+        /// <returns>The <see cref="Branch"/> that was checked out.</returns>
+        public static Branch Checkout(IRepository repository, Branch branch, CheckoutOptions options)
+        {
+            Ensure.ArgumentNotNull(repository, "repository");
+            Ensure.ArgumentNotNull(branch, "branch");
+            Ensure.ArgumentNotNull(options, "options");
+
+            // Make sure this is not an unborn branch.
+            if (branch.Tip == null)
+            {
+                throw new UnbornBranchException("The tip of branch '{0}' is null. There's nothing to checkout.",
+                    branch.FriendlyName);
+            }
+
+            Console.WriteLine("branch: {0}", branch);
+            if (!branch.IsRemote && !(branch is DetachedHead) &&
+                string.Equals(repository.Refs[branch.CanonicalName].TargetIdentifier, branch.Tip.Id.Sha,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                Checkout(repository, branch.Tip.Tree, options, branch.CanonicalName);
+            }
+            else
+            {
+                Checkout(repository, branch.Tip.Tree, options, branch.Tip.Id.Sha);
+            }
+
+            return repository.Head;
+        }
+
+        /// <summary>
+        /// Checkout the specified <see cref="LibGit2Sharp.Commit"/>.
+        /// <para>
+        ///   Will detach the HEAD and make it point to this commit sha.
+        /// </para>
+        /// </summary>
+        /// <param name="repository">The repository to act on</param>
+        /// <param name="commit">The <see cref="LibGit2Sharp.Commit"/> to check out.</param>
+        /// <returns>The <see cref="Branch"/> that was checked out.</returns>
+        public static Branch Checkout(IRepository repository, Commit commit)
+        {
+            return Checkout(repository, commit, new CheckoutOptions());
+        }
+
+        /// <summary>
+        /// Checkout the specified <see cref="LibGit2Sharp.Commit"/>.
+        /// <para>
+        ///   Will detach the HEAD and make it point to this commit sha.
+        /// </para>
+        /// </summary>
+        /// <param name="repository">The repository to act on</param>
+        /// <param name="commit">The <see cref="LibGit2Sharp.Commit"/> to check out.</param>
+        /// <param name="options"><see cref="CheckoutOptions"/> controlling checkout behavior.</param>
+        /// <returns>The <see cref="Branch"/> that was checked out.</returns>
+        public static Branch Checkout(IRepository repository, Commit commit, CheckoutOptions options)
+        {
+            Ensure.ArgumentNotNull(repository, "repository");
+            Ensure.ArgumentNotNull(commit, "commit");
+            Ensure.ArgumentNotNull(options, "options");
+
+            Checkout(repository, commit.Tree, options, commit.Id.Sha);
+
+            return repository.Head;
+        }
+
+        /// <summary>
+        /// Internal implementation of Checkout that expects the ID of the checkout target
+        /// to already be in the form of a canonical branch name or a commit ID.
+        /// </summary>
+        /// <param name="repository">The repository to act on</param>
+        /// <param name="tree">The <see cref="Tree"/> to checkout.</param>
+        /// <param name="checkoutOptions"><see cref="CheckoutOptions"/> controlling checkout behavior.</param>
+        /// <param name="refLogHeadSpec">The spec which will be written as target in the reflog.</param>
+        public static void Checkout(IRepository repository, Tree tree, CheckoutOptions checkoutOptions, string refLogHeadSpec)
+        {
+            repository.Checkout(tree, null, checkoutOptions);
+
+            repository.Refs.MoveHeadTarget(refLogHeadSpec);
+        }
+
+    }
+}
+

--- a/LibGit2Sharp/IRepository.cs
+++ b/LibGit2Sharp/IRepository.cs
@@ -79,6 +79,7 @@ namespace LibGit2Sharp
         /// <param name="branch">The <see cref="Branch"/> to check out.</param>
         /// <param name="options"><see cref="CheckoutOptions"/> controlling checkout behavior.</param>
         /// <returns>The <see cref="Branch"/> that was checked out.</returns>
+        [Obsolete("This method is deprecated. Please use LibGit2Sharp.Commands.Checkout()")]
         Branch Checkout(Branch branch, CheckoutOptions options);
 
         /// <summary>
@@ -91,6 +92,7 @@ namespace LibGit2Sharp
         /// <param name="committishOrBranchSpec">A revparse spec for the commit or branch to checkout.</param>
         /// <param name="options"><see cref="CheckoutOptions"/> controlling checkout behavior.</param>
         /// <returns>The <see cref="Branch"/> that was checked out.</returns>
+        [Obsolete("This method is deprecated. Please use LibGit2Sharp.Commands.Checkout()")]
         Branch Checkout(string committishOrBranchSpec, CheckoutOptions options);
 
         /// <summary>
@@ -102,7 +104,16 @@ namespace LibGit2Sharp
         /// <param name="commit">The <see cref="LibGit2Sharp.Commit"/> to check out.</param>
         /// <param name="options"><see cref="CheckoutOptions"/> controlling checkout behavior.</param>
         /// <returns>The <see cref="Branch"/> that was checked out.</returns>
+        [Obsolete("This method is deprecated. Please use LibGit2Sharp.Commands.Checkout()")]
         Branch Checkout(Commit commit, CheckoutOptions options);
+
+        /// <summary>
+        /// Checkout the specified tree.
+        /// </summary>
+        /// <param name="tree">The <see cref="Tree"/> to checkout.</param>
+        /// <param name="paths">The paths to checkout.</param>
+        /// <param name="opts">Collection of parameters controlling checkout behavior.</param>
+        void Checkout(Tree tree, IEnumerable<string> paths, CheckoutOptions opts);
 
         /// <summary>
         /// Updates specifed paths in the index and working directory with the versions from the specified branch, reference, or SHA.
@@ -401,5 +412,14 @@ namespace LibGit2Sharp
         /// <param name="options">Determines how the commit will be described.</param>
         /// <returns>A descriptive identifier for the commit based on the nearest annotated tag.</returns>
         string Describe(Commit commit, DescribeOptions options);
+
+        /// <summary>
+        /// Parse an extended SHA-1 expression and retrieve the object and the reference
+        /// mentioned in the revision (if any).
+        /// </summary>
+        /// <param name="revision">An extended SHA-1 expression for the object to look up</param>
+        /// <param name="reference">The reference mentioned in the revision (if any)</param>
+        /// <param name="obj">The object which the revision resolves to</param>
+        void RevParse(string revision, out Reference reference, out GitObject obj);
     }
 }

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -354,6 +354,7 @@
     <Compile Include="Commands\Fetch.cs" />
     <Compile Include="Commands\Stage.cs" />
     <Compile Include="Commands\Remove.cs" />
+    <Compile Include="Commands\Checkout.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="CustomDictionary.xml" />

--- a/LibGit2Sharp/RepositoryExtensions.cs
+++ b/LibGit2Sharp/RepositoryExtensions.cs
@@ -235,6 +235,7 @@ namespace LibGit2Sharp
         /// <param name="repository">The <see cref="Repository"/> being worked with.</param>
         /// <param name="commitOrBranchSpec">A revparse spec for the commit or branch to checkout.</param>
         /// <returns>The <see cref="Branch"/> that was checked out.</returns>
+        [Obsolete("This method is deprecated. Please use LibGit2Sharp.Commands.Checkout()")]
         public static Branch Checkout(this IRepository repository, string commitOrBranchSpec)
         {
             CheckoutOptions options = new CheckoutOptions();
@@ -251,6 +252,7 @@ namespace LibGit2Sharp
         /// <param name="repository">The <see cref="Repository"/> being worked with.</param>
         /// <param name="branch">The <see cref="Branch"/> to check out.</param>
         /// <returns>The <see cref="Branch"/> that was checked out.</returns>
+        [Obsolete("This method is deprecated. Please use LibGit2Sharp.Commands.Checkout()")]
         public static Branch Checkout(this IRepository repository, Branch branch)
         {
             CheckoutOptions options = new CheckoutOptions();
@@ -266,6 +268,7 @@ namespace LibGit2Sharp
         /// <param name="repository">The <see cref="Repository"/> being worked with.</param>
         /// <param name="commit">The <see cref="LibGit2Sharp.Commit"/> to check out.</param>
         /// <returns>The <see cref="Branch"/> that was checked out.</returns>
+        [Obsolete("This method is deprecated. Please use LibGit2Sharp.Commands.Checkout()")]
         public static Branch Checkout(this IRepository repository, Commit commit)
         {
             CheckoutOptions options = new CheckoutOptions();
@@ -452,6 +455,7 @@ namespace LibGit2Sharp
         /// <param name="branch">The <see cref="Branch"/> to check out.</param>
         /// <param name="options"><see cref="CheckoutOptions"/> controlling checkout behavior.</param>
         /// <returns>The <see cref="Branch"/> that was checked out.</returns>
+        [Obsolete("This method is deprecated. Please use LibGit2Sharp.Commands.Checkout()")]
         public static Branch Checkout(this IRepository repository, Branch branch, CheckoutOptions options)
         {
             return repository.Checkout(branch, options);
@@ -467,6 +471,7 @@ namespace LibGit2Sharp
         /// <param name="commit">The <see cref="LibGit2Sharp.Commit"/> to check out.</param>
         /// <param name="options"><see cref="CheckoutOptions"/> controlling checkout behavior.</param>
         /// <returns>The <see cref="Branch"/> that was checked out.</returns>
+        [Obsolete("This method is deprecated. Please use LibGit2Sharp.Commands.Checkout()")]
         public static Branch Checkout(this IRepository repository, Commit commit, CheckoutOptions options)
         {
             return repository.Checkout(commit, options);
@@ -483,6 +488,7 @@ namespace LibGit2Sharp
         /// <param name="committishOrBranchSpec">A revparse spec for the commit or branch to checkout.</param>
         /// <param name="options"><see cref="CheckoutOptions"/> controlling checkout behavior.</param>
         /// <returns>The <see cref="Branch"/> that was checked out.</returns>
+        [Obsolete("This method is deprecated. Please use LibGit2Sharp.Commands.Checkout()")]
         public static Branch Checkout(this IRepository repository, string committishOrBranchSpec, CheckoutOptions options)
         {
             return repository.Checkout(committishOrBranchSpec, options);


### PR DESCRIPTION
This is one of the clearest examples of reimplementing a git command instead of providing operations which you can combine.

I'd also like to eventually get rid of `CheckoutPaths` since that should just be the `Checkout` method with a list of paths, but in order to do it properly it would require public `DereferenceToT()` and/or `Peel<T>()` methods on `GitObject` so let's leave that for later.