### PR TITLE
Update libgit2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,10 @@
 
 ### Changes
 
+ - The native libraries are now expected to be in the `lib` directory,
+   instead of `NativeBinaries` for improved mono compatibility.  In
+   addition, the names of platform architectures now better reflect
+   the vendor naming (eg, `x86_64` instead of `amd64` on Linux).
  - Obsolete the config paths in RepositoryOptions
 
 ### Fixes

--- a/CI/build.msbuild
+++ b/CI/build.msbuild
@@ -49,10 +49,10 @@
         DestinationFiles="@(OutputFiles->'$(DeployFolder)\%(RecursiveDir)%(Filename)%(Extension)')" />
 
     <ItemGroup>
-      <NativeBinaries Include="$(TestBuildDir)\NativeBinaries\**\*.*" />
+      <NativeBinaries Include="$(TestBuildDir)\lib\**\*.*" />
     </ItemGroup>
 
     <Copy SourceFiles="@(NativeBinaries)"
-      DestinationFiles="@(NativeBinaries->'$(DeployFolder)\NativeBinaries\%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true" />
+      DestinationFiles="@(NativeBinaries->'$(DeployFolder)\lib\%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true" />
   </Target>
 </Project>

--- a/LibGit2Sharp.Tests/GlobalSettingsFixture.cs
+++ b/LibGit2Sharp.Tests/GlobalSettingsFixture.cs
@@ -19,7 +19,7 @@ namespace LibGit2Sharp.Tests
         public void CanRetrieveValidVersionString()
         {
             // Version string format is:
-            //      Major.Minor.Patch[-preDateTime]-LibGit2Sharp_abbrev_hash-libgit2_abbrev_hash (x86|amd64 - features)
+            //      Major.Minor.Patch[-preDateTime]-LibGit2Sharp_abbrev_hash-libgit2_abbrev_hash (x86|x64 - features)
             // Example output:
             //      "0.17.0[-pre20170914123547]-deadcafe-06d772d (x86 - Threads, Https)"
 
@@ -29,7 +29,7 @@ namespace LibGit2Sharp.Tests
             //      version: '0.17.0[-pre20170914123547]' LibGit2Sharp version number.
             //      git2SharpHash:'unknown' ( when compiled from source ) else LibGit2Sharp library hash.
             //      git2hash: '06d772d' LibGit2 library hash.
-            //      arch: 'x86' or 'amd64' LibGit2 target.
+            //      arch: 'x86' or 'x64' LibGit2 target.
             //      git2Features: 'Threads, Ssh' LibGit2 features compiled with.
             string regex = @"^(?<version>\d{1,}\.\d{1,2}\.\d{1,3}(-(pre|dev)\d{14})?)-(?<git2SharpHash>\w+)-(?<git2Hash>\w+) \((?<arch>\w+) - (?<git2Features>(?:\w*(?:, )*\w+)*)\)$";
 
@@ -38,7 +38,7 @@ namespace LibGit2Sharp.Tests
             Match regexResult = Regex.Match(versionInfo, regex);
 
             Assert.True(regexResult.Success, "The following version string format is enforced:" +
-                                             "Major.Minor.Patch[-preDateTime]-LibGit2Sharp_abbrev_hash-libgit2_abbrev_hash (x86|amd64 - features)");
+                                             "Major.Minor.Patch[-preDateTime]-LibGit2Sharp_abbrev_hash-libgit2_abbrev_hash (x86|x64 - features)");
 
             GroupCollection matchGroups = regexResult.Groups;
 

--- a/LibGit2Sharp.Tests/ShadowCopyFixture.cs
+++ b/LibGit2Sharp.Tests/ShadowCopyFixture.cs
@@ -59,14 +59,14 @@ namespace LibGit2Sharp.Tests
 
             if (!Constants.IsRunningOnUnix)
             {
-                // ...that this cache doesn't contain the `NativeBinaries` folder
+                // ...that this cache doesn't contain the `lib` folder
                 string cachedAssemblyParentPath = Path.GetDirectoryName(cachedAssemblyLocation);
-                Assert.False(Directory.Exists(Path.Combine(cachedAssemblyParentPath, "NativeBinaries")));
+                Assert.False(Directory.Exists(Path.Combine(cachedAssemblyParentPath, "lib")));
 
-                // ...whereas `NativeBinaries` of course exists next to the source assembly
+                // ...whereas `lib` of course exists next to the source assembly
                 string sourceAssemblyParentPath =
                     Path.GetDirectoryName(new Uri(sourceAssembly.EscapedCodeBase).LocalPath);
-                Assert.True(Directory.Exists(Path.Combine(sourceAssemblyParentPath, "NativeBinaries")));
+                Assert.True(Directory.Exists(Path.Combine(sourceAssemblyParentPath, "lib")));
             }
 
             AppDomain.Unload(domain);

