### PR TITLE
Prepare for work on v0.26

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
   - Windows (x86/amd64): <https://ci.appveyor.com/project/libgit2/libgit2sharp>
   - Linux/Mac OS X: <https://travis-ci.org/libgit2/libgit2sharp>
 
+## v0.26
+
 ## v0.25 - ([diff](https://github.com/libgit2/libgit2sharp/compare/v0.24..v0.25))
 
 LibGit2Sharp is now .NET Core 2.0+ and .NET Framework compatible.

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.25.0",
+  "version": "0.26.0-preview.{height}",
   "publicReleaseRefSpec": [
     "^refs/heads/master$", // we release out of master
     "^refs/heads/v\\d+(?:\\.\\d+)?$" // we also release out of vNN branches


### PR DESCRIPTION
Let's get `master` in shape for work that will eventually go into v0.26:

Update the `version.json` to begin producing 0.26-preview builds.
Update the `CHANGES.md` to include an 0.26 section.