### PR TITLE
TreeDefinition: allow `Add` a blob by ID

### DIFF
--- a/LibGit2Sharp.Tests/TreeDefinitionFixture.cs
+++ b/LibGit2Sharp.Tests/TreeDefinitionFixture.cs
@@ -266,6 +266,49 @@ namespace LibGit2Sharp.Tests
             }
         }
 
+        [Theory]
+        [InlineData("a8233120f6ad708f843d861ce2b7228ec4e3dec6", "README_TOO")]
+        [InlineData("a8233120f6ad708f843d861ce2b7228ec4e3dec6", "1/README")]
+        [InlineData("45b983be36b73c0788dc9cbcb76cbb80fc7bb057", "1/another_one.txt")]
+        [InlineData("45b983be36b73c0788dc9cbcb76cbb80fc7bb057", "another_one.txt")]
+        public void CanAddBlobById(string blobSha, string targetPath)
+        {
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
+            {
+                TreeDefinition td = TreeDefinition.From(repo.Head.Tip.Tree);
+                Assert.Null(td[targetPath]);
+
+                var objectId = new ObjectId(blobSha);
+
+                td.Add(targetPath, objectId, Mode.NonExecutableFile);
+
+                TreeEntryDefinition fetched = td[targetPath];
+                Assert.NotNull(fetched);
+
+                Assert.Equal(objectId, fetched.TargetId);
+                Assert.Equal(Mode.NonExecutableFile, fetched.Mode);
+            }
+        }
+
+        [Fact]
+        public void CannotAddTreeById()
+        {
+            const string treeSha = "7f76480d939dc401415927ea7ef25c676b8ddb8f";
+            const string targetPath = "1/2";
+
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
+            {
+                TreeDefinition td = TreeDefinition.From(repo.Head.Tip.Tree);
+                Assert.Null(td[targetPath]);
+
+                var objectId = new ObjectId(treeSha);
+
+                Assert.Throws<ArgumentException>(() => td.Add(targetPath, objectId, Mode.Directory));
+            }
+        }
+
         [Fact]
         public void CanAddAnExistingSubmodule()
         {

--- a/LibGit2Sharp/TreeDefinition.cs
+++ b/LibGit2Sharp/TreeDefinition.cs
@@ -202,6 +202,23 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
+        /// Adds or replaces a <see cref="TreeEntryDefinition"/> from an existing blob specified by its Object ID at the specified <paramref name="targetTreeEntryPath"/> location.
+        /// </summary>
+        /// <param name="targetTreeEntryPath">The path within this <see cref="TreeDefinition"/>.</param>
+        /// <param name="id">The object ID for this entry.</param>
+        /// <param name="mode">The file related <see cref="Mode"/> attributes.</param>
+        /// <returns>The current <see cref="TreeDefinition"/>.</returns>
+        public virtual TreeDefinition Add(string targetTreeEntryPath, ObjectId id, Mode mode)
+        {
+            Ensure.ArgumentNotNull(id, "id");
+            Ensure.ArgumentConformsTo(mode, m => m.HasAny(TreeEntryDefinition.BlobModes), "mode");
+
+            TreeEntryDefinition ted = TreeEntryDefinition.From(id, mode);
+
+            return Add(targetTreeEntryPath, ted);
+        }
+
+        /// <summary>
         /// Adds or replaces a <see cref="TreeEntryDefinition"/>, dynamically built from the provided <see cref="Tree"/>, at the specified <paramref name="targetTreeEntryPath"/> location.
         /// </summary>
         /// <param name="targetTreeEntryPath">The path within this <see cref="TreeDefinition"/>.</param>

--- a/LibGit2Sharp/TreeEntryDefinition.cs
+++ b/LibGit2Sharp/TreeEntryDefinition.cs
@@ -54,12 +54,27 @@ namespace LibGit2Sharp
 
         internal static TreeEntryDefinition From(Blob blob, Mode mode)
         {
+            Ensure.ArgumentNotNull(blob, "blob");
+
             return new TreeEntryDefinition
             {
                 Mode = mode,
                 TargetType = TreeEntryTargetType.Blob,
                 TargetId = blob.Id,
                 target = new Lazy<GitObject>(() => blob)
+            };
+        }
+
+        internal static TreeEntryDefinition From(ObjectId id, Mode mode)
+        {
+            Ensure.ArgumentNotNull(id, "id");
+            Ensure.ArgumentNotNull(mode, "mode");
+
+            return new TreeEntryDefinition
+            {
+                Mode = mode,
+                TargetType = TreeEntryTargetType.Blob,
+                TargetId = id
             };
         }
 


### PR DESCRIPTION
Allow consumers to add a blob to a `TreeDefinition` by specifying only the object ID and mode.  This lets users build tree entries without having to create a `Blob` object (and thus load the object itself) which is beneficial for users building trees with large objects.

This is only useful for Blobs, since they do not need to be fetched from the object database to be realized within the tree builder.  Users are not able to add Trees by ID, since we would need to load them (and cannot, since we are not guaranteed to be instantiated within the context of a repository).

See #1515 