### PR TITLE
Update for LibGit2Sharp v0.25.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,28 @@
   - Windows (x86/amd64): <https://ci.appveyor.com/project/libgit2/libgit2sharp>
   - Linux/Mac OS X: <https://travis-ci.org/libgit2/libgit2sharp>
 
+## v0.25.1 - ([diff](https://github.com/libgit2/libgit2sharp/compare/v0.25..v0.25.1))
+
+This is a security release fixing insufficient validation of submodule
+names (CVE-2018-11235, reported by Etienne Stalmans) and disallows
+`.gitmodules` files as symlinks.  This includes [libgit2
+v0.27.1](https://github.com/libgit2/libgit2/releases/tag/v0.27.1),
+whose release notes follow.
+
+While submodule names come from the untrusted `.gitmodules` file, we
+blindly append the name to `$GIT_DIR/modules` to construct the final
+path of the submodule repository. In case the name contains e.g. `../`,
+an adversary would be able to escape your repository and write data at
+arbitrary paths. In accordance with git, we now enforce some rules for
+submodule names which will cause libgit2 to ignore these malicious names.
+
+Adding a symlink as .gitmodules into the index from the workdir or
+checking out such files is not allowed as this can make a Git
+implementation write outside of the repository and bypass the fsck
+checks for CVE-2018-11235.
+
+libgit2 (and LibGit2Sharp) is not susceptible to CVE-2018-11233.
+
 ## v0.25 - ([diff](https://github.com/libgit2/libgit2sharp/compare/v0.24..v0.25))
 
 LibGit2Sharp is now .NET Core 2.0+ and .NET Framework compatible.

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="[1.0.210]" PrivateAssets="none" />
+    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="[1.0.217]" PrivateAssets="none" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.23" PrivateAssets="all" />
     <PackageReference Include="SourceLink.Create.GitHub" Version="2.8.0" PrivateAssets="all" />
     <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.8.0" />


### PR DESCRIPTION
Include libgit2 v0.27.1 and create a LibGit2Sharp v0.25.1.