### PR TITLE
Backports to 0.24.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,9 +10,13 @@
   - Windows (x86/amd64): <https://ci.appveyor.com/project/libgit2/libgit2sharp>
   - Linux/Mac OS X: <https://travis-ci.org/libgit2/libgit2sharp>
 
-## v0.24 + 1
+## v0.24.1
 
 ### Additions
+
+ - `TreeDefinition.Add` can now add a blob to a tree when given its object ID.
+ - `ObjectDatabase.Write` can now take a readable `Stream` to support writing
+   large files to the object database.
 
 ### Changes
 

--- a/LibGit2Sharp.Tests/ObjectDatabaseFixture.cs
+++ b/LibGit2Sharp.Tests/ObjectDatabaseFixture.cs
@@ -133,6 +133,19 @@ namespace LibGit2Sharp.Tests
             }
         }
 
+        [Fact]
+        public void CanWriteABlobFromAStream()
+        {
+            var ba = Encoding.ASCII.GetBytes("libgit2\r\n");
+
+            using (var stream = new MemoryStream(ba))
+            using (var repo = new Repository(InitNewRepository()))
+            {
+                var id = repo.ObjectDatabase.Write<Blob>(stream, stream.Length);
+                Assert.Equal(new ObjectId("99115ea359379a218c47cffc83cd0af8c91c4061"), id);
+            }
+        }
+
         Stream PrepareMemoryStream(int contentSize)
         {
             var sb = new StringBuilder();

--- a/LibGit2Sharp.Tests/ObjectDatabaseFixture.cs
+++ b/LibGit2Sharp.Tests/ObjectDatabaseFixture.cs
@@ -121,6 +121,18 @@ namespace LibGit2Sharp.Tests
             }
         }
 
+        [Fact]
+        public void CanWriteABlobFromAByteArray()
+        {
+            var ba = Encoding.ASCII.GetBytes("libgit2\r\n");
+
+            using (var repo = new Repository(InitNewRepository()))
+            {
+                var id = repo.ObjectDatabase.Write<Blob>(ba);
+                Assert.Equal(new ObjectId("99115ea359379a218c47cffc83cd0af8c91c4061"), id);
+            }
+        }
+
         Stream PrepareMemoryStream(int contentSize)
         {
             var sb = new StringBuilder();

--- a/LibGit2Sharp.Tests/TreeDefinitionFixture.cs
+++ b/LibGit2Sharp.Tests/TreeDefinitionFixture.cs
@@ -222,6 +222,49 @@ namespace LibGit2Sharp.Tests
             }
         }
 
