### PR TITLE
Tests: copy test resources to output directory

### DIFF
--- a/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
+++ b/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
@@ -25,6 +25,12 @@
     <Compile Remove="desktop\**" Condition=" '$(TargetFramework)' != 'net461' " />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="Resources\**\*.*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
   <Target Name="CopyTestAppExes" AfterTargets="ResolveProjectReferences">
     <ItemGroup>
       <_TestAppFile Include="@(TestAppExe->'%(RootDir)%(Directory)%(Filename).exe')" />

--- a/LibGit2Sharp.Tests/TestHelpers/BaseFixture.cs
+++ b/LibGit2Sharp.Tests/TestHelpers/BaseFixture.cs
@@ -63,9 +63,7 @@ namespace LibGit2Sharp.Tests.TestHelpers
 
             if (resourcesPath == null)
             {
-                string initialAssemblyParentFolder = Directory.GetParent(new Uri(typeof(BaseFixture).GetTypeInfo().Assembly.CodeBase).LocalPath).FullName;
-                int pos = initialAssemblyParentFolder.IndexOf("LibGit2Sharp.Tests");
-                resourcesPath = Path.Combine(initialAssemblyParentFolder.Substring(0, pos), "../LibGit2Sharp.Tests/Resources");
+                resourcesPath = Path.Combine(Directory.GetParent(new Uri(typeof(BaseFixture).GetTypeInfo().Assembly.CodeBase).LocalPath).FullName, "Resources");
             }
 
             ResourcesDirectory = new DirectoryInfo(resourcesPath);


### PR DESCRIPTION
Copy the test resources to the output directory so that we can resolve the easily, instead of trying to resolve them from the source directory.

This is a refinement on #1630 (with help from @b1thunt3r).