### PR TITLE
Improve SecureString marshaling 

### DIFF
--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Security;
 using LibGit2Sharp.Core.Handles;
 
 // ReSharper disable InconsistentNaming
@@ -471,6 +472,12 @@ namespace LibGit2Sharp.Core
             out IntPtr cred,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string username,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string password);
+
+        [DllImport(libgit2)]
+        internal static extern int git_cred_userpass_plaintext_new(
+            out IntPtr cred,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string username,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] SecureString password);
 
         [DllImport(libgit2)]
         internal static extern void git_cred_free(IntPtr cred);

--- a/LibGit2Sharp/SecureUsernamePasswordCredentials.cs
+++ b/LibGit2Sharp/SecureUsernamePasswordCredentials.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.InteropServices;
 using System.Security;
 using LibGit2Sharp.Core;
 
@@ -22,19 +21,7 @@ namespace LibGit2Sharp
                 throw new InvalidOperationException("UsernamePasswordCredentials contains a null Username or Password.");
             }
 
-            IntPtr passwordPtr = IntPtr.Zero;
-
-            try
-            {
-                passwordPtr = Marshal.SecureStringToGlobalAllocUnicode(Password);
-
-                return NativeMethods.git_cred_userpass_plaintext_new(out cred, Username, Marshal.PtrToStringUni(passwordPtr));
-            }
-            finally
-            {
-                Marshal.ZeroFreeGlobalAllocUnicode(passwordPtr);
-            }
-
+            return NativeMethods.git_cred_userpass_plaintext_new(out cred, Username, Password);
         }
 
         /// <summary>


### PR DESCRIPTION
Addresses the concerns with `SecureString` usage in `SecureUsernamePasswordCredentials`, as described in #1550.