### PR TITLE
CommitFixture: create a sensible string

### DIFF
--- a/LibGit2Sharp.Tests/CommitFixture.cs
+++ b/LibGit2Sharp.Tests/CommitFixture.cs
@@ -1057,57 +1057,57 @@ namespace LibGit2Sharp.Tests
             Assert.Equal(expected, Commit.PrettifyMessage(input.Replace('#', ';'), ';'));
         }
 
-        private readonly string signedCommit = @"tree 6b79e22d69bf46e289df0345a14ca059dfc9bdf6
-parent 34734e478d6cf50c27c9d69026d93974d052c454
-author Ben Burkert <ben@benburkert.com> 1358451456 -0800
-committer Ben Burkert <ben@benburkert.com> 1358451456 -0800
-gpgsig -----BEGIN PGP SIGNATURE-----
- Version: GnuPG v1.4.12 (Darwin)
- 
- iQIcBAABAgAGBQJQ+FMIAAoJEH+LfPdZDSs1e3EQAJMjhqjWF+WkGLHju7pTw2al
- o6IoMAhv0Z/LHlWhzBd9e7JeCnanRt12bAU7yvYp9+Z+z+dbwqLwDoFp8LVuigl8
- JGLcnwiUW3rSvhjdCp9irdb4+bhKUnKUzSdsR2CK4/hC0N2i/HOvMYX+BRsvqweq
- AsAkA6dAWh+gAfedrBUkCTGhlNYoetjdakWqlGL1TiKAefEZrtA1TpPkGn92vbLq
- SphFRUY9hVn1ZBWrT3hEpvAIcZag3rTOiRVT1X1flj8B2vGCEr3RrcwOIZikpdaW
- who/X3xh/DGbI2RbuxmmJpxxP/8dsVchRJJzBwG+yhwU/iN3MlV2c5D69tls/Dok
- 6VbyU4lm/ae0y3yR83D9dUlkycOnmmlBAHKIZ9qUts9X7mWJf0+yy2QxJVpjaTGG
- cmnQKKPeNIhGJk2ENnnnzjEve7L7YJQF6itbx5VCOcsGh3Ocb3YR7DMdWjt7f8pu
- c6j+q1rP7EpE2afUN/geSlp5i3x8aXZPDj67jImbVCE/Q1X9voCtyzGJH7MXR0N9
- ZpRF8yzveRfMH8bwAJjSOGAFF5XkcR/RNY95o+J+QcgBLdX48h+ZdNmUf6jqlu3J
- 7KmTXXQcOVpN6dD3CmRFsbjq+x6RHwa8u1iGn+oIkX908r97ckfB/kHKH7ZdXIJc
- cpxtDQQMGYFpXK/71stq
- =ozeK
- -----END PGP SIGNATURE-----
+        private readonly string signedCommit =
+            "tree 6b79e22d69bf46e289df0345a14ca059dfc9bdf6\n" +
+            "parent 34734e478d6cf50c27c9d69026d93974d052c454\n" +
+            "author Ben Burkert <ben@benburkert.com> 1358451456 -0800\n" +
+            "committer Ben Burkert <ben@benburkert.com> 1358451456 -0800\n" +
+            "gpgsig -----BEGIN PGP SIGNATURE-----\n" +
+            " Version: GnuPG v1.4.12 (Darwin)\n" +
+            " \n" +
+            " iQIcBAABAgAGBQJQ+FMIAAoJEH+LfPdZDSs1e3EQAJMjhqjWF+WkGLHju7pTw2al\n" +
+            " o6IoMAhv0Z/LHlWhzBd9e7JeCnanRt12bAU7yvYp9+Z+z+dbwqLwDoFp8LVuigl8\n" +
+            " JGLcnwiUW3rSvhjdCp9irdb4+bhKUnKUzSdsR2CK4/hC0N2i/HOvMYX+BRsvqweq\n" +
+            " AsAkA6dAWh+gAfedrBUkCTGhlNYoetjdakWqlGL1TiKAefEZrtA1TpPkGn92vbLq\n" +
+            " SphFRUY9hVn1ZBWrT3hEpvAIcZag3rTOiRVT1X1flj8B2vGCEr3RrcwOIZikpdaW\n" +
+            " who/X3xh/DGbI2RbuxmmJpxxP/8dsVchRJJzBwG+yhwU/iN3MlV2c5D69tls/Dok\n" +
+            " 6VbyU4lm/ae0y3yR83D9dUlkycOnmmlBAHKIZ9qUts9X7mWJf0+yy2QxJVpjaTGG\n" +
+            " cmnQKKPeNIhGJk2ENnnnzjEve7L7YJQF6itbx5VCOcsGh3Ocb3YR7DMdWjt7f8pu\n" +
+            " c6j+q1rP7EpE2afUN/geSlp5i3x8aXZPDj67jImbVCE/Q1X9voCtyzGJH7MXR0N9\n" +
+            " ZpRF8yzveRfMH8bwAJjSOGAFF5XkcR/RNY95o+J+QcgBLdX48h+ZdNmUf6jqlu3J\n" +
+            " 7KmTXXQcOVpN6dD3CmRFsbjq+x6RHwa8u1iGn+oIkX908r97ckfB/kHKH7ZdXIJc\n" +
+            " cpxtDQQMGYFpXK/71stq\n" +
+            " =ozeK\n" +
+            " -----END PGP SIGNATURE-----\n" +
+            "\n" +
+            "a simple commit which works\n";
 
