### PR TITLE
Expose merge analysis

### DIFF
--- a/LibGit2Sharp/Core/DisposableArray.cs
+++ b/LibGit2Sharp/Core/DisposableArray.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace LibGit2Sharp.Core
+{
+    /// <summary>
+    /// An array containing disposables, for convenience when dealing with handles
+    /// </summary>
+    internal class DisposableArray<T> : IDisposable where T : IDisposable
+    {
+        readonly T[] array;
+
+        /// <summary>
+        /// Create a wrapper for the given array so the contents will be disposed when this class is disposed.
+        /// </summary>
+        /// <param name="handles">The array of dispsables</param>
+        public DisposableArray(T[] handles)
+        {
+            array = handles;
+        }
+
+        /// <summary>
+        /// Create a wrapper for the given array so the contents will be disposed when this class is disposed.
+        /// <para>
+        /// The enumerable is first made into an array
+        /// </para>
+        /// </summary>
+        /// <param name="handles">Handles.</param>
+        public DisposableArray(IEnumerable<T> handles)
+        {
+            array = handles.ToArray();
+        }
+
+        /// <summary>
+        /// The underlying array
+        /// </summary>
+        public T[] Array { get { return array; } }
+
+        /// <summary>
+        /// Return the underlying array so we can use this wherever the methods expect an array
+        /// </summary>
+        public static implicit operator T[](DisposableArray<T> da)
+        {
+            return da.array;
+        }
+
+        /// <summary>
+        /// Call Dispose on each of the elements of the array
+        /// </summary>
+        public void Dispose()
+        {
+            foreach (var handle in array)
+            {
+                handle.Dispose();
+            }
+        }
+    }
+}
+

--- a/LibGit2Sharp/IRepository.cs
+++ b/LibGit2Sharp/IRepository.cs
@@ -216,6 +216,21 @@ namespace LibGit2Sharp
         MergeResult Merge(string committish, Signature merger, MergeOptions options);
 
         /// <summary>
+        /// Analyze the possibilities of updating HEAD with the given commit(s).
+        /// </summary>
+        /// <param name="commits">Commits to merge into HEAD</param>
+        /// <returns>Which update methods are possible and which preference the user has specified</returns>
+        MergeAnalysisResult AnalyzeMerge(params Commit[] commits);
+
+
+        /// <summary>
+        /// Analyze the possibilities of updating HEAD with the given reference(s)
+        /// </summary>
+        /// <param name="references">References to merge into HEAD</param>
+        /// <returns>Which update methods are possible and which preference the user has specified</returns>
+        MergeAnalysisResult AnalyzeMerge(params Reference[] references);
+
+        /// <summary>
         /// Access to Rebase functionality.
         /// </summary>
         Rebase Rebase { get; }

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -119,10 +119,13 @@
     <Compile Include="IndexReucEntry.cs" />
     <Compile Include="IndexReucEntryCollection.cs" />
     <Compile Include="IndexNameEntry.cs" />
+    <Compile Include="MergeAnalysis.cs" />
+    <Compile Include="MergeAnalysisResult.cs" />
     <Compile Include="MergeAndCheckoutOptionsBase.cs" />
     <Compile Include="CheckoutConflictException.cs" />
     <Compile Include="MergeOptions.cs" />
     <Compile Include="MergeOptionsBase.cs" />
+    <Compile Include="MergePreference.cs" />
     <Compile Include="MergeResult.cs" />
     <Compile Include="MergeTreeOptions.cs" />
     <Compile Include="MergeTreeResult.cs" />
@@ -354,6 +357,7 @@
     <Compile Include="Commands\Fetch.cs" />
     <Compile Include="Commands\Stage.cs" />
     <Compile Include="Commands\Remove.cs" />
+    <Compile Include="Core\DisposableArray.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="CustomDictionary.xml" />

--- a/LibGit2Sharp/MergeAnalysis.cs
+++ b/LibGit2Sharp/MergeAnalysis.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace LibGit2Sharp
+{
+    /// <summary>
+    /// Description of the possibilities for merging one or multiple branches into HEAD
+    /// </summary>
+    [Flags]
+    public enum MergeAnalysis
+    {
+        /// <summary>
+        /// No update possible. This is a dummy to serve as default value.
+        /// </summary>
+        None = 0,
+        /// <summary>
+        /// A "normal" merge; both HEAD and the given merge input have diverged
+        /// from their common ancestor.  The divergent commits must be merged.
+        /// </summary>
+        Normal = (1 << 0),
+
+        /// <summary>
+        /// All given merge inputs are reachable from HEAD, meaning the
+        /// repository is up-to-date and no merge needs to be performed.
+        /// </summary>
+        UpToDate = (1 << 1),
+
+        /// <summary>
+        /// The given merge input is a fast-forward from HEAD and no merge
+        /// needs to be performed.  Instead, the client can check out the
+        /// given merge input.
+        /// </summary>
+        FastForward = (1 << 2),
+
+        /// <summary>
+        /// The HEAD of the current repository is "unborn" and does not point to
+        /// a valid commit.  No merge can be performed, but the caller may wish
+        /// to simply set HEAD to the target commit(s).
+        /// </summary>
+        Unborn = (1 << 3),
+    }
+}

