### PR TITLE
Introduce ObjectDatabase.Write(Stream...)

### DIFF
--- a/LibGit2Sharp.Tests/ObjectDatabaseFixture.cs
+++ b/LibGit2Sharp.Tests/ObjectDatabaseFixture.cs
@@ -133,6 +133,19 @@ namespace LibGit2Sharp.Tests
             }
         }
 
+        [Fact]
+        public void CanWriteABlobFromAStream()
+        {
+            var ba = Encoding.ASCII.GetBytes("libgit2\r\n");
+
+            using (var stream = new MemoryStream(ba))
+            using (var repo = new Repository(InitNewRepository()))
+            {
+                var id = repo.ObjectDatabase.Write<Blob>(stream, stream.Length);
+                Assert.Equal(new ObjectId("99115ea359379a218c47cffc83cd0af8c91c4061"), id);
+            }
+        }
+
         Stream PrepareMemoryStream(int contentSize)
         {
             var sb = new StringBuilder();

--- a/LibGit2Sharp.Tests/ObjectDatabaseFixture.cs
+++ b/LibGit2Sharp.Tests/ObjectDatabaseFixture.cs
@@ -121,6 +121,18 @@ namespace LibGit2Sharp.Tests
             }
         }
 
+        [Fact]
+        public void CanWriteABlobFromAByteArray()
+        {
+            var ba = Encoding.ASCII.GetBytes("libgit2\r\n");
+
+            using (var repo = new Repository(InitNewRepository()))
+            {
+                var id = repo.ObjectDatabase.Write<Blob>(ba);
+                Assert.Equal(new ObjectId("99115ea359379a218c47cffc83cd0af8c91c4061"), id);
+            }
+        }
+
         Stream PrepareMemoryStream(int contentSize)
         {
             var sb = new StringBuilder();

--- a/LibGit2Sharp/ObjectDatabase.cs
+++ b/LibGit2Sharp/ObjectDatabase.cs
@@ -178,7 +178,7 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
-        /// Write an object to the object database
+        /// Writes an object to the object database.
         /// </summary>
         /// <param name="data">The contents of the object</param>
         /// <typeparam name="T">The type of object to write</typeparam>

--- a/LibGit2Sharp/ObjectDatabase.cs
+++ b/LibGit2Sharp/ObjectDatabase.cs
@@ -188,6 +188,45 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
+        /// Writes an object to the object database.
+        /// </summary>
+        /// <param name="stream">The contents of the object</param>
+        /// <param name="numberOfBytesToConsume">The number of bytes to consume from the stream</param>
+        /// <typeparam name="T">The type of object to write</typeparam>
+        public virtual ObjectId Write<T>(Stream stream, long numberOfBytesToConsume) where T : GitObject
+        {
+            Ensure.ArgumentNotNull(stream, "stream");
+
+            if (!stream.CanRead)
+            {
+                throw new ArgumentException("The stream cannot be read from.", "stream");
+            }
+
+            using (var odbStream = Proxy.git_odb_open_wstream(handle, numberOfBytesToConsume, GitObjectType.Blob))
+            {
+                var buffer = new byte[4 * 1024];
+                long totalRead = 0;
+
+                while (totalRead < numberOfBytesToConsume)
+                {
+                    long left = numberOfBytesToConsume - totalRead;
+                    int toRead = left < buffer.Length ? (int)left : buffer.Length;
+                    var read = stream.Read(buffer, 0, toRead);
+
+                    if (read == 0)
+                    {
+                        throw new EndOfStreamException("The stream ended unexpectedly");
+                    }
+
+                    Proxy.git_odb_stream_write(odbStream, buffer, read);
+                    totalRead += read;
+                }
+
+                return Proxy.git_odb_stream_finalize_write(odbStream);
+            }
+        }
+
+        /// <summary>
         /// Inserts a <see cref="Blob"/> into the object database, created from the content of a stream.
         /// <para>Optionally, git filters will be applied to the content before storing it.</para>
         /// </summary>
@@ -294,37 +333,8 @@ namespace LibGit2Sharp
         /// <returns>The created <see cref="Blob"/>.</returns>
         public virtual Blob CreateBlob(Stream stream, long numberOfBytesToConsume)
         {
-            Ensure.ArgumentNotNull(stream, "stream");
-
-            if (!stream.CanRead)
-            {
-                throw new ArgumentException("The stream cannot be read from.", "stream");
-            }
-
-            using (var odbStream = Proxy.git_odb_open_wstream(handle, numberOfBytesToConsume, GitObjectType.Blob))
-            {
-                var buffer = new byte[4 * 1024];
-                long totalRead = 0;
-
-                while (totalRead < numberOfBytesToConsume)
-                {
-                    long left = numberOfBytesToConsume - totalRead;
-                    int toRead = left < buffer.Length ? (int)left : buffer.Length;
-                    var read = stream.Read(buffer, 0, toRead);
-
-                    if (read == 0)
-                    {
-                        throw new EndOfStreamException("The stream ended unexpectedly");
-                    }
-
-                    Proxy.git_odb_stream_write(odbStream, buffer, read);
-                    totalRead += read;
-                }
-
-                var id = Proxy.git_odb_stream_finalize_write(odbStream);
-
-                return repo.Lookup<Blob>(id);
-            }
+            var id = Write<Blob>(stream, numberOfBytesToConsume);
+            return repo.Lookup<Blob>(id);
         }
 
         /// <summary>


### PR DESCRIPTION
Introduce ObjectDatabase.Write(Stream...) to write directly to the object database (without creating the subsequent `Blob`) and without having to load the entire blob into memory.  See #1515 