### PR TITLE
Commands.Unstage: write the index

### DIFF
--- a/LibGit2Sharp.Tests/StageFixture.cs
+++ b/LibGit2Sharp.Tests/StageFixture.cs
@@ -33,6 +33,24 @@ namespace LibGit2Sharp.Tests
             }
         }
 
+        [Theory]
+        [InlineData("deleted_unstaged_file.txt", FileStatus.DeletedFromIndex)]
+        [InlineData("modified_unstaged_file.txt", FileStatus.ModifiedInIndex)]
+        [InlineData("new_untracked_file.txt", FileStatus.NewInIndex)]
+        public void StagingWritesIndex(string relativePath, FileStatus expectedStatus)
+        {
+            string path = SandboxStandardTestRepo();
+            using (var repo = new Repository(path))
+            {
+                Commands.Stage(repo, relativePath);
+            }
+
+            using (var repo = new Repository(path))
+            {
+                Assert.Equal(expectedStatus, repo.RetrieveStatus(relativePath));
+            }
+        }
+
         [Fact]
         public void CanStageTheUpdationOfAStagedFile()
         {

--- a/LibGit2Sharp.Tests/UnstageFixture.cs
+++ b/LibGit2Sharp.Tests/UnstageFixture.cs
@@ -84,6 +84,25 @@ namespace LibGit2Sharp.Tests
             }
         }
 
+
+        [Theory]
+        [InlineData("modified_staged_file.txt", FileStatus.ModifiedInWorkdir)]
+        [InlineData("new_tracked_file.txt", FileStatus.NewInWorkdir)]
+        [InlineData("deleted_staged_file.txt", FileStatus.DeletedFromWorkdir)]
+        public void UnstagingWritesIndex(string relativePath, FileStatus expectedStatus)
+        {
+            string path = SandboxStandardTestRepo();
+            using (var repo = new Repository(path))
+            {
+                Commands.Unstage(repo, relativePath);
+            }
+
+            using (var repo = new Repository(path))
+            {
+                Assert.Equal(expectedStatus, repo.RetrieveStatus(relativePath));
+            }
+        }
+
         [Theory]
         [InlineData("new_untracked_file.txt", FileStatus.NewInWorkdir)]
         [InlineData("where-am-I.txt", FileStatus.Nonexistent)]

--- a/LibGit2Sharp/Commands/Stage.cs
+++ b/LibGit2Sharp/Commands/Stage.cs
@@ -199,6 +199,8 @@ namespace LibGit2Sharp
             {
                 repository.Index.Replace(repository.Head.Tip, paths, explicitPathsOptions);
             }
+
+            repository.Index.Write();
         }
 
         /// <summary>


### PR DESCRIPTION
The `Unstage` command does not write the index; it should, to match the semantics of the prior `Repository.Unstage`, and to match `Commands.Stage`.