### PR TITLE
Fix CertificateSsh constructor

### DIFF
--- a/LibGit2Sharp/CertificateSsh.cs
+++ b/LibGit2Sharp/CertificateSsh.cs
@@ -35,10 +35,6 @@ namespace LibGit2Sharp
         /// </summary>
         public readonly bool HasSHA1;
 
-        /// <summary>
-        /// True if we have the SHA1 hostkey hash from the server
-        /// </summary>public readonly bool HasSHA1;
-
         internal unsafe CertificateSsh(git_certificate_ssh* cert)
         {
 
@@ -46,21 +42,15 @@ namespace LibGit2Sharp
             HasSHA1 = cert->type.HasFlag(GitCertificateSshType.SHA1);
 
             HashMD5 = new byte[16];
-            fixed (byte* p = &HashMD5[0])
+            for (var i = 0; i < HashMD5.Length; i++)
             {
-                for (var i = 0; i < HashMD5.Length; i++)
-                {
-                    HashMD5[i] = p[i];
-                }
+                HashMD5[i] = cert->HashMD5[i];
             }
 
             HashSHA1 = new byte[20];
-            fixed (byte* p = &HashSHA1[0])
+            for (var i = 0; i < HashSHA1.Length; i++)
             {
-                for (var i = 0; i < HashSHA1.Length; i++)
-                {
-                    HashSHA1[i] = p[i];
-                }
+                HashSHA1[i] = cert->HashSHA1[i];
             }
         }
 

--- a/LibGit2Sharp/Core/GitCertificateSsh.cs
+++ b/LibGit2Sharp/Core/GitCertificateSsh.cs
@@ -14,7 +14,7 @@ namespace LibGit2Sharp.Core
         public unsafe fixed byte HashMD5[16];
 
         /// <summary>
-        /// The MD5 hash (if appropriate)
+        /// The SHA1 hash (if appropriate)
         /// </summary>
         public unsafe fixed byte HashSHA1[20];
     }


### PR DESCRIPTION
Should fix #1383.

If this looks too simple, see https://stackoverflow.com/q/44870128/ where I asked about this code to make sure that I wasn't missing something. Three people (the one who commented and the two who upvoted it) agreed that this simple-looking code is fine: there was no need for pointer arithmetic in this constructor. (And there is probably no need for pointer arithmetic in the `ToPointer()` method either, but one fix at a time).