### PR TITLE
Fix resources path computation in test setup

### DIFF
--- a/LibGit2Sharp.Tests/TestHelpers/BaseFixture.cs
+++ b/LibGit2Sharp.Tests/TestHelpers/BaseFixture.cs
@@ -64,9 +64,8 @@ namespace LibGit2Sharp.Tests.TestHelpers
             if (resourcesPath == null)
             {
                 string initialAssemblyParentFolder = Directory.GetParent(new Uri(typeof(BaseFixture).GetTypeInfo().Assembly.CodeBase).LocalPath).FullName;
-                const string sourceRelativePath = @"../../../../LibGit2Sharp.Tests/Resources";
-
-                resourcesPath = Path.Combine(initialAssemblyParentFolder, sourceRelativePath);
+                int pos = initialAssemblyParentFolder.IndexOf("LibGit2Sharp.Tests");
+                resourcesPath = Path.Combine(initialAssemblyParentFolder.Substring(0, pos), "../LibGit2Sharp.Tests/Resources");
             }
 
             ResourcesDirectory = new DirectoryInfo(resourcesPath);


### PR DESCRIPTION
The resources path is set based on the path of the current assembly.

The problem is that the assembly directory has a different number of
components, depending on whether the Configuration environment variable
is set or not.

Therefore, the previous code, that depended on the number of subdirs,
would fail if there is no value for the Configuration environment
variable.

The new code looks for the occurrence of a well-known string in the path
and bases the path of the test resources off that position.

It is still pretty sub-optimal, but I think it's a bit less sub-optimal
than it was.

Tested in the following ways:
- run dotnet test on one test from the command line on Windows;
- click on "Run Test" from Visual Studio Code.

Fixes #1629.