-a simple commit which works
-";
+        private readonly string signatureData =
+            "-----BEGIN PGP SIGNATURE-----\n" +
+            "Version: GnuPG v1.4.12 (Darwin)\n" +
+            "\n" +
+            "iQIcBAABAgAGBQJQ+FMIAAoJEH+LfPdZDSs1e3EQAJMjhqjWF+WkGLHju7pTw2al\n" +
+            "o6IoMAhv0Z/LHlWhzBd9e7JeCnanRt12bAU7yvYp9+Z+z+dbwqLwDoFp8LVuigl8\n" +
+            "JGLcnwiUW3rSvhjdCp9irdb4+bhKUnKUzSdsR2CK4/hC0N2i/HOvMYX+BRsvqweq\n" +
+            "AsAkA6dAWh+gAfedrBUkCTGhlNYoetjdakWqlGL1TiKAefEZrtA1TpPkGn92vbLq\n" +
+            "SphFRUY9hVn1ZBWrT3hEpvAIcZag3rTOiRVT1X1flj8B2vGCEr3RrcwOIZikpdaW\n" +
+            "who/X3xh/DGbI2RbuxmmJpxxP/8dsVchRJJzBwG+yhwU/iN3MlV2c5D69tls/Dok\n" +
+            "6VbyU4lm/ae0y3yR83D9dUlkycOnmmlBAHKIZ9qUts9X7mWJf0+yy2QxJVpjaTGG\n" +
+            "cmnQKKPeNIhGJk2ENnnnzjEve7L7YJQF6itbx5VCOcsGh3Ocb3YR7DMdWjt7f8pu\n" +
+            "c6j+q1rP7EpE2afUN/geSlp5i3x8aXZPDj67jImbVCE/Q1X9voCtyzGJH7MXR0N9\n" +
+            "ZpRF8yzveRfMH8bwAJjSOGAFF5XkcR/RNY95o+J+QcgBLdX48h+ZdNmUf6jqlu3J\n" +
+            "7KmTXXQcOVpN6dD3CmRFsbjq+x6RHwa8u1iGn+oIkX908r97ckfB/kHKH7ZdXIJc\n" +
+            "cpxtDQQMGYFpXK/71stq\n" +
+            "=ozeK\n" +
+            "-----END PGP SIGNATURE-----";
 
-        private readonly string signatureData = @"-----BEGIN PGP SIGNATURE-----
-Version: GnuPG v1.4.12 (Darwin)
-
-iQIcBAABAgAGBQJQ+FMIAAoJEH+LfPdZDSs1e3EQAJMjhqjWF+WkGLHju7pTw2al
-o6IoMAhv0Z/LHlWhzBd9e7JeCnanRt12bAU7yvYp9+Z+z+dbwqLwDoFp8LVuigl8
-JGLcnwiUW3rSvhjdCp9irdb4+bhKUnKUzSdsR2CK4/hC0N2i/HOvMYX+BRsvqweq
-AsAkA6dAWh+gAfedrBUkCTGhlNYoetjdakWqlGL1TiKAefEZrtA1TpPkGn92vbLq
-SphFRUY9hVn1ZBWrT3hEpvAIcZag3rTOiRVT1X1flj8B2vGCEr3RrcwOIZikpdaW
-who/X3xh/DGbI2RbuxmmJpxxP/8dsVchRJJzBwG+yhwU/iN3MlV2c5D69tls/Dok
-6VbyU4lm/ae0y3yR83D9dUlkycOnmmlBAHKIZ9qUts9X7mWJf0+yy2QxJVpjaTGG
-cmnQKKPeNIhGJk2ENnnnzjEve7L7YJQF6itbx5VCOcsGh3Ocb3YR7DMdWjt7f8pu
-c6j+q1rP7EpE2afUN/geSlp5i3x8aXZPDj67jImbVCE/Q1X9voCtyzGJH7MXR0N9
-ZpRF8yzveRfMH8bwAJjSOGAFF5XkcR/RNY95o+J+QcgBLdX48h+ZdNmUf6jqlu3J
-7KmTXXQcOVpN6dD3CmRFsbjq+x6RHwa8u1iGn+oIkX908r97ckfB/kHKH7ZdXIJc
-cpxtDQQMGYFpXK/71stq
-=ozeK
------END PGP SIGNATURE-----";
-
-        private readonly string signedData = @"tree 6b79e22d69bf46e289df0345a14ca059dfc9bdf6
-parent 34734e478d6cf50c27c9d69026d93974d052c454
-author Ben Burkert <ben@benburkert.com> 1358451456 -0800
-committer Ben Burkert <ben@benburkert.com> 1358451456 -0800
-
-a simple commit which works
-";
-
+        private readonly string signedData =
+            "tree 6b79e22d69bf46e289df0345a14ca059dfc9bdf6\n" +
+            "parent 34734e478d6cf50c27c9d69026d93974d052c454\n" +
+            "author Ben Burkert <ben@benburkert.com> 1358451456 -0800\n" +
+            "committer Ben Burkert <ben@benburkert.com> 1358451456 -0800\n" +
+            "\n" +
+            "a simple commit which works\n";
 
         [Fact]
         public void CanExtractSignatureFromCommit()


### PR DESCRIPTION
Stop the crying of the users of `core.autocrlf` everywhere.

Fixes #1313 and #1314 