### PR TITLE
Include Ignored Options

### DIFF
--- a/LibGit2Sharp.Tests/StatusFixture.cs
+++ b/LibGit2Sharp.Tests/StatusFixture.cs
@@ -319,6 +319,29 @@ namespace LibGit2Sharp.Tests
         }
 
         [Fact]
+        public void RetrievingTheStatusWithoutIncludeIgnoredIgnoresButDoesntInclude()
+        {
+            string repoPath = InitNewRepository();
+
+            using (var repo = new Repository(repoPath))
+            {
+                const string relativePath = "look-ma.txt";
+                Touch(repo.Info.WorkingDirectory, relativePath, "I'm going to be ignored!");
+                var opt = new StatusOptions { IncludeIgnored = false };
+                Assert.False(opt.IncludeIgnored);
+                RepositoryStatus status = repo.RetrieveStatus(opt);
+                Assert.Equal(new[] { relativePath }, status.Untracked.Select(s => s.FilePath));
+
+                Touch(repo.Info.WorkingDirectory, ".gitignore", "*.txt" + Environment.NewLine);
+
+                RepositoryStatus newStatus = repo.RetrieveStatus(opt);
+                Assert.Equal(".gitignore", newStatus.Untracked.Select(s => s.FilePath).Single());
+
+                Assert.False(newStatus.Ignored.Any());
+            }
+        }
+
+        [Fact]
         public void RetrievingTheStatusOfTheRepositoryHonorsTheGitIgnoreDirectives()
         {
             string path = SandboxStandardTestRepo();

--- a/LibGit2Sharp/RepositoryStatus.cs
+++ b/LibGit2Sharp/RepositoryStatus.cs
@@ -79,10 +79,14 @@ namespace LibGit2Sharp
                 Version = 1,
                 Show = (GitStatusShow)options.Show,
                 Flags =
-                    GitStatusOptionFlags.IncludeIgnored |
                     GitStatusOptionFlags.IncludeUntracked |
                     GitStatusOptionFlags.RecurseUntrackedDirs,
             };
+
+            if (options.IncludeIgnored)
+            {
+                coreOptions.Flags |= GitStatusOptionFlags.IncludeIgnored;
+            }
 
             if (options.DetectRenamesInIndex)
             {

--- a/LibGit2Sharp/StatusOptions.cs
+++ b/LibGit2Sharp/StatusOptions.cs
@@ -35,6 +35,7 @@
         public StatusOptions()
         {
             DetectRenamesInIndex = true;
+            IncludeIgnored = true;
         }
 
         /// <summary>
@@ -84,5 +85,14 @@
         /// Unaltered meaning the file is identical in the working directory, the index and HEAD.
         /// </remarks>
         public bool IncludeUnaltered { get; set; }
+
+        /// <summary>
+        /// Include ignored files when scanning for status
+        /// </summary>
+        /// <remarks>
+        /// ignored meaning present in .gitignore. Defaults to true for back compat but may improve perf to not include if you have thousands of ignored files.
+        /// </remarks>
+        public bool IncludeIgnored { get; set; }
+
     }
 }


### PR DESCRIPTION
We have some repos that produce thousands of ignored files so retrieve status takes 20 minute on them if we include ignore files vs a couple of seconds if we don't. There fore we were hoping we could make including ignored files optional. 