### PR TITLE
Typo: path => patch

### DIFF
--- a/LibGit2Sharp.Tests/PatchEntryChangesFixture.cs
+++ b/LibGit2Sharp.Tests/PatchEntryChangesFixture.cs
@@ -23,7 +23,7 @@ namespace LibGit2Sharp.Tests
         Tree rootCommitTree = repo.Lookup<Commit>("f8d44d7").Tree;
         Tree commitTreeWithUpdatedFile = repo.Lookup<Commit>("ec9e401").Tree;
 
-        // Create path by diffing
+        // Create patch by diffing
         using (var patch = repo.Diff.Compare<Patch>(rootCommitTree, commitTreeWithUpdatedFile))
         {
           PatchEntryChanges entryChanges = patch[file];


### PR DESCRIPTION
Just a one-character typo in a test comment: "path" instead of "patch".