### PR TITLE
Wireup http custom headers in fetch options

### DIFF
--- a/LibGit2Sharp.Tests/CloneFixture.cs
+++ b/LibGit2Sharp.Tests/CloneFixture.cs
@@ -557,5 +557,54 @@ namespace LibGit2Sharp.Tests
 
             }
         }
+
+        [Fact]
+        public void CannotCloneWithForbiddenCustomHeaders()
+        {
+            var scd = BuildSelfCleaningDirectory();
+
+            const string url = "https://github.com/libgit2/TestGitRepository";
+
+            const string knownHeader = "User-Agent: mygit-201";
+            var cloneOptions = new CloneOptions()
+            {
+                FetchOptions = new FetchOptions { CustomHeaders = new String[] { knownHeader } }
+            };
+
+            Assert.Throws<LibGit2SharpException>(() => Repository.Clone(url, scd.DirectoryPath, cloneOptions));
+        }
+
+        [Fact]
+        public void CannotCloneWithMalformedCustomHeaders()
+        {
+            var scd = BuildSelfCleaningDirectory();
+
+            const string url = "https://github.com/libgit2/TestGitRepository";
+
+            const string knownHeader = "hello world";
+            var cloneOptions = new CloneOptions()
+            {
+                FetchOptions = new FetchOptions { CustomHeaders = new String[] { knownHeader } }
+            };
+
+            Assert.Throws<LibGit2SharpException>(() => Repository.Clone(url, scd.DirectoryPath, cloneOptions));
+        }
+
+        [Fact]
+        public void CanCloneWithCustomHeaders()
+        {
+            var scd = BuildSelfCleaningDirectory();
+
+            const string url = "https://github.com/libgit2/TestGitRepository";
+
+            const string knownHeader = "X-Hello: world";
+            var cloneOptions = new CloneOptions()
+            {
+                FetchOptions = new FetchOptions { CustomHeaders = new String[] { knownHeader } }
+            };
+
+            var clonedRepoPath = Repository.Clone(url, scd.DirectoryPath, cloneOptions);
+            Assert.True(Directory.Exists(clonedRepoPath));
+        }
     }
 }

--- a/LibGit2Sharp.Tests/FetchFixture.cs
+++ b/LibGit2Sharp.Tests/FetchFixture.cs
@@ -239,5 +239,57 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(4, clonedRepo.Branches.Count(b => b.IsRemote));
             }
         }
+
+        [Fact]
+        public void CannotFetchWithForbiddenCustomHeaders()
+        {
+            var scd = BuildSelfCleaningDirectory();
+
+            const string url = "https://github.com/libgit2/TestGitRepository";
+
+            string clonedRepoPath = Repository.Clone(url, scd.DirectoryPath);
+
+            const string knownHeader = "User-Agent: mygit-201";
+            var options = new FetchOptions { CustomHeaders = new String[] { knownHeader } };
+            using (var repo = new Repository(clonedRepoPath))
+            {
+                Assert.Throws<LibGit2SharpException>(() => Commands.Fetch(repo, "origin", new string[0], options, null));
+            }
+        }
+
+        [Fact]
+        public void CanFetchWithCustomHeaders()
+        {
+            var scd = BuildSelfCleaningDirectory();
+
+            const string url = "https://github.com/libgit2/TestGitRepository";
+
+            string clonedRepoPath = Repository.Clone(url, scd.DirectoryPath);
+
+            const string knownHeader = "X-Hello: mygit-201";
+            var options = new FetchOptions { CustomHeaders = new String[] { knownHeader } };
+            using (var repo = new Repository(clonedRepoPath))
+            {
+                Commands.Fetch(repo, "origin", new string[0], options, null);
+            }
+        }
+
+        [Fact]
+        public void CannotFetchWithMalformedCustomHeaders()
+        {
+            var scd = BuildSelfCleaningDirectory();
+
+            const string url = "https://github.com/libgit2/TestGitRepository";
+
+            string clonedRepoPath = Repository.Clone(url, scd.DirectoryPath);
+
+            const string knownHeader = "Hello world";
+            var options = new FetchOptions { CustomHeaders = new String[] { knownHeader } };
+            using (var repo = new Repository(clonedRepoPath))
+            {
+                Assert.Throws<LibGit2SharpException>(() => Commands.Fetch(repo, "origin", new string[0], options, null));
+            }
+        }
+
     }
 }

