### PR TITLE
Allow Version class to deal with HEAD as a version hash

### DIFF
--- a/LibGit2Sharp/Version.cs
+++ b/LibGit2Sharp/Version.cs
@@ -69,7 +69,8 @@ namespace LibGit2Sharp
         {
             string sha = ReadContentFromResource(assembly, name) ?? "unknown";
 
-            return sha.Substring(0, 7);
+            var index = sha.Length > 7 ? 7 : sha.Length;
+            return sha.Substring(0, index);
         }
 
         /// <summary>

--- a/LibGit2Sharp/libgit2sharp_hash.txt
+++ b/LibGit2Sharp/libgit2sharp_hash.txt
@@ -1,1 +1,1 @@
-unknown
+HEAD


### PR DESCRIPTION
The Version code expects a commit Hash to be used to specifiy the version of code in use in the library. However this can also be HEAD. If it is HEAD the current code will crash as it tries to extract 7 characters out of 4.

There are no new unit tests, the existing ones pass, since it would require a mechanism to re-write or mock the _hash.txt files during the tests, which seemed beyond the scope of this change.

see https://github.com/libgit2/libgit2sharp/issues/1451