### PR TITLE
appveyor: maint branches aren't prerelease

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,7 +47,7 @@ install:
     Write-Host $BuildDate -ForegroundColor "Green"
 
     $VersionSuffix = ""
-    If ($Env:APPVEYOR_REPO_BRANCH -ne "master")
+    If ($Env:APPVEYOR_REPO_BRANCH -ne "master" -and ($Env:APPVEYOR_REPO_BRANCH -eq $null -or !$Env:APPVEYOR_REPO_BRANCH.StartsWith("maint/")))
     {
       $VersionSuffix = "-pre$BuildDate"
     }


### PR DESCRIPTION
Remove the `-pre` suffix from nuget packages created from maintenance branches, so that they can be published as proper maintenance releases.