--- a/LibGit2Sharp/CloneOptions.cs
+++ b/LibGit2Sharp/CloneOptions.cs
@@ -43,6 +43,11 @@ namespace LibGit2Sharp
         /// </summary>
         public CheckoutProgressHandler OnCheckoutProgress { get; set; }
 
+        /// <summary>
+        /// Gets or sets the fetch options.
+        /// </summary>
+        public FetchOptions FetchOptions { get; set; }
+
         #region IConvertableToGitCheckoutOpts
 
         CheckoutCallbacks IConvertableToGitCheckoutOpts.GenerateCallbacks()

--- a/LibGit2Sharp/Core/GitFetchOptions.cs
+++ b/LibGit2Sharp/Core/GitFetchOptions.cs
@@ -11,6 +11,6 @@ namespace LibGit2Sharp.Core
         public bool UpdateFetchHead = true;
         public TagFetchMode download_tags;
         public GitProxyOptions ProxyOptions;
-        public GitStrArrayManaged custom_headers;
+        public GitStrArrayManaged CustomHeaders;
     }
 }

--- a/LibGit2Sharp/Core/GitFetchOptionsWrapper.cs
+++ b/LibGit2Sharp/Core/GitFetchOptionsWrapper.cs
@@ -1,0 +1,36 @@
+﻿using System;
+
+namespace LibGit2Sharp.Core
+{
+    /// <summary> 
+    /// Git fetch options wrapper. Disposable wrapper for GitFetchOptions 
+    /// </summary>
+    internal class GitFetchOptionsWrapper : IDisposable
+    {
+        public GitFetchOptionsWrapper() : this(new GitFetchOptions()) { }
+
+        public GitFetchOptionsWrapper(GitFetchOptions fetchOptions)
+        {
+            this.Options = fetchOptions;
+        }
+
+        public GitFetchOptions Options { get; private set; }
+
+        #region IDisposable
+        private bool disposedValue = false; // To detect redundant calls
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposedValue)
+                return;
+
+            this.Options.CustomHeaders.Dispose();
+            disposedValue = true;
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+        #endregion
+    }
+}

--- a/LibGit2Sharp/FetchOptions.cs
+++ b/LibGit2Sharp/FetchOptions.cs
@@ -25,5 +25,26 @@
         /// </para>
         /// </summary>
         public bool? Prune { get; set; }
+
+        /// <summary>
+        /// Get/Set the custom headers.
+        /// 
+        /// <para> 
+        /// This allows you to set custom headers (e.g. X-Forwarded-For, 
+        /// X-Request-Id, etc),
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// Libgit2 sets some headers for HTTP requests (User-Agent, Host, 
+        /// Accept, Content-Type, Transfer-Encoding, Content-Length, Accept) that
+        /// cannot be overriden.
+        /// </remarks>
+        /// <example>
+        /// var fetchOptions - new FetchOptions() {
+        ///     CustomHeaders = new String[] {"X-Request-Id: 12345"}
+        /// };
+        /// </example>
+        /// <value>The custom headers string array</value>
+        public string[] CustomHeaders { get; set; }
     }
 }


### PR DESCRIPTION
__Summary__
- Expose custom headers for GitFetchOptions for Fetch, and indirectly for CloneOptions
   - Allows you to set extra headers 
   - Note: Libgit2 sets some headers for HTTP requests (User-Agent, Host, Accept, Content-Type, Transfer-Encoding, Content-Length, Accept) that cannot be overriden.
   - Libgit2 reference: https://libgit2.github.com/libgit2/#HEAD/type/git_fetch_options
- Had to wrap these custom headers with GitFetchOptionsWrapper to dispose them. (Similar to how GitCheckoutOptsWrapper)

__Tests__
- Unit-tests, Added coverage in CloneFixture .& FetchFixture. the malformed/reserved headers are handled by libgit2, so you can validate them getting passed through to libgit2. 
- Manual verification, tested against git-server