--- a/LibGit2Sharp/MergeAnalysisResult.cs
+++ b/LibGit2Sharp/MergeAnalysisResult.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using LibGit2Sharp.Core;
+
+namespace LibGit2Sharp
+{
+    /// <summary>
+    /// The result of analyzing the possibilities of merging a commit or branch into HEAD.
+    /// </summary>
+    public struct MergeAnalysisResult
+    {
+        /// <summary>
+        /// The result of the analysis done on the commits given.
+        /// </summary>
+        public MergeAnalysis Analysis;
+        /// <summary>
+        /// The user's preference for the type of merge to perform.
+        /// </summary>
+        public MergePreference Preference;
+
+        static MergeAnalysis MergeAnalysisFromGitMergeAnalysis(GitMergeAnalysis analysisIn)
+        {
+            MergeAnalysis analysis = default(MergeAnalysis);
+
+            if (analysisIn.HasFlag(GitMergeAnalysis.GIT_MERGE_ANALYSIS_NORMAL))
+            {
+                analysis |= MergeAnalysis.Normal;
+            }
+            if (analysisIn.HasFlag(GitMergeAnalysis.GIT_MERGE_ANALYSIS_UP_TO_DATE))
+            {
+                analysis |= MergeAnalysis.UpToDate;
+            }
+            if (analysisIn.HasFlag(GitMergeAnalysis.GIT_MERGE_ANALYSIS_FASTFORWARD))
+            {
+                analysis |= MergeAnalysis.FastForward;
+            }
+
+            if (analysisIn.HasFlag(GitMergeAnalysis.GIT_MERGE_ANALYSIS_UNBORN))
+            {
+                analysis |= MergeAnalysis.Unborn;
+            }
+
+            return analysis;
+        }
+
+        static MergePreference MergePreferenceFromGitMergePreference(GitMergePreference preference)
+        {
+            switch (preference)
+            {
+                case GitMergePreference.GIT_MERGE_PREFERENCE_NONE:
+                    return MergePreference.Default;
+                case GitMergePreference.GIT_MERGE_PREFERENCE_FASTFORWARD_ONLY:
+                    return MergePreference.FastForwardOnly;
+                case GitMergePreference.GIT_MERGE_PREFERENCE_NO_FASTFORWARD:
+                    return MergePreference.NoFastForward;
+                default:
+                    throw new InvalidOperationException(String.Format("Unknown merge preference: {0}", preference));
+            }
+        }
+
+        internal MergeAnalysisResult(GitMergeAnalysis analysis, GitMergePreference preference)
+        {
+            Analysis = MergeAnalysisFromGitMergeAnalysis(analysis);
+            Preference = MergePreferenceFromGitMergePreference(preference);
+        }
+    }
+}

--- a/LibGit2Sharp/MergePreference.cs
+++ b/LibGit2Sharp/MergePreference.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace LibGit2Sharp
+{
+    /// <summary>
+    /// Indicates the user's stated preference for merges
+    /// </summary>
+    public enum MergePreference
+    {
+        /// <summary>
+        /// No configuration was found that suggests a preferred behavior for
+        /// merge.
+        /// </summary>
+        Default = 0,
+
+        /// <summary>
+        /// There is a `merge.ff=false` configuration setting, suggesting that
+        /// the user does not want to allow a fast-forward merge.
+        /// </summary>
+        NoFastForward = (1 << 0),
+
+        /// <summary>
+        /// There is a `merge.ff=only` configuration setting, suggesting that
+        /// the user only wants fast-forward merges.
+        /// </summary>
+        FastForwardOnly = (1 << 1),
+    }
+}


### PR DESCRIPTION
This allows us to ask the library about what kind of actions
are available for merging into HEAD.

---

I'm still not quite sure what the overloads should be. Maybe leave as-is and think about exposing annotated commits as a type.