### PR TITLE
Improve GenerateUniqueIdentifierCs

### DIFF
--- a/Targets/CodeGenerator.targets
+++ b/Targets/CodeGenerator.targets
@@ -12,15 +12,17 @@
   </Target>
 
 
-  <Target Name="GenerateUniqueIdentifierCs" Inputs="$(MSBuildThisFileFullPath);$(MSBuildAllProjects);@(Compile)" Outputs="$(UniqueIdentifierPath)" BeforeTargets="CoreCompile" DependsOnTargets="DefineProperties">
+  <Target Name="GenerateUniqueIdentifierCs" Inputs="$(VersionSourceFile)" Outputs="$(UniqueIdentifierPath)" BeforeTargets="CoreCompile" AfterTargets="GenerateAssemblyVersionInfo" DependsOnTargets="DefineProperties">
 
     <PropertyGroup>
+      <UniqueIdentifier>$([System.Guid]::NewGuid())</UniqueIdentifier>
+      <UniqueIdentifier Condition="'$(GitCommitId)' != ''">$(GitCommitId)</UniqueIdentifier>
       <UniqueIdSourceLines>
         namespace LibGit2Sharp.Core
         {
         internal static class UniqueId
         {
-        public const string UniqueIdentifier = "$([System.Guid]::NewGuid())"%3b
+        public const string UniqueIdentifier = "$(UniqueIdentifier)"%3b
         }
         }
       </UniqueIdSourceLines>


### PR DESCRIPTION
This improves the GenerateUniqueIdentifierCs to use the commit sha as mentioned in https://github.com/libgit2/libgit2sharp/pull/1563#issuecomment-381795673.

This makes the build more deterministic, but still keeps the `UniqueIdentifier` different between releases.