### PR TITLE
Update Readme Prerequisites .NET/Mono versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@
 
 ## Prerequisites
 
- - **Windows:** .NET 4.0+
- - **Linux/Mac OS X:** Mono 3.6+
+ - **Windows:** .NET 4.6.1+
+ - **Linux/Mac OS X:** Mono 5.4+
 
 ## Online resources
 


### PR DESCRIPTION
Library now targets .NETStandard 2.0 which bumps .NET to 4.6.1+ and Mono to 5.4+
https://docs.microsoft.com/en-us/dotnet/standard/net-standard