### PR TITLE
Expose enable/disable ofs delta and strict object creation settings

### DIFF
--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -3429,7 +3429,29 @@ namespace LibGit2Sharp.Core
             Ensure.ZeroResult(res);
         }
 
-#endregion
+        /// <summary>
+        /// Enable or disable the ofs_delta capabilty
+        /// </summary>
+        /// <param name="enabled">true to enable the ofs_delta capabilty, false otherwise</param>
+        public static void git_libgit2_opts_set_enable_ofsdelta(bool enabled)
+        {
+            // libgit2 expects non-zero value for true
+            var res = NativeMethods.git_libgit2_opts((int)LibGit2Option.EnableOfsDelta, enabled ? 1 : 0);
+            Ensure.ZeroResult(res);
+        }
+
+        /// <summary>
+        /// Enable or disable the strict_object_creation capabilty
+        /// </summary>
+        /// <param name="enabled">true to enable the strict_object_creation capabilty, false otherwise</param>
+        public static void git_libgit2_opts_set_enable_strictobjectcreation(bool enabled)
+        {
+            // libgit2 expects non-zero value for true
+            var res = NativeMethods.git_libgit2_opts((int)LibGit2Option.EnableStrictObjectCreation, enabled ? 1 : 0);
+            Ensure.ZeroResult(res);
+        }
+
+        #endregion
 
         private static ICollection<TResult> git_foreach<T, TResult>(
             Func<T, TResult> resultSelector,

--- a/LibGit2Sharp/GlobalSettings.cs
+++ b/LibGit2Sharp/GlobalSettings.cs
@@ -338,5 +338,23 @@ namespace LibGit2Sharp
         {
             Proxy.git_libgit2_opts_set_enable_caching(enabled);
         }
+
+        /// <summary>
+        /// Enable or disable the ofs_delta capability
+        /// </summary>
+        /// <param name="enabled">true to enable the ofs_delta capability, false otherwise</param>
+        public static void SetEnableOfsDelta(bool enabled)
+        {
+            Proxy.git_libgit2_opts_set_enable_ofsdelta(enabled);
+        }
+
+        /// <summary>
+        /// Enable or disable the libgit2 strict_object_creation capability
+        /// </summary>
+        /// <param name="enabled">true to enable the strict_object_creation capability, false otherwise</param>
+        public static void SetEnableStrictObjectCreation(bool enabled)
+        {
+            Proxy.git_libgit2_opts_set_enable_strictobjectcreation(enabled);
+        }
     }
 }


### PR DESCRIPTION
Expose the existing GIT_OPT_ENABLE_OFS_DELTA and GIT_OPT_ENABLE_STRICT_OBJECT_CREATION setting in libgit2.
See https://github.com/libgit2/libgit2/blob/master/src/settings.c#L225 and https://github.com/libgit2/libgit2/blob/master/src/settings.c#L193