### PR TITLE
Expose message prettification

### DIFF
--- a/LibGit2Sharp.Tests/CommitFixture.cs
+++ b/LibGit2Sharp.Tests/CommitFixture.cs
@@ -1045,5 +1045,15 @@ namespace LibGit2Sharp.Tests
                     new CommitOptions { AmendPreviousCommit = true }));
             }
         }
+
+        [Fact]
+        public void CanPrettifyAMessage()
+        {
+            string input = "# Comment\nA line that will remain\n# And another character\n\n\n";
+            string expected = "A line that will remain\n";
+
+            Assert.Equal(expected, Commit.PrettifyMessage(input, '#'));
+            Assert.Equal(expected, Commit.PrettifyMessage(input.Replace('#', ';'), ';'));
+        }
     }
 }

--- a/LibGit2Sharp/Commit.cs
+++ b/LibGit2Sharp/Commit.cs
@@ -113,6 +113,20 @@ namespace LibGit2Sharp
             return encoding ?? "UTF-8";
         }
 
+        /// <summary>
+        /// Prettify a commit message
+        /// <para>
+        /// Remove comment lines and trailing lines
+        /// </para>
+        /// </summary>
+        /// <returns>The prettified message</returns>
+        /// <param name="message">The message to prettify.</param>
+        /// <param name="commentChar">Comment character. Lines starting with it will be removed</param>
+        public static string PrettifyMessage(string message, char commentChar)
+        {
+            return Proxy.git_message_prettify(message, commentChar);
+        }
+
         private string DebuggerDisplay
         {
             get

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -1256,7 +1256,7 @@ namespace LibGit2Sharp.Core
 
             using (var buf = new GitBuf())
             {
-                int res = NativeMethods.git_message_prettify(buf, message, false, (sbyte)comment);
+                int res = NativeMethods.git_message_prettify(buf, message, true, (sbyte)comment);
                 Ensure.Int32Result(res);
 
                 return LaxUtf8Marshaler.FromNative(buf.ptr) ?? string.Empty;


### PR DESCRIPTION
From #749 let's not hide this in our command-emulating methods but let the caller prettify as much as they want.

This does flip the card-coded bool to prettify... I think we should have that on or off depending on whether we actually got a comment char but that's an API change and blegh.