### PR TITLE
Update to 75db289a (v0.25)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ os:
  - osx
  - linux
 
+# The newer image cannot find mono 3.12 in the PATH
+osx_image: xcode6.4
+
 env:
  global:
   - MONO_OPTIONS=--debug

--- a/LibGit2Sharp.Tests/ConfigurationFixture.cs
+++ b/LibGit2Sharp.Tests/ConfigurationFixture.cs
@@ -497,7 +497,7 @@ namespace LibGit2Sharp.Tests
             GlobalSettings.SetConfigSearchPaths(ConfigurationLevel.Global, "$PATH", appendMe);
 
             var currentPaths = GlobalSettings.GetConfigSearchPaths(ConfigurationLevel.Global);
-            Assert.Equal(currentPaths, prevPaths.Concat(new[] { appendMe }));
+            Assert.Equal(prevPaths.Concat(new[] { appendMe }), currentPaths);
 
             // set it back to the default
             GlobalSettings.SetConfigSearchPaths(ConfigurationLevel.Global, null);

--- a/LibGit2Sharp.Tests/ConfigurationFixture.cs
+++ b/LibGit2Sharp.Tests/ConfigurationFixture.cs
@@ -455,15 +455,6 @@ namespace LibGit2Sharp.Tests
         [Fact]
         public void CanResetSearchPaths()
         {
-            // all of these calls should reset the config path to the default
-            Action[] resetActions =
-            {
-                () => GlobalSettings.SetConfigSearchPaths(ConfigurationLevel.Global),
-                () => GlobalSettings.SetConfigSearchPaths(ConfigurationLevel.Global, null),
-                () => GlobalSettings.SetConfigSearchPaths(ConfigurationLevel.Global, string.Empty),
-                () => GlobalSettings.SetConfigSearchPaths(ConfigurationLevel.Global, new string[] { }),
-            };
-
             // record the default search path
             GlobalSettings.SetConfigSearchPaths(ConfigurationLevel.Global, null);
             var oldPaths = GlobalSettings.GetConfigSearchPaths(ConfigurationLevel.Global);
@@ -472,19 +463,13 @@ namespace LibGit2Sharp.Tests
             // generate a non-default path to set
             var newPaths = new string[] { Path.Combine(Constants.TemporaryReposPath, Path.GetRandomFileName()) };
 
-            foreach (var tryToReset in resetActions)
-            {
-                // change to the non-default path
-                GlobalSettings.SetConfigSearchPaths(ConfigurationLevel.Global, newPaths);
-                Assert.Equal(newPaths, GlobalSettings.GetConfigSearchPaths(ConfigurationLevel.Global));
+            // change to the non-default path
+            GlobalSettings.SetConfigSearchPaths (ConfigurationLevel.Global, newPaths);
+            Assert.Equal (newPaths, GlobalSettings.GetConfigSearchPaths (ConfigurationLevel.Global));
 
-                // set it back to the default
-                tryToReset();
-                Assert.Equal(oldPaths, GlobalSettings.GetConfigSearchPaths(ConfigurationLevel.Global));
-            }
-
-            // make sure the config paths are reset after the test ends
-            GlobalSettings.SetConfigSearchPaths(ConfigurationLevel.Global, null);
+            // set it back to the default
+            GlobalSettings.SetConfigSearchPaths (ConfigurationLevel.Global, null);
+            Assert.Equal (oldPaths, GlobalSettings.GetConfigSearchPaths (ConfigurationLevel.Global));
         }
 
         [Fact]

--- a/LibGit2Sharp.Tests/FileHistoryFixture.cs
+++ b/LibGit2Sharp.Tests/FileHistoryFixture.cs
@@ -161,7 +161,8 @@ namespace LibGit2Sharp.Tests
                 var commit4 = MakeAndCommitChange(repo, repoPath, newPath1, "I have done it again!");
 
                 // Perform tests.
-                var fileHistoryEntries = repo.Commits.QueryBy(newPath1).ToList();
+                var commitFilter = new CommitFilter () { SortBy = CommitSortStrategies.Topological };
+                var fileHistoryEntries = repo.Commits.QueryBy(newPath1, commitFilter).ToList();
                 var changedBlobs = fileHistoryEntries.Blobs().Distinct().ToList();
 
                 Assert.Equal(4, fileHistoryEntries.Count());

--- a/LibGit2Sharp/Core/GitDiff.cs
+++ b/LibGit2Sharp/Core/GitDiff.cs
@@ -397,6 +397,7 @@ namespace LibGit2Sharp.Core
     [StructLayout(LayoutKind.Sequential)]
     internal class GitDiffBinary
     {
+        public uint ContainsData;
         public GitDiffBinaryFile OldFile;
         public GitDiffBinaryFile NewFile;
     }

--- a/LibGit2Sharp/Core/GitOdbBackend.cs
+++ b/LibGit2Sharp/Core/GitOdbBackend.cs
@@ -34,6 +34,7 @@ namespace LibGit2Sharp.Core
         public IntPtr Refresh;
         public foreach_callback Foreach;
         public IntPtr Writepack;
+        public IntPtr Freshen;
         public free_callback Free;
 
         /* The libgit2 structure definition ends here. Subsequent fields are for libgit2sharp bookkeeping. */

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\LibGit2Sharp.NativeBinaries.1.0.160\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.160\build\LibGit2Sharp.NativeBinaries.props')" />
+  <Import Project="..\packages\LibGit2Sharp.NativeBinaries.1.0.163\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.163\build\LibGit2Sharp.NativeBinaries.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -366,11 +366,11 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="libgit2sharp.snk" />
-    <None Include="packages.config" />
     <None Include="Core\Handles\Objects.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>Objects.cs</LastGenOutput>
     </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="UniqueIdentifier.targets" />
@@ -380,12 +380,6 @@
     <PreBuildEvent>
     </PreBuildEvent>
   </PropertyGroup>
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.160\build\LibGit2Sharp.NativeBinaries.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\LibGit2Sharp.NativeBinaries.1.0.160\build\LibGit2Sharp.NativeBinaries.props'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
@@ -394,4 +388,10 @@
   </Target>
   -->
   <ItemGroup />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.163\build\LibGit2Sharp.NativeBinaries.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\LibGit2Sharp.NativeBinaries.1.0.163\build\LibGit2Sharp.NativeBinaries.props'))" />
+  </Target>
 </Project>

--- a/LibGit2Sharp/packages.config
+++ b/LibGit2Sharp/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="LibGit2Sharp.NativeBinaries" version="1.0.160" targetFramework="net4" allowedVersions="[1.0.160]" />
+  <package id="LibGit2Sharp.NativeBinaries" version="1.0.163" targetFramework="net40" allowedVersions="[1.0.163]" />
 </packages>


### PR DESCRIPTION
Path resetting was doing something that should have never worked, but other than that, the only issue was with the revision walker ordering assumption, which this codebase seems to do quite a bit.