### PR TITLE
Remove FollowFilter for add an override of QueryBy

### DIFF
--- a/LibGit2Sharp.Tests/FileHistoryFixture.cs
+++ b/LibGit2Sharp.Tests/FileHistoryFixture.cs
@@ -98,7 +98,7 @@ namespace LibGit2Sharp.Tests
 
                 // Test --date-order.
                 var timeHistory = repo.Commits.QueryBy(path,
-                    new FollowFilter { SortBy = CommitSortStrategies.Time });
+                    new CommitFilter { SortBy = CommitSortStrategies.Time });
                 var timeCommits = new List<Commit>
                 {
                     master10, // master
@@ -117,7 +117,7 @@ namespace LibGit2Sharp.Tests
 
                 // Test --topo-order.
                 var topoHistory = repo.Commits.QueryBy(path,
-                    new FollowFilter { SortBy = CommitSortStrategies.Topological });
+                    new CommitFilter { SortBy = CommitSortStrategies.Topological });
                 var topoCommits = new List<Commit>
                 {
                     master10, // master
@@ -255,33 +255,33 @@ namespace LibGit2Sharp.Tests
                 MakeAndCommitChange(repo, repoPath, path, "Hello World");
 
                 Assert.Throws<ArgumentException>(() =>
-                    repo.Commits.QueryBy(path, new FollowFilter
+                    repo.Commits.QueryBy(path, new CommitFilter
                     {
                         SortBy = CommitSortStrategies.None
                     }));
 
                 Assert.Throws<ArgumentException>(() =>
-                    repo.Commits.QueryBy(path, new FollowFilter
+                    repo.Commits.QueryBy(path, new CommitFilter
                     {
                         SortBy = CommitSortStrategies.Reverse
                     }));
 
                 Assert.Throws<ArgumentException>(() =>
-                    repo.Commits.QueryBy(path, new FollowFilter
+                    repo.Commits.QueryBy(path, new CommitFilter
                     {
                         SortBy = CommitSortStrategies.Reverse |
                                  CommitSortStrategies.Topological
                     }));
 
                 Assert.Throws<ArgumentException>(() =>
-                    repo.Commits.QueryBy(path, new FollowFilter
+                    repo.Commits.QueryBy(path, new CommitFilter
                     {
                         SortBy = CommitSortStrategies.Reverse |
                                  CommitSortStrategies.Time
                     }));
 
                 Assert.Throws<ArgumentException>(() =>
-                    repo.Commits.QueryBy(path, new FollowFilter
+                    repo.Commits.QueryBy(path, new CommitFilter
                     {
                         SortBy = CommitSortStrategies.Reverse |
                                  CommitSortStrategies.Topological |

--- a/LibGit2Sharp/CommitLog.cs
+++ b/LibGit2Sharp/CommitLog.cs
@@ -97,12 +97,27 @@ namespace LibGit2Sharp
         /// <param name="path">The file's path.</param>
         /// <param name="filter">The options used to control which commits will be returned.</param>
         /// <returns>A list of file history entries, ready to be enumerated.</returns>
+        [Obsolete("This method is deprecated. Please use the overload which take LibGit2Sharp.CommitFilter")]
         public IEnumerable<LogEntry> QueryBy(string path, FollowFilter filter)
         {
             Ensure.ArgumentNotNull(path, "path");
             Ensure.ArgumentNotNull(filter, "filter");
 
-            return new FileHistory(repo, path, new CommitFilter { SortBy = filter.SortBy });
+            return QueryBy(path, new CommitFilter { SortBy = filter.SortBy });
+        }
+
+        /// <summary>
+        /// Returns the list of commits of the repository representing the history of a file beyond renames.
+        /// </summary>
+        /// <param name="path">The file's path.</param>
+        /// <param name="filter">The options used to control which commits will be returned.</param>
+        /// <returns>A list of file history entries, ready to be enumerated.</returns>
+        public IEnumerable<LogEntry> QueryBy(string path, CommitFilter filter)
+        {
+            Ensure.ArgumentNotNull(path, "path");
+            Ensure.ArgumentNotNull(filter, "filter");
+
+            return new FileHistory(repo, path, filter);
         }
 
         private class CommitEnumerator : IEnumerator<Commit>

--- a/LibGit2Sharp/FollowFilter.cs
+++ b/LibGit2Sharp/FollowFilter.cs
@@ -9,6 +9,7 @@ namespace LibGit2Sharp
     /// The commits will be enumerated from the current HEAD of the repository.
     /// </para>
     /// </summary>
+    [Obsolete("This type is deprecated. Please use LibGit2Sharp.CommitFilter")]
     public sealed class FollowFilter
     {
         private static readonly List<CommitSortStrategies> AllowedSortStrategies = new List<CommitSortStrategies>

--- a/LibGit2Sharp/IQueryableCommitLog.cs
+++ b/LibGit2Sharp/IQueryableCommitLog.cs
@@ -28,6 +28,16 @@ namespace LibGit2Sharp
         /// <param name="path">The file's path.</param>
         /// <param name="filter">The options used to control which commits will be returned.</param>
         /// <returns>A list of file history entries, ready to be enumerated.</returns>
+        [Obsolete("This method is deprecated. Please use the overload which take LibGit2Sharp.CommitFilter")]
         IEnumerable<LogEntry> QueryBy(string path, FollowFilter filter);
+
+        /// <summary>
+        /// Returns the list of commits of the repository representing the history of a file beyond renames.
+        /// </summary>
+        /// <param name="path">The file's path.</param>
+        /// <param name="filter">The options used to control which commits will be returned.</param>
+        /// <returns>A list of file history entries, ready to be enumerated.</returns>
+        IEnumerable<LogEntry> QueryBy(string path, CommitFilter filter);
+
     }
 }


### PR DESCRIPTION
`FollowFilter` is a duplicate with `CommitFilter`. We only need ensure the `SortStrategies` has checked before create `FileHistory`.

Visual Studio tests passed except `NoPublicTypesUnderLibGit2SharpCoreNamespace`

to close #1276