### PR TITLE
nuget: don't try to find msbuild (incorrectly)

### DIFF
--- a/nuget.package/BuildNugetPackage.ps1
+++ b/nuget.package/BuildNugetPackage.ps1
@@ -52,14 +52,6 @@ function Clean-OutputFolder($folder) {
     }
 }
 
-# From http://www.dougfinke.com/blog/index.php/2010/12/01/note-to-self-how-to-programmatically-get-the-msbuild-path-in-powershell/
-
-Function Get-MSBuild {
-    $lib = [System.Runtime.InteropServices.RuntimeEnvironment]
-    $rtd = $lib::GetRuntimeDirectory()
-    Join-Path $rtd msbuild.exe
-}
-
 #################
 
 $root = Split-Path -Parent -Path $MyInvocation.MyCommand.Definition
@@ -79,7 +71,7 @@ Push-Location $projectPath
 try {
   Set-Content -Encoding ASCII $(Join-Path $projectPath "libgit2sharp_hash.txt") $commitSha
   Run-Command { & "$(Join-Path $projectPath "..\Lib\NuGet\Nuget.exe")" Restore "$slnPath" }
-  Run-Command { & (Get-MSBuild) "$slnPath" "/verbosity:minimal" "/p:Configuration=Release" }
+  Run-Command { & "MSBuild.exe" "$slnPath" "/verbosity:minimal" "/p:Configuration=Release" }
 
   If ($postBuild) {
     Write-Host -ForegroundColor "Green" "Run post build script..."


### PR DESCRIPTION
With the changes in the way MSBuild is bundled and installed in Visual
Studio 2015+, we can no longer use the old hacky way to find where
msbuild is installed.

This busted AppVeyor whose image has VS 2015 installed and an old
(incompatible) version of msbuild installed elsewhere.  We would find
only the old version.

Require nuget package users to have msbuild in their path.