### PR TITLE
Fix MSBuild build with xbuild 12.0 engine (mono 4.2.1)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@
 
 language: csharp
 mono:
- - 3.12.0
  - 4.2.3
 
 os:

--- a/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
+++ b/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>LibGit2Sharp.Tests</RootNamespace>
     <AssemblyName>LibGit2Sharp.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>LibGit2Sharp</RootNamespace>
     <AssemblyName>LibGit2Sharp</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 ## Prerequisites
 
- - **Windows:** .NET 4.0+
- - **Linux/Mac OS X:** Mono 3.6+
+ - **Windows:** .NET 4.5+
+ - **Linux/Mac OS X:** Mono 4.2+
 
 ## Online resources
 


### PR DESCRIPTION
If someone tried to build libgit2sharp with the xbuild 12.0
engine that comes with mono 4.2.1 [[1]](quite widespread given
that it's the version bundled with Ubuntu 16.04.x LTS), the
build would not work.

By supporting older versions of MS.NET/Mono, newer versions
of Mono wouldn't be supported (because newer versions of Mono
don't ship older .NET 4.0 profile).

This change similar to this recent commit in MonoAddins:
mono/mono-addins@a3efa4c

[1] $ mono --version
Mono JIT compiler version 4.2.1 (Debian 4.2.1.102+dfsg2-7ubuntu4)
Copyright (C) 2002-2014 Novell, Inc, Xamarin Inc and Contributors. www.mono-project.com
    TLS:           __thread
    SIGSEGV:       altstack
    Notifications: epoll
    Architecture:  amd64
    Disabled:      none
    Misc:          softdebug
    LLVM:          supported, not enabled.
    GC:            sgen
