### PR TITLE
Target net46 instead of net461

### DIFF
--- a/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
+++ b/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net46;netcoreapp2.0</TargetFrameworks>
-    <DefineConstants Condition=" '$(TargetFramework)' == 'net46' ">$(DefineConstants);DESKTOP</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
+++ b/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
-    <DefineConstants Condition=" '$(TargetFramework)' == 'net461' ">$(DefineConstants);DESKTOP</DefineConstants>
+    <TargetFrameworks>net46;netcoreapp2.0</TargetFrameworks>
+    <DefineConstants Condition=" '$(TargetFramework)' == 'net46' ">$(DefineConstants);DESKTOP</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\LibGit2Sharp\LibGit2Sharp.csproj" />
-    <ProjectReference Include="..\NativeLibraryLoadTestApp\x86\NativeLibraryLoadTestApp.x86.csproj" Condition="'$(TargetFramework)' == 'net461'" ReferenceOutputAssembly="false" OutputItemType="TestAppExe" />
-    <ProjectReference Include="..\NativeLibraryLoadTestApp\x64\NativeLibraryLoadTestApp.x64.csproj" Condition="'$(TargetFramework)' == 'net461'" ReferenceOutputAssembly="false" OutputItemType="TestAppExe" />
+    <ProjectReference Include="..\NativeLibraryLoadTestApp\x86\NativeLibraryLoadTestApp.x86.csproj" Condition="'$(TargetFramework)' == 'net46'" ReferenceOutputAssembly="false" OutputItemType="TestAppExe" />
+    <ProjectReference Include="..\NativeLibraryLoadTestApp\x64\NativeLibraryLoadTestApp.x64.csproj" Condition="'$(TargetFramework)' == 'net46'" ReferenceOutputAssembly="false" OutputItemType="TestAppExe" />
   </ItemGroup>
 
   <ItemGroup>
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <Compile Include="..\LibGit2Sharp\Core\Platform.cs" Link="TestHelpers\Platform.cs" />
-    <Compile Remove="desktop\**" Condition=" '$(TargetFramework)' != 'net461' " />
+    <Compile Remove="desktop\**" Condition=" '$(TargetFramework)' != 'net46' " />
   </ItemGroup>
 
   <ItemGroup>

--- a/LibGit2Sharp.Tests/SetErrorFixture.cs
+++ b/LibGit2Sharp.Tests/SetErrorFixture.cs
@@ -49,7 +49,7 @@ namespace LibGit2Sharp.Tests
             Exception exceptionToThrow = new AggregateException(aggregateExceptionMessage, new Exception(innerExceptionMessage), new Exception(innerExceptionMessage2));
 
             StringBuilder sb = new StringBuilder();
-#if DESKTOP
+#if NETFRAMEWORK
             sb.AppendLine(aggregateExceptionMessage);
 #else
             sb.AppendLine($"{aggregateExceptionMessage} ({innerExceptionMessage}) ({innerExceptionMessage2})");

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>LibGit2Sharp brings all the might and speed of libgit2, a native Git implementation, to the managed world of .Net and Mono.</Description>
     <Company>LibGit2Sharp contributors</Company>

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="[1.0.258]" PrivateAssets="none" />
+    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="[1.0.260]" PrivateAssets="none" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="all" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.13" PrivateAssets="all" />
   </ItemGroup>

--- a/NativeLibraryLoadTestApp/x64/NativeLibraryLoadTestApp.x64.csproj
+++ b/NativeLibraryLoadTestApp/x64/NativeLibraryLoadTestApp.x64.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net46</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 

--- a/NativeLibraryLoadTestApp/x86/NativeLibraryLoadTestApp.x86.csproj
+++ b/NativeLibraryLoadTestApp/x86/NativeLibraryLoadTestApp.x86.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net46</TargetFramework>
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -90,16 +90,16 @@ test_script:
       {
         .\packages\OpenCover\tools\OpenCover.Console.exe `
           -register:user `
-          "-target:""$Env:userprofile\.nuget\packages\xunit.runner.console\2.4.0\tools\net461\$runner""" `
-          "-targetargs:""$Env:APPVEYOR_BUILD_FOLDER\bin\LibGit2Sharp.Tests\Release\net461\LibGit2Sharp.Tests.dll"" -noshadow" `
+          "-target:""$Env:userprofile\.nuget\packages\xunit.runner.console\2.4.0\tools\net46\$runner""" `
+          "-targetargs:""$Env:APPVEYOR_BUILD_FOLDER\bin\LibGit2Sharp.Tests\Release\net46\LibGit2Sharp.Tests.dll"" -noshadow" `
           "-filter:+[LibGit2Sharp]* -[LibGit2Sharp.Tests]*" `
           -hideskipped:All `
           -output:opencoverCoverage.xml
       }
       ElseIf ($Env:SHOULD_RUN_COVERITY_ANALYSIS -eq $False)
       {
-        & "$Env:userprofile\.nuget\packages\xunit.runner.console\2.4.0\tools\net461\$runner" `
-            "$Env:APPVEYOR_BUILD_FOLDER\bin\LibGit2Sharp.Tests\Release\net461\LibGit2Sharp.Tests.dll" -noshadow
+        & "$Env:userprofile\.nuget\packages\xunit.runner.console\2.4.0\tools\net46\$runner" `
+            "$Env:APPVEYOR_BUILD_FOLDER\bin\LibGit2Sharp.Tests\Release\net46\LibGit2Sharp.Tests.dll" -noshadow
       }
     }
 

--- a/buildandtest.cmd
+++ b/buildandtest.cmd
@@ -31,7 +31,7 @@ dotnet build "%~dp0\" /v:minimal /nologo /property:ExtraDefine="%EXTRADEFINE%"
 @IF ERRORLEVEL 1 EXIT /B %ERRORLEVEL%
 
 :: Run tests on Desktop and CoreCLR
-"%userprofile%\.nuget\packages\xunit.runner.console\2.4.0\tools\net452\xunit.console.exe" "%~dp0bin\LibGit2Sharp.Tests\%Configuration%\net461\LibGit2Sharp.Tests.dll" -noshadow
+"%userprofile%\.nuget\packages\xunit.runner.console\2.4.0\tools\net452\xunit.console.exe" "%~dp0bin\LibGit2Sharp.Tests\%Configuration%\net46\LibGit2Sharp.Tests.dll" -noshadow
 @IF ERRORLEVEL 1 EXIT /B %ERRORLEVEL%
 dotnet test "%~dp0LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj" -f netcoreapp2.0 --no-restore --no-build
 @IF ERRORLEVEL 1 EXIT /B %ERRORLEVEL%


### PR DESCRIPTION
In order to better support using LibGit2Sharp from inside of Visual Studio, we need to switch to `net46` instead of `net461`. See https://github.com/github/VisualStudio/issues/1849#issuecomment-411570902 for details.