+        [Theory]
+        [InlineData("a8233120f6ad708f843d861ce2b7228ec4e3dec6", "README_TOO")]
+        [InlineData("a8233120f6ad708f843d861ce2b7228ec4e3dec6", "1/README")]
+        [InlineData("45b983be36b73c0788dc9cbcb76cbb80fc7bb057", "1/another_one.txt")]
+        [InlineData("45b983be36b73c0788dc9cbcb76cbb80fc7bb057", "another_one.txt")]
+        public void CanAddBlobById(string blobSha, string targetPath)
+        {
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
+            {
+                TreeDefinition td = TreeDefinition.From(repo.Head.Tip.Tree);
+                Assert.Null(td[targetPath]);
+
+                var objectId = new ObjectId(blobSha);
+
+                td.Add(targetPath, objectId, Mode.NonExecutableFile);
+
+                TreeEntryDefinition fetched = td[targetPath];
+                Assert.NotNull(fetched);
+
+                Assert.Equal(objectId, fetched.TargetId);
+                Assert.Equal(Mode.NonExecutableFile, fetched.Mode);
+            }
+        }
+
+        [Fact]
+        public void CannotAddTreeById()
+        {
+            const string treeSha = "7f76480d939dc401415927ea7ef25c676b8ddb8f";
+            const string targetPath = "1/2";
+
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
+            {
+                TreeDefinition td = TreeDefinition.From(repo.Head.Tip.Tree);
+                Assert.Null(td[targetPath]);
+
+                var objectId = new ObjectId(treeSha);
+
+                Assert.Throws<ArgumentException>(() => td.Add(targetPath, objectId, Mode.Directory));
+            }
+        }
+
         [Fact]
         public void CanAddAnExistingSubmodule()
         {

--- a/LibGit2Sharp/ObjectDatabase.cs
+++ b/LibGit2Sharp/ObjectDatabase.cs
@@ -178,7 +178,7 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
-        /// Write an object to the object database
+        /// Writes an object to the object database.
         /// </summary>
         /// <param name="data">The contents of the object</param>
         /// <typeparam name="T">The type of object to write</typeparam>

--- a/LibGit2Sharp/ObjectDatabase.cs
+++ b/LibGit2Sharp/ObjectDatabase.cs
@@ -188,6 +188,45 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
+        /// Writes an object to the object database.
+        /// </summary>
+        /// <param name="stream">The contents of the object</param>
+        /// <param name="numberOfBytesToConsume">The number of bytes to consume from the stream</param>
+        /// <typeparam name="T">The type of object to write</typeparam>
+        public virtual ObjectId Write<T>(Stream stream, long numberOfBytesToConsume) where T : GitObject
+        {
+            Ensure.ArgumentNotNull(stream, "stream");
+
+            if (!stream.CanRead)
+            {
+                throw new ArgumentException("The stream cannot be read from.", "stream");
+            }
+
+            using (var odbStream = Proxy.git_odb_open_wstream(handle, numberOfBytesToConsume, GitObjectType.Blob))
+            {
+                var buffer = new byte[4 * 1024];
+                long totalRead = 0;
+
+                while (totalRead < numberOfBytesToConsume)
+                {
+                    long left = numberOfBytesToConsume - totalRead;
+                    int toRead = left < buffer.Length ? (int)left : buffer.Length;
+                    var read = stream.Read(buffer, 0, toRead);
+
+                    if (read == 0)
+                    {
+                        throw new EndOfStreamException("The stream ended unexpectedly");
+                    }
+
+                    Proxy.git_odb_stream_write(odbStream, buffer, read);
+                    totalRead += read;
+                }
+
+                return Proxy.git_odb_stream_finalize_write(odbStream);
+            }
+        }
+
+        /// <summary>
         /// Inserts a <see cref="Blob"/> into the object database, created from the content of a stream.
         /// <para>Optionally, git filters will be applied to the content before storing it.</para>
         /// </summary>
@@ -294,37 +333,8 @@ namespace LibGit2Sharp
         /// <returns>The created <see cref="Blob"/>.</returns>
         public virtual Blob CreateBlob(Stream stream, long numberOfBytesToConsume)
         {
-            Ensure.ArgumentNotNull(stream, "stream");
-
-            if (!stream.CanRead)
-            {
-                throw new ArgumentException("The stream cannot be read from.", "stream");
-            }
-
-            using (var odbStream = Proxy.git_odb_open_wstream(handle, numberOfBytesToConsume, GitObjectType.Blob))
-            {
-                var buffer = new byte[4 * 1024];
-                long totalRead = 0;
-
-                while (totalRead < numberOfBytesToConsume)
-                {
-                    long left = numberOfBytesToConsume - totalRead;
-                    int toRead = left < buffer.Length ? (int)left : buffer.Length;
-                    var read = stream.Read(buffer, 0, toRead);
-
-                    if (read == 0)
-                    {
-                        throw new EndOfStreamException("The stream ended unexpectedly");
-                    }
-
-                    Proxy.git_odb_stream_write(odbStream, buffer, read);
-                    totalRead += read;
-                }
-
-                var id = Proxy.git_odb_stream_finalize_write(odbStream);
-
-                return repo.Lookup<Blob>(id);
-            }
+            var id = Write<Blob>(stream, numberOfBytesToConsume);
+            return repo.Lookup<Blob>(id);
         }
 
         /// <summary>

--- a/LibGit2Sharp/Properties/AssemblyInfo.cs
+++ b/LibGit2Sharp/Properties/AssemblyInfo.cs
@@ -42,6 +42,6 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("0.24.0")]
-[assembly: AssemblyFileVersion("0.24.0")]
-[assembly: AssemblyInformationalVersion("0.24.0-dev00000000000000")]
+[assembly: AssemblyVersion("0.24.1")]
+[assembly: AssemblyFileVersion("0.24.1")]
+[assembly: AssemblyInformationalVersion("0.24.1-dev00000000000000")]

