### PR TITLE
Add filepaths to ContentChangeStats.

### DIFF
--- a/LibGit2Sharp/ContentChangeStats.cs
+++ b/LibGit2Sharp/ContentChangeStats.cs
@@ -16,15 +16,27 @@ namespace LibGit2Sharp
         public virtual int LinesDeleted { get; private set; }
 
         /// <summary>
+        /// The number of lines deleted in the diff.
+        /// </summary>
+        public virtual string OldFileName { get; private set; }
+
+        /// <summary>
+        /// The number of lines deleted in the diff.
+        /// </summary>
+        public virtual string NewFileName { get; private set; }
+
+        /// <summary>
         /// For mocking.
         /// </summary>
         protected ContentChangeStats()
         { }
 
-        internal ContentChangeStats(int added, int deleted)
+        internal ContentChangeStats(int added, int deleted, string oldFileName, string newFileName)
         {
             LinesAdded = added;
             LinesDeleted = deleted;
+            OldFileName = oldFileName;
+            NewFileName = newFileName;
         }
     }
 }

--- a/LibGit2Sharp/PatchStats.cs
+++ b/LibGit2Sharp/PatchStats.cs
@@ -37,11 +37,12 @@ namespace LibGit2Sharp
                         var delta = Proxy.git_diff_get_delta(diff, i);
                         var pathPtr = delta->new_file.Path != null ? delta->new_file.Path : delta->old_file.Path;
                         var newFilePath = LaxFilePathMarshaler.FromNative(pathPtr);
+                        var oldFilePath = LaxFilePathMarshaler.FromNative(delta->old_file.Path);
 
                         var stats = Proxy.git_patch_line_stats(patch);
                         int added = stats.Item1;
                         int deleted = stats.Item2;
-                        changes.Add(newFilePath, new ContentChangeStats(added, deleted));
+                        changes.Add(newFilePath, new ContentChangeStats(added, deleted, oldFilePath.ToString(), newFilePath.ToString()));
                         totalLinesAdded += added;
                         totalLinesDeleted += deleted;
                     }


### PR DESCRIPTION
Hi,

I'm looking for a way to exclude file renames when counting lines changed by a commit.  At the moment it is possible to iterate the individual ContentChangeStats which a PatchStats diff contains.
However it is not possible to see if a ContentChangeStats corresponds to a file rename.

Hence adding the original filepath and new filepath to the ContentChangeStats would be helpful.

Thanks,