### PR TITLE
Add signature-handling methods

### DIFF
--- a/LibGit2Sharp/Commit.cs
+++ b/LibGit2Sharp/Commit.cs
@@ -164,6 +164,42 @@ namespace LibGit2Sharp
             return Proxy.git_commit_extract_signature(repo.Handle, id, null);
         }
 
+        /// <summary>
+        /// Create a commit in-memory
+        /// <para>
+        /// Prettifing the message includes:
+        /// * Removing empty lines from the beginning and end.
+        /// * Removing trailing spaces from every line.
+        /// * Turning multiple consecutive empty lines between paragraphs into just one empty line.
+        /// * Ensuring the commit message ends with a newline.
+        /// * Removing every line starting with the <paramref name="commentChar"/>.
+        /// </para>
+        /// </summary>
+        /// <param name="author">The <see cref="Signature"/> of who made the change.</param>
+        /// <param name="committer">The <see cref="Signature"/> of who added the change to the repository.</param>
+        /// <param name="message">The description of why a change was made to the repository.</param>
+        /// <param name="tree">The <see cref="Tree"/> of the <see cref="Commit"/> to be created.</param>
+        /// <param name="parents">The parents of the <see cref="Commit"/> to be created.</param>
+        /// <param name="prettifyMessage">True to prettify the message, or false to leave it as is.</param>
+        /// <param name="commentChar">When non null, lines starting with this character will be stripped if prettifyMessage is true.</param>
+        /// <returns>The contents of the commit object.</returns>
+        public static string CreateBuffer(Signature author, Signature committer, string message, Tree tree, IEnumerable<Commit> parents, bool prettifyMessage, char? commentChar)
+        {
+            Ensure.ArgumentNotNull(message, "message");
+            Ensure.ArgumentDoesNotContainZeroByte(message, "message");
+            Ensure.ArgumentNotNull(author, "author");
+            Ensure.ArgumentNotNull(committer, "committer");
+            Ensure.ArgumentNotNull(tree, "tree");
+            Ensure.ArgumentNotNull(parents, "parents");
+
+            if (prettifyMessage)
+            {
+                message = Proxy.git_message_prettify(message, commentChar);
+            }
+
+            return Proxy.git_commit_create_buffer(tree.repo.Handle, author, committer, message, tree, parents.ToArray());
+        }
+
         private class ParentsCollection : ICollection<Commit>
         {
             private readonly Lazy<ICollection<Commit>> _parents;

--- a/LibGit2Sharp/Commit.cs
+++ b/LibGit2Sharp/Commit.cs
@@ -138,6 +138,32 @@ namespace LibGit2Sharp
             }
         }
 
+        /// <summary>
+        /// Extract the signature data from this commit
+        /// </summary>
+        /// <returns>The signature and the signed data</returns>
+        /// <param name="repo">The repository in which the object lives</param>
+        /// <param name="id">The commit to extract the signature from</param>
+        /// <param name="field">The header field which contains the signature; use null for the default of "gpgsig"</param>
+        public static SignatureInfo ExtractSignature(Repository repo, ObjectId id, string field)
+        {
+            return Proxy.git_commit_extract_signature(repo.Handle, id, field);
+        }
+
+        /// <summary>
+        /// Extract the signature data from this commit
+        /// <para>
+        /// The overload uses the default header field "gpgsig"
+        /// </para>
+        /// </summary>
+        /// <returns>The signature and the signed data</returns>
+        /// <param name="repo">The repository in which the object lives</param>
+        /// <param name="id">The commit to extract the signature from</param>
+        public static SignatureInfo ExtractSignature(Repository repo, ObjectId id)
+        {
+            return Proxy.git_commit_extract_signature(repo.Handle, id, null);
+        }
+
         private class ParentsCollection : ICollection<Commit>
         {
             private readonly Lazy<ICollection<Commit>> _parents;

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -338,6 +338,14 @@ namespace LibGit2Sharp.Core
         internal static extern unsafe git_oid* git_commit_tree_id(git_object* commit);
 
         [DllImport(libgit2)]
+        internal static extern unsafe int git_commit_extract_signature(
+            GitBuf signature,
+            GitBuf signed_data,
+            git_repository *repo,
+            ref GitOid commit_id,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string field);
+
+        [DllImport(libgit2)]
         internal static extern unsafe int git_config_delete_entry(
             git_config* cfg,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name);

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -317,6 +317,27 @@ namespace LibGit2Sharp.Core
             [MarshalAs(UnmanagedType.LPArray)] [In] IntPtr[] parents);
 
         [DllImport(libgit2)]
+        internal static extern unsafe int git_commit_create_buffer(
+            GitBuf res,
+            git_repository* repo,
+            git_signature* author,
+            git_signature* committer,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string encoding,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string message,
+            git_object* tree,
+            UIntPtr parent_count,
+            IntPtr* parents /* git_commit** originally */);
+
+        [DllImport(libgit2)]
+        internal static extern unsafe int git_commit_create_with_signature(
+            out GitOid id,
+            git_repository* repo,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string commit_content,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string signature,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string signature_field);
+
+
+        [DllImport(libgit2)]
         [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))]
         internal static extern unsafe string git_commit_message(git_object* commit);
 

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -920,6 +920,9 @@ namespace LibGit2Sharp.Core
         internal static extern unsafe void git_odb_stream_free(git_odb_stream* stream);
 
         [DllImport(libgit2)]
