### PR TITLE
README: reorganize build/code analysis badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,21 @@
 # LibGit2Sharp
 
+[![master win][master-win-badge]][master-win]
+[![master nix][master-nix-badge]][master-nix]
+[![coverity][coverity-badge]][coverity-project]
+[![coveralls][coveralls-badge]][coveralls-project]
+
+[master-win-badge]: https://ci.appveyor.com/api/projects/status/8qxcoqdo9kp7x2w9/branch/master?svg=true
+[master-win]: https://ci.appveyor.com/project/libgit2/libgit2sharp/branch/master
+[master-nix-badge]: https://travis-ci.org/libgit2/libgit2sharp.svg?branch=master
+[master-nix]: https://travis-ci.org/libgit2/libgit2sharp/branches
+
+[coverity-project]: https://scan.coverity.com/projects/2088
+[coverity-badge]: https://scan.coverity.com/projects/2088/badge.svg
+
+[coveralls-project]: https://coveralls.io/r/libgit2/libgit2sharp?branch=vNext
+[coveralls-badge]: https://coveralls.io/repos/libgit2/libgit2sharp/badge.svg?branch=vNext
+
 **LibGit2Sharp brings all the might and speed of [libgit2][libgit2], a native Git implementation, to the managed world of .NET and Mono.**
 
  [libgit2]: http://libgit2.github.com/
@@ -26,42 +42,6 @@
  [so]: http://stackoverflow.com/questions/tagged/libgit2sharp
  [tracker]: https://github.com/libgit2/libgit2sharp/issues
  [twitter]: http://twitter.com/libgit2sharp
-
-## Current project status
-
-The CI builds are generously hosted and run on the [Travis][travis] and [AppVeyor][appveyor] infrastructures.
-
-|  | Windows (x86/amd64) | Linux/Mac OS X |
-| :------ | :------: | :------: |
-| **master** | [![master win][master-win-badge]][master-win] | [![master nix][master-nix-badge]][master-nix] |
-| **vNext** | [![vNext win][vNext-win-badge]][vNext-win] | [![vNext nix][vNext-nix-badge]][vNext-nix] |
-
-The security-oriented static code analysis is kindly run through the [Coverity][coverity] service. Code coverage is kindly run through [Coveralls.io][coveralls].
-
-|       | Static Analysis | Code Coverage |
-|-------|-----------------|---------------|
-| **vNext** | [![coverity][coverity-badge]][coverity-project] | [![coveralls][coveralls-badge]][coveralls-project] |
-
-
- [travis]: https://travis-ci.org/
- [appveyor]: http://appveyor.com/
- [coverity]: https://scan.coverity.com/
- [coveralls]: https://coveralls.io/
-
- [master-win-badge]: https://ci.appveyor.com/api/projects/status/8qxcoqdo9kp7x2w9/branch/master?svg=true
- [master-win]: https://ci.appveyor.com/project/libgit2/libgit2sharp/branch/master
- [master-nix-badge]: https://travis-ci.org/libgit2/libgit2sharp.svg?branch=master
- [master-nix]: https://travis-ci.org/libgit2/libgit2sharp/branches
- [vNext-win-badge]: https://ci.appveyor.com/api/projects/status/8qxcoqdo9kp7x2w9/branch/vNext?svg=true
- [vNext-win]: https://ci.appveyor.com/project/libgit2/libgit2sharp/branch/vNext
- [vNext-nix-badge]: https://travis-ci.org/libgit2/libgit2sharp.svg?branch=vNext
- [vNext-nix]: https://travis-ci.org/libgit2/libgit2sharp/branches
-
- [coverity-project]: https://scan.coverity.com/projects/2088
- [coverity-badge]: https://scan.coverity.com/projects/2088/badge.svg
-
- [coveralls-project]: https://coveralls.io/r/libgit2/libgit2sharp?branch=vNext
- [coveralls-badge]: https://coveralls.io/repos/libgit2/libgit2sharp/badge.svg?branch=vNext
 
 ## Quick contributing guide
 


### PR DESCRIPTION
Drop vNext branch information, since it's now unused. Reorganize build badges up top.