### PR TITLE
Update Dependencies

### DIFF
--- a/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
+++ b/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
@@ -18,12 +18,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.7.99" />
-    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="Moq" Version="4.7.145" />
+    <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.skippablefact" Version="1.3.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.console" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.console" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Nerdbank.GitVersioning" Version="2.0.41" />
   </ItemGroup>
 
 </Project>

--- a/LibGit2Sharp.Tests/RemoveFixture.cs
+++ b/LibGit2Sharp.Tests/RemoveFixture.cs
@@ -28,14 +28,14 @@ namespace LibGit2Sharp.Tests
          *   'git rm <file>' fails ("error: '<file>' has local modifications").
          */
         [InlineData(false, "modified_unstaged_file.txt", false, FileStatus.ModifiedInWorkdir, true, true, FileStatus.NewInWorkdir | FileStatus.DeletedFromIndex)]
-        [InlineData(true, "modified_unstaged_file.txt", true,  FileStatus.ModifiedInWorkdir, true, true, 0)]
+        [InlineData(true, "modified_unstaged_file.txt", true,  FileStatus.ModifiedInWorkdir, true, true, FileStatus.Unaltered)]
         /***
          * Test case: modified file in wd, the modifications have already been promoted to the index.
          *   'git rm --cached <file>' works (removes the file from the index)
          *   'git rm <file>' fails ("error: '<file>' has changes staged in the index")
          */
         [InlineData(false, "modified_staged_file.txt", false, FileStatus.ModifiedInIndex, true, true, FileStatus.NewInWorkdir | FileStatus.DeletedFromIndex)]
-        [InlineData(true, "modified_staged_file.txt", true, FileStatus.ModifiedInIndex, true, true, 0)]
+        [InlineData(true, "modified_staged_file.txt", true, FileStatus.ModifiedInIndex, true, true, FileStatus.Unaltered)]
         /***
          * Test case: modified file in wd, the modifications have already been promoted to the index, and
          * the file does not exist in the HEAD.
@@ -43,7 +43,7 @@ namespace LibGit2Sharp.Tests
          *   'git rm <file>' throws ("error: '<file>' has changes staged in the index")
          */
         [InlineData(false, "new_tracked_file.txt", false, FileStatus.NewInIndex, true, true, FileStatus.NewInWorkdir)]
-        [InlineData(true, "new_tracked_file.txt", true, FileStatus.NewInIndex, true, true, 0)]
+        [InlineData(true, "new_tracked_file.txt", true, FileStatus.NewInIndex, true, true, FileStatus.Unaltered)]
         public void CanRemoveAnUnalteredFileFromTheIndexWithoutRemovingItFromTheWorkingDirectory(
             bool removeFromWorkdir, string filename, bool throws, FileStatus initialStatus, bool existsBeforeRemove, bool existsAfterRemove, FileStatus lastStatus)
         {

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -34,8 +34,12 @@
 
   <ItemGroup>
     <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="[1.0.185]" PrivateAssets="contentFiles" />
-    <PackageReference Include="SourceLink.Create.GitHub" Version="2.2.0" PrivateAssets="all" />
+    <PackageReference Include="SourceLink.Create.GitHub" Version="2.5.0" PrivateAssets="all" />
     <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Nerdbank.GitVersioning" Version="2.0.41" />
   </ItemGroup>
 
   <Import Project="CodeGenerator.targets" />


### PR DESCRIPTION
The current version of xunit's Visual Studio integration has been _incredibly_ flaky on my machines.  So far, the Xunit 2.3 betas have been much more stable.  Now that there's a proper Xunit version, let's upgrade our dependencies to use it.