### PR TITLE
Add MergeCommitsIntoIndex to ObjectDatabase

### DIFF
--- a/LibGit2Sharp.Tests/MergeFixture.cs
+++ b/LibGit2Sharp.Tests/MergeFixture.cs
@@ -902,6 +902,48 @@ namespace LibGit2Sharp.Tests
             }
         }
 
+        [Fact]
+        public void CanMergeIntoIndex()
+        {
+            string path = SandboxMergeTestRepo();
+            using (var repo = new Repository(path))
+            {
+                var master = repo.Lookup<Commit>("master");
+
+                Index index = repo.ObjectDatabase.MergeCommitsIntoIndex(master, master, null);
+                var tree = index.WriteToTree();
+                Assert.Equal(master.Tree.Id, tree.Id);
+            }
+        }
+
+        [Fact]
+        public void CanMergeIntoIndexWithConflicts()
+        {
+            string path = SandboxMergeTestRepo();
+            using (var repo = new Repository(path))
+            {
+                var master = repo.Lookup<Commit>("master");
+                var branch = repo.Lookup<Commit>("conflicts");
+
+                Index index = repo.ObjectDatabase.MergeCommitsIntoIndex(branch, master, null);
+                Assert.False(index.IsFullyMerged);
+
+                var conflict = index.Conflicts.First();
+
+                //Resolve the conflict by taking the blob from branch
+                var blob = repo.Lookup<Blob>(conflict.Ours.Id);
+                //Add() does not remove conflict entries for the same path, so they must be explicitly removed first.
+                index.Remove(conflict.Ours.Path);
+                index.Add(blob, conflict.Ours.Path, Mode.NonExecutableFile);
+
+                Assert.True(index.IsFullyMerged);
+                var tree = index.WriteToTree();
+
+                //Since we took the conflicted blob from the branch, the merged result should be the same as the branch.
+                Assert.Equal(branch.Tree.Id, tree.Id);
+            }
+        }
+
         private Commit AddFileCommitToRepo(IRepository repository, string filename, string content = null)
         {
             Touch(repository.Info.WorkingDirectory, filename, content);

--- a/LibGit2Sharp/Index.cs
+++ b/LibGit2Sharp/Index.cs
@@ -31,13 +31,12 @@ namespace LibGit2Sharp
             this.repo = repo;
             this.handle = handle;
             conflicts = new ConflictCollection(this);
-
-            repo.RegisterForCleanup(handle);
         }
 
         internal Index(Repository repo)
             : this(Proxy.git_repository_index(repo.Handle), repo)
         {
+            repo.RegisterForCleanup(handle);
         }
 
         internal Index(Repository repo, string indexPath)

--- a/LibGit2Sharp/Index.cs
+++ b/LibGit2Sharp/Index.cs
@@ -26,14 +26,18 @@ namespace LibGit2Sharp
         protected Index()
         { }
 
-        internal Index(Repository repo)
+        internal Index(IndexHandle handle, Repository repo)
         {
             this.repo = repo;
-
-            handle = Proxy.git_repository_index(repo.Handle);
+            this.handle = handle;
             conflicts = new ConflictCollection(this);
 
             repo.RegisterForCleanup(handle);
+        }
+
+        internal Index(Repository repo)
+            : this(Proxy.git_repository_index(repo.Handle), repo)
+        {
         }
 
         internal Index(Repository repo, string indexPath)
@@ -304,6 +308,17 @@ namespace LibGit2Sharp
         public virtual void Write()
         {
             Proxy.git_index_write(handle);
+        }
+
+        /// <summary>
+        /// Write the contents of this <see cref="Index"/> to a tree
+        /// </summary>
+        /// <returns></returns>
+        public virtual Tree WriteToTree()
+        {
+            var treeId = Proxy.git_index_write_tree_to(this.handle, this.repo.Handle);
+            var result = this.repo.Lookup<Tree>(treeId);
+            return result;
         }
     }
 }

--- a/LibGit2Sharp/ObjectDatabase.cs
+++ b/LibGit2Sharp/ObjectDatabase.cs
@@ -856,8 +856,9 @@ namespace LibGit2Sharp
         /// <param name="ours">The first tree</param>
         /// <param name="theirs">The second tree</param>
         /// <param name="options">The <see cref="MergeTreeOptions"/> controlling the merge</param>
