### PR TITLE
Don't convert to Windows-style paths when dealing with Git data

### DIFF
--- a/LibGit2Sharp.Tests/DiffTreeToTreeFixture.cs
+++ b/LibGit2Sharp.Tests/DiffTreeToTreeFixture.cs
@@ -10,7 +10,7 @@ namespace LibGit2Sharp.Tests
 {
     public class DiffTreeToTreeFixture : BaseFixture
     {
-        private static readonly string subBranchFilePath = Path.Combine("1", "branch_file.txt");
+        private static readonly string subBranchFilePath = String.Join("/", "1", "branch_file.txt");
 
         [Fact]
         public void ComparingATreeAgainstItselfReturnsNoDifference()

--- a/LibGit2Sharp.Tests/FileHistoryFixture.cs
+++ b/LibGit2Sharp.Tests/FileHistoryFixture.cs
@@ -151,7 +151,7 @@ namespace LibGit2Sharp.Tests
                 var commit2 = MakeAndCommitChange(repo, repoPath, path1, "Hello World again");
 
                 // Move the first file to a new directory.
-                var newPath1 = Path.Combine(SubFolderPath1, path1);
+                var newPath1 = Path.Combine(SubFolderPath1, path1).Replace(@"\", "/");
                 Commands.Move(repo, path1, newPath1);
                 var commit3 = repo.Commit("Moved " + path1 + " to " + newPath1,
                     Constants.Signature, Constants.Signature);

--- a/LibGit2Sharp.Tests/IgnoreFixture.cs
+++ b/LibGit2Sharp.Tests/IgnoreFixture.cs
@@ -79,8 +79,8 @@ namespace LibGit2Sharp.Tests
 
                 Assert.False(repo.Ignore.IsPathIgnored("File.txt"));
                 Assert.True(repo.Ignore.IsPathIgnored("NewFolder"));
-                Assert.True(repo.Ignore.IsPathIgnored(string.Format(@"NewFolder{0}NewFolder", Path.DirectorySeparatorChar)));
-                Assert.True(repo.Ignore.IsPathIgnored(string.Format(@"NewFolder{0}NewFolder{0}File.txt", Path.DirectorySeparatorChar)));
+                Assert.True(repo.Ignore.IsPathIgnored(string.Join("/", "NewFolder", "NewFolder")));
+                Assert.True(repo.Ignore.IsPathIgnored(string.Join("/", "NewFolder", "NewFolder", "File.txt")));
             }
         }
 
@@ -90,9 +90,7 @@ namespace LibGit2Sharp.Tests
             string path = InitNewRepository();
             using (var repo = new Repository(path))
             {
-                char pd = Path.DirectorySeparatorChar;
-
-                var gitIgnoreFile = string.Format("deeply{0}nested{0}.gitignore", pd);
+                var gitIgnoreFile = string.Join("/", "deeply", "nested", ".gitignore");
                 Touch(repo.Info.WorkingDirectory, gitIgnoreFile, "SmtCounters.h");
 
                 Commands.Stage(repo, gitIgnoreFile);
@@ -100,11 +98,11 @@ namespace LibGit2Sharp.Tests
 
                 Assert.False(repo.RetrieveStatus().IsDirty);
 
-                var ignoredFile = string.Format("deeply{0}nested{0}SmtCounters.h", pd);
+                var ignoredFile = string.Join("/", "deeply", "nested", "SmtCounters.h");
                 Touch(repo.Info.WorkingDirectory, ignoredFile, "Content");
                 Assert.False(repo.RetrieveStatus().IsDirty);
 
-                var file = string.Format("deeply{0}nested{0}file.txt", pd);
+                var file = string.Join("/", "deeply", "nested", "file.txt");
                 Touch(repo.Info.WorkingDirectory, file, "Yeah!");
 
                 var repositoryStatus = repo.RetrieveStatus();

--- a/LibGit2Sharp.Tests/IndexFixture.cs
+++ b/LibGit2Sharp.Tests/IndexFixture.cs
@@ -10,7 +10,7 @@ namespace LibGit2Sharp.Tests
 {
     public class IndexFixture : BaseFixture
     {
-        private static readonly string subBranchFile = Path.Combine("1", "branch_file.txt");
+        private static readonly string subBranchFile = string.Join("/", "1", "branch_file.txt");
         private readonly string[] expectedEntries = new[]
                                                         {
                                                             "1.txt",
@@ -202,7 +202,7 @@ namespace LibGit2Sharp.Tests
         public void PathsOfIndexEntriesAreExpressedInNativeFormat()
         {
             // Build relative path
-            string relFilePath = Path.Combine("directory", "Testfile.txt");
+            string relFilePath = Path.Combine("directory", "Testfile.txt").Replace('\\', '/');
 
             string repoPath = InitNewRepository();
 

--- a/LibGit2Sharp.Tests/ResetIndexFixture.cs
+++ b/LibGit2Sharp.Tests/ResetIndexFixture.cs
@@ -79,7 +79,7 @@ namespace LibGit2Sharp.Tests
 
                 RepositoryStatus newStatus = repo.RetrieveStatus();
 
-                var expected = new[] { "1.txt", Path.Combine("1", "branch_file.txt"), "deleted_staged_file.txt",
+                var expected = new[] { "1.txt", string.Join("/", "1", "branch_file.txt"), "deleted_staged_file.txt",
                     "deleted_unstaged_file.txt", "modified_staged_file.txt", "modified_unstaged_file.txt" };
 
                 Assert.Equal(expected.Length, newStatus.Where(IsStaged).Count());

--- a/LibGit2Sharp.Tests/StageFixture.cs
+++ b/LibGit2Sharp.Tests/StageFixture.cs
@@ -222,7 +222,7 @@ namespace LibGit2Sharp.Tests
 
                 const string posixifiedPath = "Project/a_file.txt";
                 Assert.NotNull(repo.Index[posixifiedPath]);
-                Assert.Equal(file, repo.Index[posixifiedPath].Path);
+                Assert.Equal(posixifiedPath, repo.Index[posixifiedPath].Path);
             }
         }
 

--- a/LibGit2Sharp.Tests/StatusFixture.cs
+++ b/LibGit2Sharp.Tests/StatusFixture.cs
@@ -268,7 +268,7 @@ namespace LibGit2Sharp.Tests
         }
 
         [Fact]
-        public void RetrievingTheStatusOfARepositoryReturnNativeFilePaths()
+        public void RetrievingTheStatusOfARepositoryReturnsGitPaths()
         {
             // Build relative path
             string relFilePath = Path.Combine("directory", "Testfile.txt");
@@ -289,7 +289,7 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(1, repoStatus.Count());
                 StatusEntry statusEntry = repoStatus.Single();
 
-                Assert.Equal(relFilePath, statusEntry.FilePath);
+                Assert.Equal(relFilePath.Replace('\\', '/'), statusEntry.FilePath);
 
                 Assert.Equal(statusEntry.FilePath, repoStatus.Added.Select(s => s.FilePath).Single());
             }
@@ -360,6 +360,7 @@ namespace LibGit2Sharp.Tests
 
                 RepositoryStatus status = repo.RetrieveStatus();
 
+                relativePath = relativePath.Replace('\\', '/');
                 Assert.Equal(new[] { relativePath, "new_untracked_file.txt" }, status.Untracked.Select(s => s.FilePath));
 
                 Touch(repo.Info.WorkingDirectory, ".gitignore", "*.txt" + Environment.NewLine);
@@ -461,8 +462,6 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void RetrievingTheStatusOfTheRepositoryHonorsTheGitIgnoreDirectivesThroughoutDirectories()
         {
-            char dirSep = Path.DirectorySeparatorChar;
-
             string path = SandboxStandardTestRepo();
             using (var repo = new Repository(path))
             {
@@ -476,7 +475,7 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(FileStatus.Ignored, repo.RetrieveStatus("bin/what-about-me.txt"));
 
                 RepositoryStatus newStatus = repo.RetrieveStatus();
-                Assert.Equal(new[] { "bin" + dirSep }, newStatus.Ignored.Select(s => s.FilePath));
+                Assert.Equal(new[] { "bin/" }, newStatus.Ignored.Select(s => s.FilePath));
 
                 var sb = new StringBuilder();
                 sb.AppendLine("bin/*");
@@ -488,8 +487,8 @@ namespace LibGit2Sharp.Tests
 
                 newStatus = repo.RetrieveStatus();
 
-                Assert.Equal(new[] { "bin" + dirSep + "look-ma.txt" }, newStatus.Ignored.Select(s => s.FilePath));
-                Assert.True(newStatus.Untracked.Select(s => s.FilePath).Contains("bin" + dirSep + "what-about-me.txt"));
+                Assert.Equal(new[] { "bin/look-ma.txt" }, newStatus.Ignored.Select(s => s.FilePath));
+                Assert.True(newStatus.Untracked.Select(s => s.FilePath).Contains("bin/what-about-me.txt"));
             }
         }
 
@@ -603,7 +602,7 @@ namespace LibGit2Sharp.Tests
             var path = SandboxStandardTestRepo();
             string[] unalteredPaths = {
                 "1.txt",
-                "1" + Path.DirectorySeparatorChar + "branch_file.txt",
+                "1/branch_file.txt",
                 "branch_file.txt",
                 "new.txt",
                 "README",

--- a/LibGit2Sharp.Tests/SubmoduleFixture.cs
+++ b/LibGit2Sharp.Tests/SubmoduleFixture.cs
@@ -133,12 +133,10 @@ namespace LibGit2Sharp.Tests
         }
 
         [Theory]
-        [InlineData("sm_changed_head", false)]
-        [InlineData("sm_changed_head", true)]
-        public void CanStageChangeInSubmoduleViaIndexStage(string submodulePath, bool appendPathSeparator)
+        [InlineData("sm_changed_head")]
+        [InlineData("sm_changed_head/")]
+        public void CanStageChangeInSubmoduleViaIndexStage(string submodulePath)
         {
-            submodulePath += appendPathSeparator ? Path.DirectorySeparatorChar : default(char?);
-
             var path = SandboxSubmoduleTestRepo();
             using (var repo = new Repository(path))
             {
@@ -156,12 +154,10 @@ namespace LibGit2Sharp.Tests
         }
 
         [Theory]
-        [InlineData("sm_changed_head", false)]
-        [InlineData("sm_changed_head", true)]
-        public void CanStageChangeInSubmoduleViaIndexStageWithOtherPaths(string submodulePath, bool appendPathSeparator)
+        [InlineData("sm_changed_head")]
+        [InlineData("sm_changed_head/")]
+        public void CanStageChangeInSubmoduleViaIndexStageWithOtherPaths(string submodulePath)
         {
-            submodulePath += appendPathSeparator ? Path.DirectorySeparatorChar : default(char?);
-
             var path = SandboxSubmoduleTestRepo();
             using (var repo = new Repository(path))
             {

--- a/LibGit2Sharp.Tests/TreeFixture.cs
+++ b/LibGit2Sharp.Tests/TreeFixture.cs
@@ -169,6 +169,18 @@ namespace LibGit2Sharp.Tests
         }
 
         [Fact]
+        public void TreeUsesPosixStylePaths()
+        {
+            using (var repo = new Repository(BareTestRepoPath))
+            {
+                /* From a commit tree */
+                var commitTree = repo.Lookup<Commit>("4c062a6").Tree;
+                Assert.NotNull(commitTree["1/branch_file.txt"]);
+                Assert.Null(commitTree["1\\branch_file.txt"]);
+            }
+        }
+
+        [Fact]
         public void CanRetrieveTreeEntryPath()
         {
             string path = SandboxBareTestRepo();
@@ -180,7 +192,7 @@ namespace LibGit2Sharp.Tests
                 TreeEntry treeTreeEntry = commitTree["1"];
                 Assert.Equal("1", treeTreeEntry.Path);
 
-                string completePath = Path.Combine("1", "branch_file.txt");
+                string completePath = "1/branch_file.txt";
 
                 TreeEntry blobTreeEntry = commitTree["1/branch_file.txt"];
                 Assert.Equal(completePath, blobTreeEntry.Path);

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -103,7 +103,7 @@ namespace LibGit2Sharp.Core
         internal static extern unsafe int git_blame_file(
             out git_blame* blame,
             git_repository* repo,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath path,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string path,
             git_blame_options options);
 
         [DllImport(libgit2)]
@@ -130,7 +130,7 @@ namespace LibGit2Sharp.Core
         internal static extern unsafe int git_blob_create_fromstream(
             out IntPtr stream,
             git_repository* repositoryPtr,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath hintpath);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string hintpath);
 
         [DllImport(libgit2)]
         internal static extern unsafe int git_blob_create_fromstream_commit(
@@ -141,7 +141,7 @@ namespace LibGit2Sharp.Core
         internal static extern unsafe int git_blob_create_fromchunks(
             ref GitOid oid,
             git_repository* repositoryPtr,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath hintpath,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string hintpath,
             source_callback fileCallback,
             IntPtr data);
 
@@ -149,7 +149,7 @@ namespace LibGit2Sharp.Core
         internal static extern unsafe int git_blob_filtered_content(
             GitBuf buf,
             git_object* blob,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath as_path,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string as_path,
             [MarshalAs(UnmanagedType.Bool)] bool check_for_binary_data);
 
         [DllImport(libgit2)]
@@ -587,9 +587,9 @@ namespace LibGit2Sharp.Core
         [DllImport(libgit2)]
         internal static extern unsafe int git_diff_blobs(
             git_object* oldBlob,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath old_as_path,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string old_as_path,
             git_object* newBlob,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath new_as_path,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string new_as_path,
             GitDiffOptions options,
             git_diff_file_cb fileCallback,
             git_diff_binary_cb binaryCallback,
@@ -672,7 +672,7 @@ namespace LibGit2Sharp.Core
         internal static extern unsafe int git_ignore_path_is_ignored(
             out int ignored,
             git_repository* repo,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath path);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string path);
 
         [DllImport(libgit2)]
         internal static extern unsafe int git_index_add_bypath(
@@ -690,7 +690,7 @@ namespace LibGit2Sharp.Core
             out git_index_entry* ours,
             out git_index_entry* theirs,
             git_index* index,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath path);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string path);
 
         [DllImport(libgit2)]
         internal static extern unsafe int git_index_conflict_iterator_new(
@@ -723,7 +723,7 @@ namespace LibGit2Sharp.Core
         [DllImport(libgit2)]
         internal static extern unsafe git_index_entry* git_index_get_bypath(
             git_index* index,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath path,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string path,
             int stage);
 
         [DllImport(libgit2)]
@@ -748,7 +748,7 @@ namespace LibGit2Sharp.Core
         [DllImport(libgit2)]
         internal static extern unsafe int git_index_remove_bypath(
             git_index* index,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath path);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string path);
 
 
         [DllImport(libgit2)]
@@ -760,7 +760,7 @@ namespace LibGit2Sharp.Core
         [DllImport(libgit2)]
         internal static extern unsafe git_index_reuc_entry* git_index_reuc_get_bypath(
             git_index* handle,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath path);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string path);
 
         [DllImport(libgit2)]
         internal static extern unsafe int git_index_write(git_index* index);
@@ -1623,7 +1623,7 @@ namespace LibGit2Sharp.Core
         internal static extern unsafe int git_submodule_lookup(
             out git_submodule* reference,
             git_repository* repo,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath name);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name);
 
         [DllImport(libgit2)]
         internal static extern unsafe int git_submodule_resolve_url(

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -1821,7 +1821,7 @@ namespace LibGit2Sharp.Core
         internal static extern unsafe int git_tree_entry_bypath(
             out git_tree_entry* tree,
             git_object* root,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath treeentry_path);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string treeentry_path);
 
         [DllImport(libgit2)]
         internal static extern unsafe void git_tree_entry_free(git_tree_entry* treeEntry);

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -97,7 +97,7 @@ namespace LibGit2Sharp.Core
 
         public static unsafe BlameHandle git_blame_file(
             RepositoryHandle repo,
-            FilePath path,
+            string path,
             git_blame_options options)
         {
             git_blame* ptr;
@@ -115,7 +115,7 @@ namespace LibGit2Sharp.Core
 
         #region git_blob_
 
-        public static unsafe IntPtr git_blob_create_fromstream(RepositoryHandle repo, FilePath hintpath)
+        public static unsafe IntPtr git_blob_create_fromstream(RepositoryHandle repo, string hintpath)
         {
             IntPtr writestream_ptr;
 
@@ -148,7 +148,7 @@ namespace LibGit2Sharp.Core
             return oid;
         }
 
-        public static unsafe UnmanagedMemoryStream git_blob_filtered_content_stream(RepositoryHandle repo, ObjectId id, FilePath path, bool check_for_binary_data)
+        public static unsafe UnmanagedMemoryStream git_blob_filtered_content_stream(RepositoryHandle repo, ObjectId id, string path, bool check_for_binary_data)
         {
             var buf = new GitBuf();
             var handle = new ObjectSafeWrapper(id, repo).ObjectPtr;
@@ -1008,7 +1008,7 @@ namespace LibGit2Sharp.Core
 
         public static unsafe Conflict git_index_conflict_get(
             IndexHandle index,
-            FilePath path)
+            string path)
         {
             git_index_entry* ancestor, ours, theirs;
 
@@ -1073,7 +1073,7 @@ namespace LibGit2Sharp.Core
             return NativeMethods.git_index_get_byindex(index, n);
         }
 
-        public static unsafe git_index_entry* git_index_get_bypath(IndexHandle index, FilePath path, int stage)
+        public static unsafe git_index_entry* git_index_get_bypath(IndexHandle index, string path, int stage)
         {
             return NativeMethods.git_index_get_bypath(index, path, stage);
         }
@@ -1112,7 +1112,7 @@ namespace LibGit2Sharp.Core
             Ensure.ZeroResult(res);
         }
 
-        public static unsafe void git_index_remove_bypath(IndexHandle index, FilePath path)
+        public static unsafe void git_index_remove_bypath(IndexHandle index, string path)
         {
             int res = NativeMethods.git_index_remove_bypath(index, path);
             Ensure.ZeroResult(res);
@@ -2922,7 +2922,7 @@ namespace LibGit2Sharp.Core
         /// Returns a handle to the corresponding submodule,
         /// or an invalid handle if a submodule is not found.
         /// </summary>
-        public static unsafe SubmoduleHandle git_submodule_lookup(RepositoryHandle repo, FilePath name)
+        public static unsafe SubmoduleHandle git_submodule_lookup(RepositoryHandle repo, string name)
         {
             git_submodule* submodule;
             var res = NativeMethods.git_submodule_lookup(out submodule, repo, name);

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -3220,7 +3220,7 @@ namespace LibGit2Sharp.Core
             return new TreeEntryHandle(handle, false);
         }
 
-        public static unsafe TreeEntryHandle git_tree_entry_bypath(RepositoryHandle repo, ObjectId id, FilePath treeentry_path)
+        public static unsafe TreeEntryHandle git_tree_entry_bypath(RepositoryHandle repo, ObjectId id, string treeentry_path)
         {
             using (var obj = new ObjectSafeWrapper(id, repo))
             {

--- a/LibGit2Sharp/GitObject.cs
+++ b/LibGit2Sharp/GitObject.cs
@@ -60,7 +60,7 @@ namespace LibGit2Sharp
             get { return Id.Sha; }
         }
 
-        internal static GitObject BuildFrom(Repository repo, ObjectId id, GitObjectType type, FilePath path)
+        internal static GitObject BuildFrom(Repository repo, ObjectId id, GitObjectType type, string path)
         {
             switch (type)
             {

--- a/LibGit2Sharp/IndexEntry.cs
+++ b/LibGit2Sharp/IndexEntry.cs
@@ -47,11 +47,11 @@ namespace LibGit2Sharp
                 return null;
             }
 
-            FilePath path = LaxFilePathMarshaler.FromNative(entry->path);
+            string path = LaxUtf8Marshaler.FromNative(entry->path);
 
             return new IndexEntry
             {
-                Path = path.Native,
+                Path = path,
                 Id = new ObjectId(entry->id.Id),
                 StageLevel = Proxy.git_index_entry_stage(entry),
                 Mode = (Mode)entry->mode,

--- a/LibGit2Sharp/Repository.cs
+++ b/LibGit2Sharp/Repository.cs
@@ -527,7 +527,7 @@ namespace LibGit2Sharp
             return Lookup(objectish, type.ToGitObjectType(), LookUpOptions.None);
         }
 
-        internal GitObject LookupInternal(ObjectId id, GitObjectType type, FilePath knownPath)
+        internal GitObject LookupInternal(ObjectId id, GitObjectType type, string knownPath)
         {
             Ensure.ArgumentNotNull(id, "id");
 

--- a/LibGit2Sharp/RepositoryStatus.cs
+++ b/LibGit2Sharp/RepositoryStatus.cs
@@ -138,24 +138,24 @@ namespace LibGit2Sharp
             if ((gitStatus & FileStatus.RenamedInIndex) == FileStatus.RenamedInIndex)
             {
                 headToIndexRenameDetails =
-                    new RenameDetails(LaxFilePathMarshaler.FromNative(deltaHeadToIndex->old_file.Path).Native,
-                                      LaxFilePathMarshaler.FromNative(deltaHeadToIndex->new_file.Path).Native,
+                    new RenameDetails(LaxUtf8Marshaler.FromNative(deltaHeadToIndex->old_file.Path),
+                                      LaxUtf8Marshaler.FromNative(deltaHeadToIndex->new_file.Path),
                                       (int)deltaHeadToIndex->similarity);
             }
 
             if ((gitStatus & FileStatus.RenamedInWorkdir) == FileStatus.RenamedInWorkdir)
             {
                 indexToWorkDirRenameDetails =
-                    new RenameDetails(LaxFilePathMarshaler.FromNative(deltaIndexToWorkDir->old_file.Path).Native,
-                                      LaxFilePathMarshaler.FromNative(deltaIndexToWorkDir->new_file.Path).Native,
+                    new RenameDetails(LaxUtf8Marshaler.FromNative(deltaIndexToWorkDir->old_file.Path),
+                                      LaxUtf8Marshaler.FromNative(deltaIndexToWorkDir->new_file.Path),
                                       (int)deltaIndexToWorkDir->similarity);
             }
 
-            var filePath = (deltaIndexToWorkDir != null)
-                ? LaxFilePathMarshaler.FromNative(deltaIndexToWorkDir->new_file.Path)
-                : LaxFilePathMarshaler.FromNative(deltaHeadToIndex->new_file.Path);
+            var filePath = LaxUtf8Marshaler.FromNative(deltaIndexToWorkDir != null ?
+                deltaIndexToWorkDir->new_file.Path :
+                deltaHeadToIndex->new_file.Path);
 
-            StatusEntry statusEntry = new StatusEntry(filePath.Native, gitStatus, headToIndexRenameDetails, indexToWorkDirRenameDetails);
+            StatusEntry statusEntry = new StatusEntry(filePath, gitStatus, headToIndexRenameDetails, indexToWorkDirRenameDetails);
 
             if (gitStatus == FileStatus.Unaltered)
             {

--- a/LibGit2Sharp/TreeDefinition.cs
+++ b/LibGit2Sharp/TreeDefinition.cs
@@ -126,11 +126,6 @@ namespace LibGit2Sharp
             Ensure.ArgumentNotNullOrEmptyString(targetTreeEntryPath, "targetTreeEntryPath");
             Ensure.ArgumentNotNull(treeEntryDefinition, "treeEntryDefinition");
 
-            if (Path.IsPathRooted(targetTreeEntryPath))
-            {
-                throw new ArgumentException("The provided path is an absolute path.");
-            }
-
             if (treeEntryDefinition is TransientTreeTreeEntryDefinition)
             {
                 throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture,
@@ -383,9 +378,9 @@ namespace LibGit2Sharp
             }
         }
 
-        private static Tuple<string, string> ExtractPosixLeadingSegment(FilePath targetPath)
+        private static Tuple<string, string> ExtractPosixLeadingSegment(string targetPath)
         {
-            string[] segments = targetPath.Posix.Split(new[] { '/' }, 2);
+            string[] segments = targetPath.Split(new[] { '/' }, 2);
 
             if (segments[0] == string.Empty || (segments.Length == 2 && (segments[1] == string.Empty || segments[1].StartsWith("/", StringComparison.Ordinal))))
             {

--- a/LibGit2Sharp/TreeEntry.cs
+++ b/LibGit2Sharp/TreeEntry.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Diagnostics;
 using System.Globalization;
-using System.Runtime.InteropServices;
 using LibGit2Sharp.Core;
 using LibGit2Sharp.Core.Handles;
 
@@ -28,7 +27,7 @@ namespace LibGit2Sharp
         protected TreeEntry()
         { }
 
-        internal unsafe TreeEntry(TreeEntryHandle entry, ObjectId parentTreeId, Repository repo, FilePath parentPath)
+        internal unsafe TreeEntry(TreeEntryHandle entry, ObjectId parentTreeId, Repository repo, string parentPath)
         {
             this.parentTreeId = parentTreeId;
             this.repo = repo;
@@ -41,7 +40,7 @@ namespace LibGit2Sharp
 
             Mode = Proxy.git_tree_entry_attributes(entry);
             Name = Proxy.git_tree_entry_name(entry);
-            path = new Lazy<string>(() => System.IO.Path.Combine(parentPath.Native, Name));
+            path = new Lazy<string>(() => Tree.CombinePath(parentPath, Name));
         }
 
         /// <summary>

--- a/LibGit2Sharp/TreeEntryChanges.cs
+++ b/LibGit2Sharp/TreeEntryChanges.cs
@@ -18,8 +18,8 @@ namespace LibGit2Sharp
 
         internal unsafe TreeEntryChanges(git_diff_delta* delta)
         {
-            Path = LaxFilePathMarshaler.FromNative(delta->new_file.Path).Native;
-            OldPath = LaxFilePathMarshaler.FromNative(delta->old_file.Path).Native;
+            Path = LaxUtf8Marshaler.FromNative(delta->new_file.Path);
+            OldPath = LaxUtf8Marshaler.FromNative(delta->old_file.Path);
 
             Mode = (Mode)delta->new_file.Mode;
             OldMode = (Mode)delta->old_file.Mode;


### PR DESCRIPTION
I've ported the tests from #603 on top of master to check what we still had to do, but they pass on my system.

So we should probably add them to make sure they don't break, but AFAICT these situations are already handled.
