### PR TITLE
Native loading: simplify `git_libgit2_init` / `git_libgit2_shutdown`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,9 @@
 
 ### Fixes
 
+ - The exception thrown when the native library cannot be loaded is now
+   able to be caught and will no longer crash the process.
+
 ## v0.24 - ([diff](https://github.com/libgit2/libgit2sharp/compare/v0.23..v0.24))
 
 This is the last release before a moving to .NET Core compatible library.

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -56,7 +56,7 @@ namespace LibGit2Sharp.Core
         }
 
         // Shutdown the native library in a finalizer.
-        private sealed class NativeShutdownObject : CriticalFinalizerObject
+        private sealed class NativeShutdownObject
         {
             ~NativeShutdownObject()
             {

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -17,58 +17,28 @@ namespace LibGit2Sharp.Core
     {
         public const uint GIT_PATH_MAX = 4096;
         private const string libgit2 = NativeDllName.Name;
-        // This is here to keep the pointer alive
-#pragma warning disable 0414
-        private static readonly LibraryLifetimeObject lifetimeObject;
-#pragma warning restore 0414
-        private static int handlesCount;
 
-        /// <summary>
-        /// Internal hack to ensure that the call to git_threads_shutdown is called after all handle finalizers
-        /// have run to completion ensuring that no dangling git-related finalizer runs after git_threads_shutdown.
-        /// There should never be more than one instance of this object per AppDomain.
-        /// </summary>
-        private sealed class LibraryLifetimeObject
-#if DESKTOP
-            : CriticalFinalizerObject
-#endif
+        // An object tied to the lifecycle of the NativeMethods static class.
+        // This will handle initialization and shutdown of the underlying
+        // native library.
+        #pragma warning disable 0414
+        private static readonly LibraryLifetimeObject lifetimeObject;
+        #pragma warning restore 0414
+
+        private sealed class LibraryLifetimeObject : CriticalFinalizerObject
         {
-            // Ensure mono can JIT the .cctor and adjust the PATH before trying to load the native library.
-            // See https://github.com/libgit2/libgit2sharp/pull/190
             [MethodImpl(MethodImplOptions.NoInlining)]
             public LibraryLifetimeObject()
             {
-                int res = git_libgit2_init();
-                Ensure.Int32Result(res);
-                if (res == 1)
+                // Configure the OpenSSL locking on the true initialization
+                // of the library.
+                if (git_libgit2_init() == 1)
                 {
-                    // Ignore the error that this propagates. Call it in case openssl is being used.
                     git_openssl_set_locking();
                 }
-                AddHandle();
             }
 
             ~LibraryLifetimeObject()
-            {
-                RemoveHandle();
-            }
-        }
-
-#if DESKTOP
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
-#endif
-        internal static void AddHandle()
-        {
-            Interlocked.Increment(ref handlesCount);
-        }
-
-#if DESKTOP
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
-#endif
-        internal static void RemoveHandle()
-        {
-            int count = Interlocked.Decrement(ref handlesCount);
-            if (count == 0)
             {
                 git_libgit2_shutdown();
             }


### PR DESCRIPTION
Move the `git_libgit2_init` call _out_ of the object that contains the finalizer that does the corresponding `git_libgit2_shutdown`.  We do not want to create the object with that finalizer until we are sure that libgit2 has been loaded.

Otherwise, that finalizer will be called even when the constructor threw an exception (probably from `git_libgit2_init` not finding the native library).  In this case, when the finalizer is invoked, it will rethrow the `TypeInitializationException`, and exceptions from finalizers are not catchable.

By ensuring that the object with the finalizer is only created after `git_libgit2_init` succeeds, then we can ensure that any failures in `git_libgit2_init` remain catchable.

Now that our object's lifecycle ensures that we must have called `git_libgit2_init` in order for it to have been created, we can remove the unnecessary reference counting logic.  We previously refcounted the native methods, with each `SafeHandleBase` updating that reference count, [so that we did not call `git_libgit2_shutdown` before we were finished with the safe handle](https://github.com/libgit2/libgit2sharp/pull/361).  But this is obsolete, and this refcounting was unused outside of the load / unload scenario.  So we can simply do the unload in the finalizer, without trying to do any unnecessary work on the refcount.