### PR TITLE
Expose enable/disable cache setting

### DIFF
--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -636,6 +636,10 @@ namespace LibGit2Sharp.Core
         internal static extern int git_libgit2_opts(int option, uint level,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))]string path);
 
+        // git_libgit2_opts(GIT_OPT_ENABLE_CACHING, uint enabled)
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int git_libgit2_opts(int option, uint enabled);
+
         #endregion
 
         [DllImport(libgit2)]

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -3403,6 +3403,17 @@ namespace LibGit2Sharp.Core
             Ensure.ZeroResult(res);
         }
 
+        /// <summary>
+        /// Enable or disable the libgit2 cache
+        /// </summary>
+        /// <param name="enabled">true to enable the cache, false otherwise</param>
+        public static void git_libgit2_opts_set_enable_caching(bool enabled)
+        {
+            // libgit2 expects non-zero value for true
+            var res = NativeMethods.git_libgit2_opts((int)LibGitOption.EnableCaching, (uint)(enabled ? 1 : 0));
+            Ensure.ZeroResult(res);
+        }
+
         #endregion
 
         private static ICollection<TResult> git_foreach<T, TResult>(

--- a/LibGit2Sharp/GlobalSettings.cs
+++ b/LibGit2Sharp/GlobalSettings.cs
@@ -299,5 +299,14 @@ namespace LibGit2Sharp
             var pathString = (paths == null) ? null : string.Join(Path.PathSeparator.ToString(), paths);
             Proxy.git_libgit2_opts_set_search_path(level, pathString);
         }
+
+        /// <summary>
+        /// Enable or disable the libgit2 cache
+        /// </summary>
+        /// <param name="enabled">true to enable the cache, false otherwise</param>
+        public static void SetEnableCaching(bool enabled)
+        {
+            Proxy.git_libgit2_opts_set_enable_caching(enabled);
+        }
     }
 }


### PR DESCRIPTION
Expose the existing GIT_OPT_ENABLE_CACHING setting in libgit2.
See: https://github.com/libgit2/libgit2/blob/master/src/settings.c#L139
