### PR TITLE
Update LibGit2Sharp.NativeBinaries to 1.0.245

### DIFF
--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="[1.0.235]" PrivateAssets="none" />
+    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="[1.0.245]" PrivateAssets="none" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="all" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.13" PrivateAssets="all" />
   </ItemGroup>


### PR DESCRIPTION
The new version of LibGit2Sharp.NativeBinaries contains the following changes:
- There is a new `ubuntu.18.04-x64` binary
- The `rhel-x64` binary is now built with glibc 2.12, so it should work with RHEL6

This should help stop some of the pain people have been having while we continue to work on the real solution: #1618