-        /// <returns>The <see cref="Index"/> containing the merged trees and any conflicts, or null if the merge stopped early due to conflicts</returns>
-        public virtual Index MergeCommitsIntoIndex(Commit ours, Commit theirs, MergeTreeOptions options)
+        /// <returns>The <see cref="TransientIndex"/> containing the merged trees and any conflicts, or null if the merge stopped early due to conflicts.
+        /// The index must be disposed by the caller.</returns>
+        public virtual TransientIndex MergeCommitsIntoIndex(Commit ours, Commit theirs, MergeTreeOptions options)
         {
             Ensure.ArgumentNotNull(ours, "ours");
             Ensure.ArgumentNotNull(theirs, "theirs");
@@ -874,7 +875,7 @@ namespace LibGit2Sharp
                 }
                 return null;
             }
-            var result = new Index(indexHandle, repo);
+            var result = new TransientIndex(indexHandle, repo);
             return result;
         }
 

--- a/LibGit2Sharp/ObjectDatabase.cs
+++ b/LibGit2Sharp/ObjectDatabase.cs
@@ -755,47 +755,36 @@ namespace LibGit2Sharp
 
         /// <summary>
         /// Perform a three-way merge of two commits, looking up their
-        /// commit ancestor. The returned index will contain the results
-        /// of the merge and can be examined for conflicts. The returned
-        /// index must be disposed.
+        /// commit ancestor. The returned <see cref="MergeTreeResult"/> will contain the results
+        /// of the merge and can be examined for conflicts.
         /// </summary>
-        /// <param name="ours">The first tree</param>
-        /// <param name="theirs">The second tree</param>
+        /// <param name="ours">The first commit</param>
+        /// <param name="theirs">The second commit</param>
         /// <param name="options">The <see cref="MergeTreeOptions"/> controlling the merge</param>
-        /// <returns>The <see cref="Index"/> containing the merged trees and any conflicts</returns>
+        /// <returns>The <see cref="MergeTreeResult"/> containing the merged trees and any conflicts</returns>
         public virtual MergeTreeResult MergeCommits(Commit ours, Commit theirs, MergeTreeOptions options)
         {
             Ensure.ArgumentNotNull(ours, "ours");
             Ensure.ArgumentNotNull(theirs, "theirs");
 
-            options = options ?? new MergeTreeOptions();
+            var modifiedOptions = new MergeTreeOptions();
 
             // We throw away the index after looking at the conflicts, so we'll never need the REUC
             // entries to be there
-            GitMergeFlag mergeFlags = GitMergeFlag.GIT_MERGE_NORMAL | GitMergeFlag.GIT_MERGE_SKIP_REUC;
-            if (options.FindRenames)
-            {
-                mergeFlags |= GitMergeFlag.GIT_MERGE_FIND_RENAMES;
-            }
-            if (options.FailOnConflict)
-            {
-                mergeFlags |= GitMergeFlag.GIT_MERGE_FAIL_ON_CONFLICT;
-            }
+            modifiedOptions.SkipReuc = true;
 
-
-            var mergeOptions = new GitMergeOpts
+            if (options != null)
             {
-                Version = 1,
-                MergeFileFavorFlags = options.MergeFileFavor,
-                MergeTreeFlags = mergeFlags,
-                RenameThreshold = (uint)options.RenameThreshold,
-                TargetLimit = (uint)options.TargetLimit,
-            };
+                modifiedOptions.FailOnConflict = options.FailOnConflict;
+                modifiedOptions.FindRenames = options.FindRenames;
+                modifiedOptions.IgnoreWhitespaceChange = options.IgnoreWhitespaceChange;
+                modifiedOptions.MergeFileFavor = options.MergeFileFavor;
+                modifiedOptions.RenameThreshold = options.RenameThreshold;
+                modifiedOptions.TargetLimit = options.TargetLimit;
+            }
 
             bool earlyStop;
