### PR TITLE
Fixed issue #1362: enumerating the notes collection for a repository …

### DIFF
--- a/LibGit2Sharp.Tests/NoteFixture.cs
+++ b/LibGit2Sharp.Tests/NoteFixture.cs
@@ -308,6 +308,21 @@ namespace LibGit2Sharp.Tests
             }
         }
 
+	    [Fact]
+	    public void CanRetrieveNotesWhenThereAreNotAny()
+	    {
+		    string path = InitNewRepository();	// doesn't reproduce an error when using a sandbox repository so we have to create an actual repo.
+		    using (var repo = new Repository(path))
+		    {
+			    foreach (var note in repo.Notes)
+			    {
+				    Assert.NotNull(note);
+			    }
+			    Assert.Equal(0, repo.Notes.Count());
+		    }
+	    }
+
+
         private static T[] SortedNotes<T>(IEnumerable<Note> notes, Func<Note, T> selector)
         {
             return notes.OrderBy(n => n.Message, StringComparer.Ordinal).Select(selector).ToArray();

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -1392,7 +1392,7 @@ namespace LibGit2Sharp.Core
             return git_foreach(resultSelector, c => NativeMethods.git_note_foreach(repo,
                                                                                    notes_ref,
                                                                                    (ref GitOid x, ref GitOid y, IntPtr p) => c(x, y, p),
-                                                                                   IntPtr.Zero));
+                                                                                   IntPtr.Zero), GitErrorCode.NotFound);
         }
 
         public static unsafe string git_note_message(NoteHandle note)


### PR DESCRIPTION
…that has no notes throws an exception.

I'm not sure if this is the best solution, but the test reproduces the problem.

This fixes issue #1362 .