--- a/LibGit2Sharp/TreeDefinition.cs
+++ b/LibGit2Sharp/TreeDefinition.cs
@@ -207,6 +207,23 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
+        /// Adds or replaces a <see cref="TreeEntryDefinition"/> from an existing blob specified by its Object ID at the specified <paramref name="targetTreeEntryPath"/> location.
+        /// </summary>
+        /// <param name="targetTreeEntryPath">The path within this <see cref="TreeDefinition"/>.</param>
+        /// <param name="id">The object ID for this entry.</param>
+        /// <param name="mode">The file related <see cref="Mode"/> attributes.</param>
+        /// <returns>The current <see cref="TreeDefinition"/>.</returns>
+        public virtual TreeDefinition Add(string targetTreeEntryPath, ObjectId id, Mode mode)
+        {
+            Ensure.ArgumentNotNull(id, "id");
+            Ensure.ArgumentConformsTo(mode, m => m.HasAny(TreeEntryDefinition.BlobModes), "mode");
+
+            TreeEntryDefinition ted = TreeEntryDefinition.From(id, mode);
+
+            return Add(targetTreeEntryPath, ted);
+        }
+
+        /// <summary>
         /// Adds or replaces a <see cref="TreeEntryDefinition"/>, dynamically built from the provided <see cref="Tree"/>, at the specified <paramref name="targetTreeEntryPath"/> location.
         /// </summary>
         /// <param name="targetTreeEntryPath">The path within this <see cref="TreeDefinition"/>.</param>

--- a/LibGit2Sharp/TreeEntryDefinition.cs
+++ b/LibGit2Sharp/TreeEntryDefinition.cs
@@ -54,12 +54,27 @@ namespace LibGit2Sharp
 
         internal static TreeEntryDefinition From(Blob blob, Mode mode)
         {
+            Ensure.ArgumentNotNull(blob, "blob");
+
             return new TreeEntryDefinition
             {
                 Mode = mode,
                 TargetType = TreeEntryTargetType.Blob,
                 TargetId = blob.Id,
                 target = new Lazy<GitObject>(() => blob)
+            };
+        }
+
+        internal static TreeEntryDefinition From(ObjectId id, Mode mode)
+        {
+            Ensure.ArgumentNotNull(id, "id");
+            Ensure.ArgumentNotNull(mode, "mode");
+
+            return new TreeEntryDefinition
+            {
+                Mode = mode,
+                TargetType = TreeEntryTargetType.Blob,
+                TargetId = id
             };
         }
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ environment:
     secure: nuzUT+HecXGIi3KaPd/1hgFEZJan/j6+oNbPV75JKjk=
   coverity_email:
     secure: eGVilNg1Yuq+Xj+SW8r3WCtjnzhoDV0sNJkma4NRq7A=
-  version : 0.24.0
+  version : 0.24.1
   matrix:
   - xunit_runner: xunit.console.x86.exe
     Arch: 32


### PR DESCRIPTION
This backports the following changes to the 0.24 maintenance branch:

- `TreeDefinition.Add` can now add a blob to a tree when given a blob ID.
- `ObjectDatabase.Write` can now write a stream to the object database.