--- a/LibGit2Sharp/Core/GitMergeOpts.cs
+++ b/LibGit2Sharp/Core/GitMergeOpts.cs
@@ -36,6 +36,12 @@ namespace LibGit2Sharp.Core
         public uint RecursionLimit;
 
         /// <summary>
+        /// Default merge driver to be used when both sides of a merge have
+        /// changed.  The default is the `text` driver.
+        /// </summary>
+        public string DefaultDriver;
+
+        /// <summary>
         /// Flags for automerging content.
         /// </summary>
         public MergeFileFavor MergeFileFavorFlags;

--- a/LibGit2Sharp/Core/GitWriteStream.cs
+++ b/LibGit2Sharp/Core/GitWriteStream.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 namespace LibGit2Sharp.Core
 {
     [StructLayout(LayoutKind.Sequential)]
-    internal class GitWriteStream
+    internal struct GitWriteStream
     {
         [MarshalAs(UnmanagedType.FunctionPtr)]
         public write_fn write;

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -127,6 +127,17 @@ namespace LibGit2Sharp.Core
             IntPtr data);
 
         [DllImport(libgit2)]
+        internal static extern unsafe int git_blob_create_fromstream(
+            out IntPtr stream,
+            git_repository* repositoryPtr,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath hintpath);
+
+        [DllImport(libgit2)]
+        internal static extern unsafe int git_blob_create_fromstream_commit(
+            ref GitOid oid,
+            IntPtr stream);
+
+        [DllImport(libgit2)]
         internal static extern unsafe int git_blob_create_fromchunks(
             ref GitOid oid,
             git_repository* repositoryPtr,

--- a/LibGit2Sharp/Core/Platform.cs
+++ b/LibGit2Sharp/Core/Platform.cs
@@ -13,7 +13,7 @@ namespace LibGit2Sharp.Core
     {
         public static string ProcessorArchitecture
         {
-            get { return Environment.Is64BitProcess ? "amd64" : "x86"; }
+            get { return Environment.Is64BitProcess ? "x64" : "x86"; }
         }
 
         public static OperatingSystemType OperatingSystem

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -115,18 +115,18 @@ namespace LibGit2Sharp.Core
 
         #region git_blob_
 
-        public static unsafe ObjectId git_blob_create_fromchunks(RepositoryHandle repo, FilePath hintpath, NativeMethods.source_callback fileCallback)
+        public static unsafe IntPtr git_blob_create_fromstream(RepositoryHandle repo, FilePath hintpath)
+        {
+            IntPtr writestream_ptr;
+
+            Ensure.ZeroResult(NativeMethods.git_blob_create_fromstream(out writestream_ptr, repo, hintpath));
+            return writestream_ptr;
+        }
+
+        public static unsafe ObjectId git_blob_create_fromstream_commit(IntPtr writestream_ptr)
         {
             var oid = new GitOid();
-            int res = NativeMethods.git_blob_create_fromchunks(ref oid, repo, hintpath, fileCallback, IntPtr.Zero);
-
-            if (res == (int)GitErrorCode.User)
-            {
-                throw new EndOfStreamException("The stream ended unexpectedly");
-            }
-
-            Ensure.ZeroResult(res);
-
+            Ensure.ZeroResult(NativeMethods.git_blob_create_fromstream_commit(ref oid, writestream_ptr));
             return oid;
         }
 

--- a/LibGit2Sharp/Filter.cs
+++ b/LibGit2Sharp/Filter.cs
@@ -261,8 +261,7 @@ namespace LibGit2Sharp
                 Marshal.StructureToPtr(state.thisStream, state.thisPtr, false);
 
                 state.nextPtr = git_writestream_next;
-                state.nextStream = new GitWriteStream();
-                Marshal.PtrToStructure(state.nextPtr, state.nextStream);
+                state.nextStream = (GitWriteStream)Marshal.PtrToStructure(state.nextPtr, typeof(GitWriteStream));
                 
                 state.filterSource = FilterSource.FromNativePtr(filterSourcePtr);
                 state.output = new WriteStream(state.nextStream, state.nextPtr);

--- a/LibGit2Sharp/GlobalSettings.cs
+++ b/LibGit2Sharp/GlobalSettings.cs
@@ -24,7 +24,7 @@ namespace LibGit2Sharp
             if (Platform.OperatingSystem == OperatingSystemType.Windows)
             {
                 string managedPath = new Uri(Assembly.GetExecutingAssembly().EscapedCodeBase).LocalPath;
-                nativeLibraryPath = Path.Combine(Path.GetDirectoryName(managedPath), "NativeBinaries");
+                nativeLibraryPath = Path.Combine(Path.Combine(Path.GetDirectoryName(managedPath), "lib"), "win32");
             }
 
             registeredFilters = new Dictionary<Filter, FilterRegistration>();
@@ -129,10 +129,10 @@ namespace LibGit2Sharp
         /// <summary>
         /// Sets a hint path for searching for native binaries: when
         /// specified, native binaries will first be searched in a
-        /// subdirectory of the given path corresponding to the architecture
-        /// (eg, "x86" or "amd64") before falling back to the default
-        /// path ("NativeBinaries\x86" or "NativeBinaries\amd64" next
-        /// to the application).
+        /// subdirectory of the given path corresponding to the operating
+        /// system and architecture (eg, "x86" or "x64") before falling
+        /// back to the default path ("lib\win32\x86" or "lib\win32\x64"
+        /// next to the application).
         /// <para>
         /// This must be set before any other calls to the library,
         /// and is not available on Unix platforms: see your dynamic

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\LibGit2Sharp.NativeBinaries.1.0.132\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.132\build\LibGit2Sharp.NativeBinaries.props')" />
+  <Import Project="..\packages\LibGit2Sharp.NativeBinaries.1.0.137\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.137\build\LibGit2Sharp.NativeBinaries.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -79,8 +79,8 @@
     <Compile Include="Core\GitFetchOptions.cs" />
     <Compile Include="Core\GitPushUpdate.cs" />
     <Compile Include="Core\GitSubmoduleIgnore.cs" />
-    <Compile Include="Core\Platform.cs" />
     <Compile Include="Core\GitWriteStream.cs" />
+    <Compile Include="Core\Platform.cs" />
     <Compile Include="Core\WriteStream.cs" />
     <Compile Include="Core\GitRebaseOperation.cs" />
     <Compile Include="Core\GitRebaseOptions.cs" />
@@ -381,7 +381,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.132\build\LibGit2Sharp.NativeBinaries.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\LibGit2Sharp.NativeBinaries.1.0.132\build\LibGit2Sharp.NativeBinaries.props'))" />
+    <Error Condition="!Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.137\build\LibGit2Sharp.NativeBinaries.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\LibGit2Sharp.NativeBinaries.1.0.137\build\LibGit2Sharp.NativeBinaries.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
@@ -390,7 +390,5 @@
   <Target Name="AfterBuild">
   </Target>
   -->
-  <ItemGroup>
-    <Folder Include="Commands\" />
-  </ItemGroup>
+  <ItemGroup />
 </Project>

--- a/LibGit2Sharp/Version.cs
+++ b/LibGit2Sharp/Version.cs
@@ -77,7 +77,7 @@ namespace LibGit2Sharp
         /// </summary>
         /// <para>
         ///   The format of the version number is as follows:
-        ///   <para>Major.Minor.Patch-LibGit2Sharp_abbrev_hash-libgit2_abbrev_hash (x86|amd64 - features)</para>
+        ///   <para>Major.Minor.Patch-LibGit2Sharp_abbrev_hash-libgit2_abbrev_hash (x86|x64 - features)</para>
         /// </para>
         /// <returns></returns>
         public override string ToString()

--- a/LibGit2Sharp/packages.config
+++ b/LibGit2Sharp/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="LibGit2Sharp.NativeBinaries" version="1.0.132" targetFramework="net4" allowedVersions="[1.0.132]" />
+  <package id="LibGit2Sharp.NativeBinaries" version="1.0.137" targetFramework="net4" allowedVersions="[1.0.137]" />
 </packages>


### PR DESCRIPTION
This depends on https://github.com/libgit2/libgit2/pull/3724, as we were bombing one of the submodule status tests when [looking for a submodule named `sm_changed_head/` with a trailing slash](https://github.com/libgit2/libgit2sharp/blob/master/LibGit2Sharp.Tests/SubmoduleFixture.cs#L137).  (Sigh.)

This uses the fancy new LibGit2Sharp.NativeBinaries where the native binaries now live in `lib` instead of `NativeBinaries`.  That means that this _should_ fix #1170.  So please argue if you think this is a terrible idea.

Otherwise, once https://github.com/libgit2/libgit2/pull/3724 is merged, I will reroll a new LibGit2Sharp.NativeBinaries nuget package and update this to use that.