### PR TITLE
Remove obsolete field.

### DIFF
--- a/LibGit2Sharp/Core/GitCloneOptions.cs
+++ b/LibGit2Sharp/Core/GitCloneOptions.cs
@@ -23,8 +23,6 @@ namespace LibGit2Sharp.Core
         public GitCloneLocal Local;
         public IntPtr CheckoutBranch;
 
-        public IntPtr signature; // Really a SignatureSafeHandle
-
         public IntPtr RepositoryCb;
         public IntPtr RepositoryCbPayload;
 


### PR DESCRIPTION
This field was removed from libgit2 a year and a half ago.

This is the libgit2 commit: https://github.com/libgit2/libgit2/commit/659cf2029f322ea876d663d85783b48945227e8f#diff-7c9f3aae8ea34d171fe8f44fbedde372L140

This is the libgit2sharp commit: https://github.com/libgit2/libgit2sharp/commit/4c5c088e8f9b1bb494ed1c088f5838f8d67031d9