### PR TITLE
SmartSubtransport: use TLS 1.2 for tests

### DIFF
--- a/LibGit2Sharp.Tests/desktop/SmartSubtransportFixture.cs
+++ b/LibGit2Sharp.Tests/desktop/SmartSubtransportFixture.cs
@@ -259,6 +259,8 @@ namespace LibGit2Sharp.Tests
 
                 private static HttpWebRequest CreateWebRequest(string endpointUrl, bool isPost, string contentType)
                 {
+                    ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+
                     HttpWebRequest webRequest = (HttpWebRequest)HttpWebRequest.Create(endpointUrl);
                     webRequest.UserAgent = "git/1.0 (libgit2 custom transport)";
                     webRequest.ServicePoint.Expect100Continue = false;


### PR DESCRIPTION
The subtransport tests create a new subtransport and tests that it can
talk to github.com.  GitHub recently required TLS 1.2 connections,
upgrade our test to build a TLS 1.2 connection to GitHub.