### PR TITLE
Add InludeUntracked and RecurseUntrackedDirs to StatusOptions

### DIFF
--- a/LibGit2Sharp/RepositoryStatus.cs
+++ b/LibGit2Sharp/RepositoryStatus.cs
@@ -78,14 +78,16 @@ namespace LibGit2Sharp
             {
                 Version = 1,
                 Show = (GitStatusShow)options.Show,
-                Flags =
-                    GitStatusOptionFlags.IncludeUntracked |
-                    GitStatusOptionFlags.RecurseUntrackedDirs,
             };
 
             if (options.IncludeIgnored)
             {
                 coreOptions.Flags |= GitStatusOptionFlags.IncludeIgnored;
+            }
+
+            if (options.IncludeUntracked)
+            {
+                coreOptions.Flags |= GitStatusOptionFlags.IncludeUntracked;
             }
 
             if (options.DetectRenamesInIndex)
@@ -112,6 +114,12 @@ namespace LibGit2Sharp
             {
                 coreOptions.Flags |=
                     GitStatusOptionFlags.RecurseIgnoredDirs;
+            }
+
+            if (options.RecurseUntrackedDirs)
+            {
+                coreOptions.Flags |=
+                    GitStatusOptionFlags.RecurseUntrackedDirs;
             }
 
             if (options.PathSpec != null)

--- a/LibGit2Sharp/StatusOptions.cs
+++ b/LibGit2Sharp/StatusOptions.cs
@@ -36,6 +36,8 @@
         {
             DetectRenamesInIndex = true;
             IncludeIgnored = true;
+            IncludeUntracked = true;
+            RecurseUntrackedDirs = true;
         }
 
         /// <summary>
@@ -62,6 +64,11 @@
         /// Recurse into ignored directories
         /// </summary>
         public bool RecurseIgnoredDirs { get; set; }
+
+        /// <summary>
+        /// Recurse into untracked directories
+        /// </summary>
+        public bool RecurseUntrackedDirs { get; set; }
 
         /// <summary>
         /// Limit the scope of paths to consider to the provided pathspecs
@@ -94,5 +101,9 @@
         /// </remarks>
         public bool IncludeIgnored { get; set; }
 
+        /// <summary>
+        /// Include untracked files when scanning for status
+        /// </summary>
+        public bool IncludeUntracked { get; set; }
     }
 }


### PR DESCRIPTION
These map directly to options of the same name on libgit2, and are useful when you don't want to bother retrieving them.