+        internal static extern unsafe int git_odb_write(out GitOid id, git_odb *odb, byte* data, UIntPtr len, GitObjectType type);
+
+        [DllImport(libgit2)]
         internal static extern unsafe git_oid* git_object_id(git_object* obj);
 
         [DllImport(libgit2)]

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -426,6 +426,22 @@ namespace LibGit2Sharp.Core
             return ObjectId.BuildFromPtr(NativeMethods.git_commit_tree_id(obj));
         }
 
+        public static unsafe SignatureInfo git_commit_extract_signature(RepositoryHandle repo, ObjectId id, string field)
+        {
+            using (var signature = new GitBuf())
+            using (var signedData = new GitBuf())
+            {
+                var oid = id.Oid;
+                Ensure.ZeroResult(NativeMethods.git_commit_extract_signature(signature, signedData, repo, ref oid, field));
+
+                return new SignatureInfo()
+                {
+                    Signature = LaxUtf8Marshaler.FromNative(signature.ptr, signature.size.ConvertToInt()),
+                    SignedData = LaxUtf8Marshaler.FromNative(signedData.ptr, signedData.size.ConvertToInt()),
+                };
+            }
+        }
+
         #endregion
 
         #region git_config_

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -1510,6 +1510,19 @@ namespace LibGit2Sharp.Core
             return id;
         }
 
+        public static unsafe ObjectId git_odb_write(ObjectDatabaseHandle odb, byte[] data, ObjectType type)
+        {
+            GitOid id;
+            int res;
+            fixed(byte* p = data)
+            {
+                res = NativeMethods.git_odb_write(out id, odb, p, new UIntPtr((ulong)data.LongLength), type.ToGitObjectType());
+            }
+            Ensure.ZeroResult(res);
+
+            return id;
+        }
+
         #endregion
 
         #region git_patch_

--- a/LibGit2Sharp/GitObject.cs
+++ b/LibGit2Sharp/GitObject.cs
@@ -28,7 +28,7 @@ namespace LibGit2Sharp
         /// <summary>
         /// The <see cref="Repository"/> containing the object.
         /// </summary>
-        protected readonly Repository repo;
+        internal readonly Repository repo;
 
         /// <summary>
         /// Needed for mocking purposes.

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -355,6 +355,7 @@
     <Compile Include="Commands\Stage.cs" />
     <Compile Include="Commands\Remove.cs" />
     <Compile Include="Commands\Checkout.cs" />
+    <Compile Include="SignatureInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="CustomDictionary.xml" />

--- a/LibGit2Sharp/ObjectDatabase.cs
+++ b/LibGit2Sharp/ObjectDatabase.cs
@@ -423,6 +423,32 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
+        /// Inserts a <see cref="Commit"/> into the object database after attaching the given signature.
+        /// </summary>
+        /// <param name="commitContent">The raw unsigned commit</param>
+        /// <param name="signature">The signature data </param>
+        /// <param name="field">The header field in the commit in which to store the signature</param>
+        /// <returns>The created <see cref="Commit"/>.</returns>
+        public virtual ObjectId CreateCommitWithSignature(string commitContent, string signature, string field)
+        {
+            return Proxy.git_commit_create_with_signature(repo.Handle, commitContent, signature, field);
+        }
+
+        /// <summary>
+        /// Inserts a <see cref="Commit"/> into the object database after attaching the given signature.
+        /// <para>
+        /// This overload uses the default header field of "gpgsig"
+        /// </para>
+        /// </summary>
+        /// <param name="commitContent">The raw unsigned commit</param>
+        /// <param name="signature">The signature data </param>
+        /// <returns>The created <see cref="Commit"/>.</returns>
+        public virtual ObjectId CreateCommitWithSignature(string commitContent, string signature)
+        {
+            return Proxy.git_commit_create_with_signature(repo.Handle, commitContent, signature, null);
+        }
+
+        /// <summary>
         /// Inserts a <see cref="TagAnnotation"/> into the object database, pointing to a specific <see cref="GitObject"/>.
         /// </summary>
         /// <param name="name">The name.</param>

--- a/LibGit2Sharp/ObjectDatabase.cs
+++ b/LibGit2Sharp/ObjectDatabase.cs
@@ -178,6 +178,16 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
+        /// Write an object to the object database
+        /// </summary>
+        /// <param name="data">The contents of the object</param>
+        /// <typeparam name="T">The type of object to write</typeparam>
+        public virtual ObjectId Write<T>(byte[] data) where T : GitObject
+        {
+            return Proxy.git_odb_write(handle, data, GitObject.TypeToKindMap[typeof(T)]);
+        }
+
+        /// <summary>
         /// Inserts a <see cref="Blob"/> into the object database, created from the content of a stream.
         /// <para>Optionally, git filters will be applied to the content before storing it.</para>
         /// </summary>

--- a/LibGit2Sharp/SignatureInfo.cs
+++ b/LibGit2Sharp/SignatureInfo.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace LibGit2Sharp
+{
+    /// <summary>
+    /// Structure for holding a signature extracted from a commit or a tag
+    /// </summary>
+    public struct SignatureInfo
+    {
+        /// <summary>
+        /// The signature data, PGP/GPG or otherwise.
+        /// </summary>
+        public string Signature;
+        /// <summary>
+        /// The data which was signed. The object contents without the signature part.
+        /// </summary>
+        public string SignedData;
+    }
+}
+


### PR DESCRIPTION
Wrap the library's signed-commit handling methods.

`CreateCommitWithSignature()` is in `ObjectDatabase` since that's where the rest are, although we'd want to move them all together into `Repository` eventually.

Fixes #1101