### PR TITLE
NativePath: use Assembly.CodeBase

### DIFF
--- a/LibGit2Sharp/GlobalSettings.cs
+++ b/LibGit2Sharp/GlobalSettings.cs
@@ -23,7 +23,26 @@ namespace LibGit2Sharp
         {
             if (Platform.OperatingSystem == OperatingSystemType.Windows)
             {
-                string managedPath = new Uri(Assembly.GetExecutingAssembly().EscapedCodeBase).LocalPath;
+                /* Assembly.CodeBase is not actually a correctly formatted
+                 * URI.  It's merely prefixed with `file:///` and has its
+                 * backslashes flipped.  This is superior to EscapedCodeBase,
+                 * which does not correctly escape things, and ambiguates a
+                 * space (%20) with a literal `%20` in the path.  Sigh.
+                 */
+                var managedPath = Assembly.GetExecutingAssembly().CodeBase;
+                if (managedPath == null)
+                {
+                    managedPath = Assembly.GetExecutingAssembly().Location;
+                }
+                else if (managedPath.StartsWith("file:///"))
+                {
+                    managedPath = managedPath.Substring(8).Replace('/', '\\');
+                }
+                else if (managedPath.StartsWith("file://"))
+                {
+                    managedPath = @"\\" + managedPath.Substring(7).Replace('/', '\\');
+                }
+
                 nativeLibraryPath = Path.Combine(Path.Combine(Path.GetDirectoryName(managedPath), "lib"), "win32");
             }
 


### PR DESCRIPTION
Use `Assembly.CodeBase` instead of `Assembly.EscapedCodeBase` since
the latter does not actually properly escape the path in a reversible
way.

eg, if a path contains a space, it will be encoded as `%20` in the
`EscapedCodeBase` however if a path contains a literal `%20` then it
will _also_ be encoded as `%20`.

Fixes #1389 