-            using (var oneHandle = Proxy.git_object_lookup(repo.Handle, ours.Id, GitObjectType.Commit))
-            using (var twoHandle = Proxy.git_object_lookup(repo.Handle, theirs.Id, GitObjectType.Commit))
-            using (var indexHandle = Proxy.git_merge_commits(repo.Handle, oneHandle, twoHandle, mergeOptions, out earlyStop))
+            using (var indexHandle = MergeCommits(ours, theirs, modifiedOptions, out earlyStop))
             {
                 MergeTreeResult mergeResult;
 
@@ -858,6 +847,79 @@ namespace LibGit2Sharp
         {
             return InternalPack(options, packDelegate);
         }
+
+        /// <summary>
+        /// Perform a three-way merge of two commits, looking up their
+        /// commit ancestor. The returned index will contain the results
+        /// of the merge and can be examined for conflicts.
+        /// </summary>
+        /// <param name="ours">The first tree</param>
+        /// <param name="theirs">The second tree</param>
+        /// <param name="options">The <see cref="MergeTreeOptions"/> controlling the merge</param>
+        /// <returns>The <see cref="Index"/> containing the merged trees and any conflicts, or null if the merge stopped early due to conflicts</returns>
+        public virtual Index MergeCommitsIntoIndex(Commit ours, Commit theirs, MergeTreeOptions options)
+        {
+            Ensure.ArgumentNotNull(ours, "ours");
+            Ensure.ArgumentNotNull(theirs, "theirs");
+
+            options = options ?? new MergeTreeOptions();
+
+            bool earlyStop;
+            var indexHandle = MergeCommits(ours, theirs, options, out earlyStop);
+            if (earlyStop)
+            {
+                if (indexHandle != null)
+                {
+                    indexHandle.Dispose();
+                }
+                return null;
+            }
+            var result = new Index(indexHandle, repo);
+            return result;
+        }
+
+        /// <summary>
+        /// Perform a three-way merge of two commits, looking up their
+        /// commit ancestor. The returned index will contain the results
+        /// of the merge and can be examined for conflicts.
+        /// </summary>
+        /// <param name="ours">The first tree</param>
+        /// <param name="theirs">The second tree</param>
+        /// <param name="options">The <see cref="MergeTreeOptions"/> controlling the merge</param>
+        /// <param name="earlyStop">True if the merge stopped early due to conflicts</param>
+        /// <returns>The <see cref="IndexHandle"/> containing the merged trees and any conflicts</returns>
+        private IndexHandle MergeCommits(Commit ours, Commit theirs, MergeTreeOptions options, out bool earlyStop)
+        {
+            GitMergeFlag mergeFlags = GitMergeFlag.GIT_MERGE_NORMAL;
+            if (options.SkipReuc)
+            {
+                mergeFlags |= GitMergeFlag.GIT_MERGE_SKIP_REUC;
+            }
+            if (options.FindRenames)
+            {
+                mergeFlags |= GitMergeFlag.GIT_MERGE_FIND_RENAMES;
+            }
+            if (options.FailOnConflict)
+            {
+                mergeFlags |= GitMergeFlag.GIT_MERGE_FAIL_ON_CONFLICT;
+            }
+
+            var mergeOptions = new GitMergeOpts
+            {
+                Version = 1,
+                MergeFileFavorFlags = options.MergeFileFavor,
+                MergeTreeFlags = mergeFlags,
+                RenameThreshold = (uint)options.RenameThreshold,
+                TargetLimit = (uint)options.TargetLimit,
+            };
+            using (var oneHandle = Proxy.git_object_lookup(repo.Handle, ours.Id, GitObjectType.Commit))
+            using (var twoHandle = Proxy.git_object_lookup(repo.Handle, theirs.Id, GitObjectType.Commit))
+            {
+                var indexHandle = Proxy.git_merge_commits(repo.Handle, oneHandle, twoHandle, mergeOptions, out earlyStop);
+                return indexHandle;
+            }
+        }
+
 
         /// <summary>
         /// Packs objects in the <see cref="ObjectDatabase"/> and write a pack (.pack) and index (.idx) files for them.

--- a/LibGit2Sharp/TransientIndex.cs
+++ b/LibGit2Sharp/TransientIndex.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using LibGit2Sharp.Core.Handles;
+
+namespace LibGit2Sharp
+{
+    /// <summary>
+    /// An implementation of <see cref="Index"/> with disposal managed by the caller
+    /// (instead of automatically disposing when the repository is disposed)
+    /// </summary>
+    public class TransientIndex: Index, IDisposable
+    {
+        /// <summary>
+        /// Needed for mocking purposes.
+        /// </summary>
+        protected TransientIndex()
+        { }
+
+        internal TransientIndex(IndexHandle handle, Repository repo)
+            : base(handle, repo)
+        {
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            this.Handle.SafeDispose();
+        }
+    }
+}


### PR DESCRIPTION
Adds a new method MergeCommitsIntoIndex to ObjectDatabase to make the intermediate result of MergeCommits available (so that conflicts can be resolved directly against the produced index).

Also adds WriteToTree to Index so that the produced index can be converted to a tree just like MergeCommits currently does.