### PR TITLE
Use cdecl calling conventions

### DIFF
--- a/LibGit2Sharp/Core/GitCheckoutOpts.cs
+++ b/LibGit2Sharp/Core/GitCheckoutOpts.cs
@@ -118,6 +118,7 @@ namespace LibGit2Sharp.Core
         GIT_CHECKOUT_UPDATE_SUBMODULES_IF_CHANGED = (1 << 17),
     }
 
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     internal delegate int checkout_notify_cb(
         CheckoutNotifyFlags why,
         IntPtr path,
@@ -126,12 +127,14 @@ namespace LibGit2Sharp.Core
         IntPtr workdir,
         IntPtr payload);
 
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     internal delegate void progress_cb(
             IntPtr strPtr,
             UIntPtr completed_steps,
             UIntPtr total_steps,
             IntPtr payload);
 
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     internal delegate int perfdata_cb(
             IntPtr perfdata,
             IntPtr payload);

--- a/LibGit2Sharp/Core/GitDiff.cs
+++ b/LibGit2Sharp/Core/GitDiff.cs
@@ -198,12 +198,14 @@ namespace LibGit2Sharp.Core
         GIT_DIFF_SHOW_BINARY = (1 << 30),
     }
 
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     internal delegate int diff_notify_cb(
         IntPtr diff_so_far,
         IntPtr delta_to_add,
         IntPtr matched_pathspec,
         IntPtr payload);
 
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     internal delegate int diff_progress_cb(
         IntPtr diff_so_far,
         IntPtr old_path,

--- a/LibGit2Sharp/Core/GitFilter.cs
+++ b/LibGit2Sharp/Core/GitFilter.cs
@@ -43,6 +43,7 @@ namespace LibGit2Sharp.Core
         /// before the first use of the filter, so you can defer expensive
         /// initialization operations (in case libgit2 is being used in a way that doesn't need the filter).
         /// </summary>
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int git_filter_init_fn(IntPtr filter);
 
         /// <summary>
@@ -53,6 +54,7 @@ namespace LibGit2Sharp.Core
         /// will be called once at most and should release resources as needed.
         /// Typically this function will free the `git_filter` object itself.
         /// </summary>
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate void git_filter_shutdown_fn(IntPtr filter);
 
         /// <summary>
@@ -69,6 +71,7 @@ namespace LibGit2Sharp.Core
         /// away before the `apply` callback can use it.  If a filter allocates and assigns a value to the `payload`, it will need a `cleanup`
         /// callback to free the payload.
         /// </summary>
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int git_filter_check_fn(
             GitFilter gitFilter,
             IntPtr payload,
@@ -85,6 +88,7 @@ namespace LibGit2Sharp.Core
         ///
         /// The `payload` value will refer to any payload that was set by the `check` callback.  It may be read from or written to as needed.
         /// </summary>
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int git_filter_apply_fn(
             GitFilter gitFilter,
             IntPtr payload,
@@ -92,6 +96,7 @@ namespace LibGit2Sharp.Core
             IntPtr gitBufFrom,
             IntPtr filterSource);
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int git_filter_stream_fn(
             out IntPtr git_writestream_out,
             GitFilter self,
@@ -104,6 +109,7 @@ namespace LibGit2Sharp.Core
         /// after the filter has been applied.  If the `check` or `apply` callbacks allocated a `payload`
         /// to keep per-source filter state, use this  callback to free that payload and release resources as required.
         /// </summary>
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate void git_filter_cleanup_fn(IntPtr gitFilter, IntPtr payload);
     }
     /// <summary>

--- a/LibGit2Sharp/Core/GitOdbBackend.cs
+++ b/LibGit2Sharp/Core/GitOdbBackend.cs
@@ -55,6 +55,7 @@ namespace LibGit2Sharp.Core
         /// <param name="backend">[in] A pointer to the backend which is being asked to perform the task.</param>
         /// <param name="oid">[in] The OID which the backend is being asked to look up.</param>
         /// <returns>0 if successful; an error code otherwise.</returns>
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int read_callback(
             out IntPtr buffer_p,
             out UIntPtr len_p,
@@ -77,6 +78,7 @@ namespace LibGit2Sharp.Core
         /// <param name="short_oid">[in] The short-form OID which the backend is being asked to look up.</param>
         /// <param name="len">[in] The length of the short-form OID (short_oid).</param>
         /// <returns>0 if successful; an error code otherwise.</returns>
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int read_prefix_callback(
             out GitOid out_oid,
             out IntPtr buffer_p,
@@ -95,6 +97,7 @@ namespace LibGit2Sharp.Core
         /// <param name="backend">[in] A pointer to the backend which is being asked to perform the task.</param>
         /// <param name="oid">[in] The OID which the backend is being asked to look up.</param>
         /// <returns>0 if successful; an error code otherwise.</returns>
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int read_header_callback(
             out UIntPtr len_p,
             out GitObjectType type_p,
@@ -111,6 +114,7 @@ namespace LibGit2Sharp.Core
         /// <param name="len">[in] The length of the buffer pointed to by data.</param>
         /// <param name="type">[in] The type of the object.</param>
         /// <returns>0 if successful; an error code otherwise.</returns>
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int write_callback(
             IntPtr backend,
             ref GitOid oid,
@@ -128,6 +132,7 @@ namespace LibGit2Sharp.Core
         /// <param name="length">[in] The length of the object's contents.</param>
         /// <param name="type">[in] The type of the object being written.</param>
         /// <returns>0 if successful; an error code otherwise.</returns>
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int writestream_callback(
             out IntPtr stream_out,
             IntPtr backend,
@@ -142,6 +147,7 @@ namespace LibGit2Sharp.Core
         /// <param name="backend">[in] A pointer to the backend which is being asked to perform the task.</param>
         /// <param name="oid">[in] The object ID that the caller is requesting.</param>
         /// <returns>0 if successful; an error code otherwise.</returns>
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int readstream_callback(
             out IntPtr stream_out,
             IntPtr backend,
@@ -154,6 +160,7 @@ namespace LibGit2Sharp.Core
         /// <param name="backend">[in] A pointer to the backend which is being asked to perform the task.</param>
         /// <param name="oid">[in] The object ID that the caller is requesting.</param>
         /// <returns>True if the object exists; false otherwise</returns>
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate bool exists_callback(
             IntPtr backend,
             ref GitOid oid);
@@ -169,6 +176,7 @@ namespace LibGit2Sharp.Core
         /// <param name="short_oid">[in] The short-form OID which the backend is being asked to look up.</param>
         /// <param name="len">[in] The length of the short-form OID (short_oid).</param>
         /// <returns>1 if the object exists, 0 if the object doesn't; an error code otherwise.</returns>
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int exists_prefix_callback(
             ref GitOid found_oid,
             IntPtr backend,
@@ -182,6 +190,7 @@ namespace LibGit2Sharp.Core
         /// <param name="backend">[in] A pointer to the backend which is being asked to perform the task.</param>
         /// <param name="cb">[in] The callback function to invoke.</param>
         /// <param name="data">[in] An arbitrary parameter to pass through to the callback</param>
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int foreach_callback(
             IntPtr backend,
             foreach_callback_callback cb,
@@ -191,6 +200,7 @@ namespace LibGit2Sharp.Core
         /// The owner of this backend is finished with it. The backend is asked to clean up and shut down.
         /// </summary>
         /// <param name="backend">[in] A pointer to the backend which is being freed.</param>
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate void free_callback(
             IntPtr backend);
 
@@ -200,6 +210,7 @@ namespace LibGit2Sharp.Core
         /// <param name="oid">The oid of each object in the backing store.</param>
         /// <param name="data">The arbitrary parameter given to foreach_callback.</param>
         /// <returns>A non-negative result indicates the enumeration should continue. Otherwise, the enumeration should stop.</returns>
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int foreach_callback_callback(
             IntPtr oid,
             IntPtr data);

--- a/LibGit2Sharp/Core/GitOdbBackendStream.cs
+++ b/LibGit2Sharp/Core/GitOdbBackendStream.cs
@@ -38,18 +38,22 @@ namespace LibGit2Sharp.Core
 
         public static int GCHandleOffset;
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int read_callback(
             IntPtr stream,
             IntPtr buffer,
             UIntPtr len);
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int write_callback(
             IntPtr stream,
             IntPtr buffer,
             UIntPtr len);
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int finalize_write_callback(IntPtr stream, ref GitOid oid);
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate void free_callback(IntPtr stream);
     }
 }

--- a/LibGit2Sharp/Core/GitSmartSubtransport.cs
+++ b/LibGit2Sharp/Core/GitSmartSubtransport.cs
@@ -23,14 +23,17 @@ namespace LibGit2Sharp.Core
 
         public static int GCHandleOffset;
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int action_callback(
             out IntPtr stream,
             IntPtr subtransport,
             IntPtr url,
             GitSmartSubtransportAction action);
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int close_callback(IntPtr subtransport);
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate void free_callback(IntPtr subtransport);
     }
 }

--- a/LibGit2Sharp/Core/GitSmartSubtransportRegistration.cs
+++ b/LibGit2Sharp/Core/GitSmartSubtransportRegistration.cs
@@ -10,6 +10,7 @@ namespace LibGit2Sharp.Core
         public uint Rpc;
         public uint Param;
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int create_callback(
             out IntPtr subtransport,
             IntPtr owner,

--- a/LibGit2Sharp/Core/GitSmartSubtransportStream.cs
+++ b/LibGit2Sharp/Core/GitSmartSubtransportStream.cs
@@ -25,17 +25,20 @@ namespace LibGit2Sharp.Core
 
         public static int GCHandleOffset;
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int read_callback(
             IntPtr stream,
             IntPtr buffer,
             UIntPtr buf_size,
             out UIntPtr bytes_read);
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int write_callback(
             IntPtr stream,
             IntPtr buffer,
             UIntPtr len);
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate void free_callback(IntPtr stream);
     }
 }

--- a/LibGit2Sharp/Core/GitStashApplyOpts.cs
+++ b/LibGit2Sharp/Core/GitStashApplyOpts.cs
@@ -3,6 +3,7 @@ using System.Runtime.InteropServices;
 
 namespace LibGit2Sharp.Core
 {
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     internal delegate int stash_apply_progress_cb(StashApplyProgress progress, IntPtr payload);
 
     [StructLayout(LayoutKind.Sequential)]

--- a/LibGit2Sharp/Core/GitWriteStream.cs
+++ b/LibGit2Sharp/Core/GitWriteStream.cs
@@ -15,8 +15,13 @@ namespace LibGit2Sharp.Core
         [MarshalAs(UnmanagedType.FunctionPtr)]
         public free_fn free;
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int write_fn(IntPtr stream, IntPtr buffer, UIntPtr len);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int close_fn(IntPtr stream);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate void free_fn(IntPtr stream);
     }
 }

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -95,71 +95,71 @@ namespace LibGit2Sharp.Core
             }
         }
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe GitError* giterr_last();
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void giterr_set_str(
             GitErrorCategory error_class,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string errorString);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void giterr_set_oom();
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe UInt32 git_blame_get_hunk_count(git_blame* blame);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe git_blame_hunk* git_blame_get_hunk_byindex(
             git_blame* blame, UInt32 index);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_blame_file(
             out git_blame* blame,
             git_repository* repo,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string path,
             git_blame_options options);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe void git_blame_free(git_blame* blame);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_blob_create_fromdisk(
             ref GitOid id,
             git_repository* repo,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath path);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_blob_create_fromworkdir(
             ref GitOid id,
             git_repository* repo,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath relative_path);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_blob_create_fromstream(
             out IntPtr stream,
             git_repository* repositoryPtr,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string hintpath);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_blob_create_fromstream_commit(
             ref GitOid oid,
             IntPtr stream);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_blob_filtered_content(
             GitBuf buf,
             git_object* blob,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string as_path,
             [MarshalAs(UnmanagedType.Bool)] bool check_for_binary_data);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe IntPtr git_blob_rawcontent(git_object* blob);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe Int64 git_blob_rawsize(git_object* blob);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_branch_create_from_annotated(
             out git_reference* ref_out,
             git_repository* repo,
@@ -167,45 +167,46 @@ namespace LibGit2Sharp.Core
             git_annotated_commit* target,
             [MarshalAs(UnmanagedType.Bool)] bool force);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_branch_delete(
             git_reference* reference);
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate int branch_foreach_callback(
             IntPtr branch_name,
             GitBranchType branch_type,
             IntPtr payload);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void git_branch_iterator_free(
             IntPtr iterator);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_branch_iterator_new(
             out IntPtr iter_out,
             IntPtr repo,
             GitBranchType branch_type);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_branch_move(
             out git_reference* ref_out,
             git_reference* reference,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string new_branch_name,
             [MarshalAs(UnmanagedType.Bool)] bool force);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_branch_next(
             out IntPtr ref_out,
             out GitBranchType type_out,
             IntPtr iter);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_branch_remote_name(
             GitBuf buf,
             git_repository* repo,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string canonical_branch_name);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_rebase_init(
             out git_rebase* rebase,
             git_repository* repo,
@@ -214,31 +215,31 @@ namespace LibGit2Sharp.Core
             git_annotated_commit* onto,
             GitRebaseOptions options);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_rebase_open(
             out git_rebase* rebase,
             git_repository* repo,
             GitRebaseOptions options);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe UIntPtr git_rebase_operation_entrycount(
             git_rebase* rebase);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe UIntPtr git_rebase_operation_current(
             git_rebase* rebase);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe git_rebase_operation* git_rebase_operation_byindex(
             git_rebase* rebase,
             UIntPtr index);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_rebase_next(
             out git_rebase_operation* operation,
             git_rebase* rebase);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_rebase_commit(
             ref GitOid id,
             git_rebase* rebase,
@@ -247,64 +248,65 @@ namespace LibGit2Sharp.Core
             IntPtr message_encoding,
             IntPtr message);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_rebase_abort(
             git_rebase* rebase);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_rebase_finish(
             git_rebase* repo,
             git_signature* signature);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe void git_rebase_free(git_rebase* rebase);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_remote_rename(
             ref GitStrArray problems,
             git_repository* repo,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string old_name,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string new_name);
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate int git_remote_rename_problem_cb(
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))] string problematic_refspec,
             IntPtr payload);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_branch_upstream_name(
             GitBuf buf,
             git_repository* repo,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string referenceName);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void git_buf_free(GitBuf buf);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_checkout_tree(
             git_repository* repo,
             git_object* treeish,
             ref GitCheckoutOpts opts);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_checkout_index(
             git_repository* repo,
             git_object* treeish,
             ref GitCheckoutOpts opts);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_clone(
             out git_repository* repo,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string origin_url,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath workdir_path,
             ref GitCloneOptions opts);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe git_signature* git_commit_author(git_object* commit);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe git_signature* git_commit_committer(git_object* commit);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_commit_create_from_ids(
             out GitOid id,
             git_repository* repo,
@@ -317,7 +319,7 @@ namespace LibGit2Sharp.Core
             UIntPtr parentCount,
             [MarshalAs(UnmanagedType.LPArray)] [In] IntPtr[] parents);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_commit_create_buffer(
             GitBuf res,
             git_repository* repo,
@@ -329,7 +331,7 @@ namespace LibGit2Sharp.Core
             UIntPtr parent_count,
             IntPtr* parents /* git_commit** originally */);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_commit_create_with_signature(
             out GitOid id,
             git_repository* repo,
@@ -337,28 +339,28 @@ namespace LibGit2Sharp.Core
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string signature,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string signature_field);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))]
         internal static extern unsafe string git_commit_message(git_object* commit);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))]
         internal static extern unsafe string git_commit_summary(git_object* commit);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))]
         internal static extern unsafe string git_commit_message_encoding(git_object* commit);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe git_oid* git_commit_parent_id(git_object* commit, uint n);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe uint git_commit_parentcount(git_object* commit);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe git_oid* git_commit_tree_id(git_object* commit);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_commit_extract_signature(
             GitBuf signature,
             GitBuf signed_data,
@@ -366,45 +368,45 @@ namespace LibGit2Sharp.Core
             ref GitOid commit_id,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string field);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_config_delete_entry(
             git_config* cfg,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_config_lock(out IntPtr txn, git_config* config);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_config_delete_multivar(
             git_config* cfg,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string regexp);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_config_find_global(GitBuf global_config_path);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_config_find_system(GitBuf system_config_path);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_config_find_xdg(GitBuf xdg_config_path);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_config_find_programdata(GitBuf programdata_config_path);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe void git_config_free(git_config* cfg);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe void git_config_entry_free(GitConfigEntry* entry);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_config_get_entry(
             out GitConfigEntry* entry,
             git_config* cfg,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_config_add_file_ondisk(
             git_config* cfg,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath path,
@@ -412,79 +414,80 @@ namespace LibGit2Sharp.Core
             git_repository* repo,
             [MarshalAs(UnmanagedType.Bool)] bool force);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_config_new(out git_config* cfg);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_config_open_level(
             out git_config* cfg,
             git_config* parent,
             uint level);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_config_parse_bool(
             [MarshalAs(UnmanagedType.Bool)] out bool value,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string valueToParse);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_config_parse_int32(
             [MarshalAs(UnmanagedType.I4)] out int value,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string valueToParse);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_config_parse_int64(
             [MarshalAs(UnmanagedType.I8)] out long value,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string valueToParse);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_config_set_bool(
             git_config* cfg,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name,
             [MarshalAs(UnmanagedType.Bool)] bool value);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_config_set_int32(
             git_config* cfg,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name,
             int value);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_config_set_int64(
             git_config* cfg,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name,
             long value);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_config_set_string(
             git_config* cfg,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string value);
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate int config_foreach_callback(
             IntPtr entry,
             IntPtr payload);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_config_foreach(
             git_config* cfg,
             config_foreach_callback callback,
             IntPtr payload);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_config_iterator_glob_new(
             out IntPtr iter,
             IntPtr cfg,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string regexp);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_config_next(
             out IntPtr entry,
             IntPtr iter);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void git_config_iterator_free(IntPtr iter);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_config_snapshot(out git_config* @out, git_config* config);
 
         // Ordinarily we would decorate the `url` parameter with the StrictUtf8Marshaler like we do everywhere
@@ -492,6 +495,7 @@ namespace LibGit2Sharp.Core
         // sometimes vomit when using a custom IMarshaler.  So yeah, don't do that.  If you need the url,
         // call StrictUtf8Marshaler.FromNative manually.  See the discussion here:
         // http://social.msdn.microsoft.com/Forums/en-US/netfx64bit/thread/1eb746c6-d695-4632-8a9e-16c4fa98d481
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate int git_cred_acquire_cb(
             out IntPtr cred,
             IntPtr url,
@@ -499,37 +503,37 @@ namespace LibGit2Sharp.Core
             GitCredentialType allowed_types,
             IntPtr payload);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_cred_default_new(out IntPtr cred);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_cred_userpass_plaintext_new(
             out IntPtr cred,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string username,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string password);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void git_cred_free(IntPtr cred);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_describe_commit(
             out git_describe_result* describe,
             git_object* committish,
             ref GitDescribeOptions options);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_describe_format(
             GitBuf buf,
             git_describe_result* describe,
             ref GitDescribeFormatOptions options);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe void git_describe_result_free(git_describe_result* describe);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe void git_diff_free(git_diff* diff);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_diff_tree_to_tree(
             out git_diff* diff,
             git_repository* repo,
@@ -537,7 +541,7 @@ namespace LibGit2Sharp.Core
             git_object* newTree,
             GitDiffOptions options);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_diff_tree_to_index(
             out git_diff* diff,
             git_repository* repo,
@@ -545,47 +549,51 @@ namespace LibGit2Sharp.Core
             git_index* index,
             GitDiffOptions options);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_diff_merge(
             git_diff* onto,
             git_diff* from);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_diff_index_to_workdir(
             out git_diff* diff,
             git_repository* repo,
             git_index* index,
             GitDiffOptions options);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_diff_tree_to_workdir(
             out git_diff* diff,
             git_repository* repo,
             git_object* oldTree,
             GitDiffOptions options);
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal unsafe delegate int git_diff_file_cb(
             [In] git_diff_delta* delta,
             float progress,
             IntPtr payload);
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal unsafe delegate int git_diff_hunk_cb(
             [In] git_diff_delta* delta,
             [In] GitDiffHunk hunk,
             IntPtr payload);
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal unsafe delegate int git_diff_line_cb(
             [In] git_diff_delta* delta,
             [In] GitDiffHunk hunk,
             [In] GitDiffLine line,
             IntPtr payload);
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal unsafe delegate int git_diff_binary_cb(
             [In] git_diff_delta* delta,
             [In] GitDiffBinary binary,
             IntPtr payload);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_diff_blobs(
             git_object* oldBlob,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string old_as_path,
@@ -598,7 +606,7 @@ namespace LibGit2Sharp.Core
             git_diff_line_cb lineCallback,
             IntPtr payload);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_diff_foreach(
             git_diff* diff,
             git_diff_file_cb fileCallback,
@@ -607,30 +615,30 @@ namespace LibGit2Sharp.Core
             git_diff_line_cb lineCallback,
             IntPtr payload);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_diff_find_similar(
             git_diff* diff,
             GitDiffFindOptions options);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe UIntPtr git_diff_num_deltas(git_diff* diff);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe git_diff_delta* git_diff_get_delta(git_diff* diff, UIntPtr idx);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_filter_register(
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name,
             IntPtr gitFilter, int priority);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_filter_unregister(
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_filter_source_mode(git_filter_source* source);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_libgit2_features();
 
         #region git_libgit2_opts
@@ -655,40 +663,40 @@ namespace LibGit2Sharp.Core
         internal static extern int git_libgit2_opts(int option, int enabled);
         #endregion
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_graph_ahead_behind(out UIntPtr ahead, out UIntPtr behind, git_repository* repo, ref GitOid one, ref GitOid two);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_graph_descendant_of(
             git_repository* repo,
             ref GitOid commit,
             ref GitOid ancestor);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_ignore_add_rule(
             git_repository* repo,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string rules);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_ignore_clear_internal_rules(git_repository* repo);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_ignore_path_is_ignored(
             out int ignored,
             git_repository* repo,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string path);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_index_add_bypath(
             git_index* index,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath path);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_index_add(
             git_index* index,
             git_index_entry* entry);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_index_conflict_get(
             out git_index_entry* ancestor,
             out git_index_entry* ours,
@@ -696,111 +704,111 @@ namespace LibGit2Sharp.Core
             git_index* index,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string path);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_index_conflict_iterator_new(
             out git_index_conflict_iterator* iterator,
             git_index* index);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_index_conflict_next(
             out git_index_entry* ancestor,
             out git_index_entry* ours,
             out git_index_entry* theirs,
             git_index_conflict_iterator* iterator);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe void git_index_conflict_iterator_free(
             git_index_conflict_iterator* iterator);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe UIntPtr git_index_entrycount(git_index* index);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_index_entry_stage(git_index_entry* indexentry);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe void git_index_free(git_index* index);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe git_index_entry* git_index_get_byindex(git_index* index, UIntPtr n);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe git_index_entry* git_index_get_bypath(
             git_index* index,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string path,
             int stage);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_index_has_conflicts(git_index* index);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe UIntPtr git_index_name_entrycount(git_index* handle);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe git_index_name_entry* git_index_name_get_byindex(git_index* handle, UIntPtr n);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_index_open(
             out git_index* index,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath indexpath);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_index_read(
             git_index* index,
             [MarshalAs(UnmanagedType.Bool)] bool force);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_index_remove_bypath(
             git_index* index,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string path);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe UIntPtr git_index_reuc_entrycount(git_index* handle);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe git_index_reuc_entry* git_index_reuc_get_byindex(git_index* handle, UIntPtr n);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe git_index_reuc_entry* git_index_reuc_get_bypath(
             git_index* handle,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string path);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_index_write(git_index* index);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_index_write_tree(out GitOid treeOid, git_index* index);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_index_write_tree_to(out GitOid treeOid, git_index* index, git_repository* repo);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_index_read_tree(git_index* index, git_object* tree);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_index_clear(git_index* index);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_merge_base_many(
             out GitOid mergeBase,
             git_repository* repo,
             int length,
             [In] GitOid[] input_array);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_merge_base_octopus(
             out GitOid mergeBase,
             git_repository* repo,
             int length,
             [In] GitOid[] input_array);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_annotated_commit_from_ref(
             out git_annotated_commit* annotatedCommit,
             git_repository* repo,
             git_reference* reference);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_annotated_commit_from_fetchhead(
             out git_annotated_commit* annotatedCommit,
             git_repository* repo,
@@ -808,23 +816,23 @@ namespace LibGit2Sharp.Core
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string remote_url,
             ref GitOid oid);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_annotated_commit_from_revspec(
             out git_annotated_commit* annotatedCommit,
             git_repository* repo,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string revspec);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_annotated_commit_lookup(
             out git_annotated_commit* annotatedCommit,
             git_repository* repo,
             ref GitOid id);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe git_oid* git_annotated_commit_id(
             git_annotated_commit* annotatedCommit);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_merge(
             git_repository* repo,
             [In] IntPtr[] their_heads,
@@ -832,7 +840,7 @@ namespace LibGit2Sharp.Core
             ref GitMergeOpts merge_opts,
             ref GitCheckoutOpts checkout_opts);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_merge_commits(
             out git_index* index,
             git_repository* repo,
@@ -840,7 +848,7 @@ namespace LibGit2Sharp.Core
             git_object* their_commit,
             ref GitMergeOpts merge_opts);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_merge_analysis(
             out GitMergeAnalysis status_out,
             out GitMergePreference preference_out,
@@ -848,17 +856,17 @@ namespace LibGit2Sharp.Core
             [In] IntPtr[] their_heads,
             int their_heads_len);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe void git_annotated_commit_free(git_annotated_commit* commit);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_message_prettify(
             GitBuf buf,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string message,
             [MarshalAs(UnmanagedType.Bool)] bool strip_comments,
             sbyte comment_char);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_note_create(
             out GitOid noteOid,
             git_repository* repo,
@@ -869,24 +877,24 @@ namespace LibGit2Sharp.Core
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string note,
             int force);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe void git_note_free(git_note* note);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))]
         internal static extern unsafe string git_note_message(git_note* note);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe git_oid* git_note_id(git_note* note);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_note_read(
             out git_note* note,
             git_repository* repo,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string notes_ref,
             ref GitOid oid);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_note_remove(
             git_repository* repo,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string notes_ref,
@@ -894,141 +902,145 @@ namespace LibGit2Sharp.Core
             git_signature* committer,
             ref GitOid oid);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_note_default_ref(
             GitBuf notes_ref,
             git_repository* repo);
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate int git_note_foreach_cb(
             ref GitOid blob_id,
             ref GitOid annotated_object_id,
             IntPtr payload);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_note_foreach(
             git_repository* repo,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string notes_ref,
             git_note_foreach_cb cb,
             IntPtr payload);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_odb_add_backend(git_odb* odb, IntPtr backend, int priority);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr git_odb_backend_malloc(IntPtr backend, UIntPtr len);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_odb_exists(git_odb* odb, ref GitOid id);
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate int git_odb_foreach_cb(
             IntPtr id,
             IntPtr payload);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_odb_foreach(
             git_odb* odb,
             git_odb_foreach_cb cb,
             IntPtr payload);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_odb_open_wstream(out git_odb_stream* stream, git_odb* odb, Int64 size, GitObjectType type);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe void git_odb_free(git_odb* odb);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_odb_read_header(out UIntPtr len_out, out GitObjectType type, git_odb* odb, ref GitOid id);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe void git_object_free(git_object* obj);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_odb_stream_write(git_odb_stream* Stream, IntPtr Buffer, UIntPtr len);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_odb_stream_finalize_write(out GitOid id, git_odb_stream* stream);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe void git_odb_stream_free(git_odb_stream* stream);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_odb_write(out GitOid id, git_odb* odb, byte* data, UIntPtr len, GitObjectType type);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe git_oid* git_object_id(git_object* obj);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_object_lookup(out git_object* obj, git_repository* repo, ref GitOid id, GitObjectType type);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_object_peel(
             out git_object* peeled,
             git_object* obj,
             GitObjectType type);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_object_short_id(
             GitBuf buf,
             git_object* obj);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe GitObjectType git_object_type(git_object* obj);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_patch_from_diff(out git_patch* patch, git_diff* diff, UIntPtr idx);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_patch_print(git_patch* patch, git_diff_line_cb print_cb, IntPtr payload);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_patch_line_stats(
             out UIntPtr total_context,
             out UIntPtr total_additions,
             out UIntPtr total_deletions,
             git_patch* patch);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe void git_patch_free(git_patch* patch);
 
         /* Push network progress notification function */
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate int git_push_transfer_progress(uint current, uint total, UIntPtr bytes, IntPtr payload);
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate int git_packbuilder_progress(int stage, uint current, uint total, IntPtr payload);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe void git_packbuilder_free(git_packbuilder* packbuilder);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_packbuilder_insert(
             git_packbuilder* packbuilder,
             ref GitOid id,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_packbuilder_insert_commit(
             git_packbuilder* packbuilder,
             ref GitOid id);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_packbuilder_insert_recur(
             git_packbuilder* packbuilder,
             ref GitOid id,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_packbuilder_insert_tree(
             git_packbuilder* packbuilder,
             ref GitOid id);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_packbuilder_new(out git_packbuilder* packbuilder, git_repository* repo);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe UIntPtr git_packbuilder_object_count(git_packbuilder* packbuilder);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe UInt32 git_packbuilder_set_threads(git_packbuilder* packbuilder, UInt32 numThreads);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_packbuilder_write(
             git_packbuilder* packbuilder,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath path,
@@ -1036,10 +1048,10 @@ namespace LibGit2Sharp.Core
             IntPtr progressCallback,
             IntPtr payload);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe UIntPtr git_packbuilder_written(git_packbuilder* packbuilder);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_reference_create(
             out git_reference* reference,
             git_repository* repo,
@@ -1048,7 +1060,7 @@ namespace LibGit2Sharp.Core
             [MarshalAs(UnmanagedType.Bool)] bool force,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string log_message);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_reference_symbolic_create(
             out git_reference* reference,
             git_repository* repo,
@@ -1057,46 +1069,47 @@ namespace LibGit2Sharp.Core
             [MarshalAs(UnmanagedType.Bool)] bool force,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string log_message);
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate int ref_glob_callback(
             IntPtr reference_name,
             IntPtr payload);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_reference_foreach_glob(
             git_repository* repo,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string glob,
             ref_glob_callback callback,
             IntPtr payload);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe void git_reference_free(git_reference* reference);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_reference_is_valid_name(
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string refname);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_reference_list(out GitStrArray array, git_repository* repo);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_reference_lookup(
             out git_reference* reference,
             git_repository* repo,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))]
         internal static extern unsafe string git_reference_name(git_reference* reference);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_reference_remove(
             git_repository* repo,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe git_oid* git_reference_target(git_reference* reference);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_reference_rename(
             out git_reference* ref_out,
             git_reference* reference,
@@ -1104,114 +1117,114 @@ namespace LibGit2Sharp.Core
             [MarshalAs(UnmanagedType.Bool)] bool force,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string log_message);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_reference_set_target(
             out git_reference* ref_out,
             git_reference* reference,
             ref GitOid id,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string log_message);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_reference_symbolic_set_target(
             out git_reference* ref_out,
             git_reference* reference,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string target,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string log_message);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))]
         internal static extern unsafe string git_reference_symbolic_target(git_reference* reference);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe GitReferenceType git_reference_type(git_reference* reference);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_reference_ensure_log(
             git_repository* repo,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string refname);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe void git_reflog_free(git_reflog* reflog);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_reflog_read(
             out git_reflog* ref_out,
             git_repository* repo,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe UIntPtr git_reflog_entrycount
             (git_reflog* reflog);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe git_reflog_entry* git_reflog_entry_byindex(
             git_reflog* reflog,
             UIntPtr idx);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe git_oid* git_reflog_entry_id_old(
             git_reflog_entry* entry);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe git_oid* git_reflog_entry_id_new(
             git_reflog_entry* entry);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe git_signature* git_reflog_entry_committer(
             git_reflog_entry* entry);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))]
         internal static extern unsafe string git_reflog_entry_message(git_reflog_entry* entry);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_refspec_transform(
             GitBuf buf,
             IntPtr refspec,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name);
 
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_refspec_rtransform(
             GitBuf buf,
             IntPtr refspec,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))]
         internal static extern string git_refspec_string(
             IntPtr refSpec);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern RefSpecDirection git_refspec_direction(IntPtr refSpec);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))]
         internal static extern string git_refspec_dst(
             IntPtr refSpec);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))]
         internal static extern string git_refspec_src(
             IntPtr refspec);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern bool git_refspec_force(IntPtr refSpec);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern bool git_refspec_src_matches(
             IntPtr refspec,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string reference);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern bool git_refspec_dst_matches(
             IntPtr refspec,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string reference);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_remote_autotag(git_remote* remote);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_remote_connect(
             git_remote* remote,
             GitDirection direction,
@@ -1219,21 +1232,21 @@ namespace LibGit2Sharp.Core
             ref GitProxyOptions proxy_options,
             ref GitStrArray custom_headers);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_remote_create(
             out git_remote* remote,
             git_repository* repo,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string url);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_remote_create_anonymous(
             out git_remote* remote,
             git_repository* repo,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string url);
 
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_remote_create_with_fetchspec(
             out git_remote* remote,
             git_repository* repo,
@@ -1241,125 +1254,131 @@ namespace LibGit2Sharp.Core
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string url,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string refspec);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_remote_delete(
             git_repository* repo,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_remote_fetch(
             git_remote* remote,
             ref GitStrArray refspecs,
             GitFetchOptions fetch_opts,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string log_message);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe void git_remote_free(git_remote* remote);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_remote_get_fetch_refspecs(out GitStrArray array, git_remote* remote);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe git_refspec* git_remote_get_refspec(git_remote* remote, UIntPtr n);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_remote_get_push_refspecs(out GitStrArray array, git_remote* remote);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_remote_push(
             git_remote* remote,
             ref GitStrArray refSpecs,
             GitPushOptions opts);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe UIntPtr git_remote_refspec_count(git_remote* remote);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_remote_set_url(
             git_repository* repo,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string remote,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string url);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_remote_add_fetch(
             git_repository* repo,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string remote,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string url);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_remote_set_pushurl(
             git_repository* repo,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string remote,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string url);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_remote_add_push(
             git_repository* repo,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string remote,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string url);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_remote_is_valid_name(
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string remote_name);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_remote_list(out GitStrArray array, git_repository* repo);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_remote_lookup(
             out git_remote* remote,
             git_repository* repo,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_remote_ls(out git_remote_head** heads, out UIntPtr size, git_remote* remote);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))]
         internal static extern unsafe string git_remote_name(git_remote* remote);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))]
         internal static extern unsafe string git_remote_url(git_remote* remote);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))]
         internal static extern unsafe string git_remote_pushurl(git_remote* remote);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe void git_remote_set_autotag(
             git_repository* repo,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name,
             TagFetchMode option);
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate int remote_progress_callback(IntPtr str, int len, IntPtr data);
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate int remote_completion_callback(RemoteCompletionType type, IntPtr data);
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate int remote_update_tips_callback(
             IntPtr refName,
             ref GitOid oldId,
             ref GitOid newId,
             IntPtr data);
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate int push_negotiation_callback(
             IntPtr updates,
             UIntPtr len,
             IntPtr payload);
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate int push_update_reference_callback(
             IntPtr refName,
             IntPtr status,
             IntPtr data
             );
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_repository_discover(
             GitBuf buf,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath start_path,
             [MarshalAs(UnmanagedType.Bool)] bool across_fs,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath ceiling_dirs);
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate int git_repository_fetchhead_foreach_cb(
             IntPtr remote_name,
             IntPtr remote_url,
@@ -1367,147 +1386,148 @@ namespace LibGit2Sharp.Core
             [MarshalAs(UnmanagedType.Bool)] bool is_merge,
             IntPtr payload);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_repository_fetchhead_foreach(
             git_repository* repo,
             git_repository_fetchhead_foreach_cb cb,
             IntPtr payload);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe void git_repository_free(git_repository* repo);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_repository_head_detached(IntPtr repo);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_repository_head_unborn(IntPtr repo);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_repository_ident(
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))] out string name,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))] out string email,
             git_repository* repo);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_repository_index(out git_index* index, git_repository* repo);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_repository_init_ext(
             out git_repository* repository,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath path,
             GitRepositoryInitOptions options);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_repository_is_bare(IntPtr handle);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_repository_is_shallow(IntPtr repo);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_repository_state_cleanup(git_repository* repo);
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate int git_repository_mergehead_foreach_cb(
             ref GitOid oid,
             IntPtr payload);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_repository_mergehead_foreach(
             git_repository* repo,
             git_repository_mergehead_foreach_cb cb,
             IntPtr payload);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_repository_message(
             GitBuf buf,
             git_repository* repository);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_repository_new(
             out git_repository* repo);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_repository_odb(out git_odb* odb, git_repository* repo);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_repository_open(
             out git_repository* repository,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath path);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_repository_open_ext(
             out git_repository* repository,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath path,
             RepositoryOpenFlags flags,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath ceilingDirs);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxFilePathNoCleanupMarshaler))]
         internal static extern unsafe FilePath git_repository_path(git_repository* repository);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe void git_repository_set_config(
             git_repository* repository,
             git_config* config);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_repository_set_ident(
             git_repository* repo,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string email);
 
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe void git_repository_set_index(
             git_repository* repository,
             git_index* index);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_repository_set_workdir(
             git_repository* repository,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath workdir,
             [MarshalAs(UnmanagedType.Bool)] bool update_gitlink);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_repository_set_head_detached(
             git_repository* repo,
             ref GitOid commitish);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_repository_set_head_detached_from_annotated(
             git_repository* repo,
             git_annotated_commit* commit);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_repository_set_head(
             git_repository* repo,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string refname);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_repository_state(
             git_repository* repository);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxFilePathNoCleanupMarshaler))]
         internal static extern unsafe FilePath git_repository_workdir(git_repository* repository);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxFilePathNoCleanupMarshaler))]
         internal static extern FilePath git_repository_workdir(IntPtr repository);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_reset(
             git_repository* repo,
             git_object* target,
             ResetMode reset_type,
             ref GitCheckoutOpts opts);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_revert(
             git_repository* repo,
             git_object* commit,
             GitRevertOpts opts);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_revert_commit(
             out git_index* index,
             git_repository* repo,
@@ -1516,41 +1536,41 @@ namespace LibGit2Sharp.Core
             uint mainline,
             ref GitMergeOpts opts);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_revparse_ext(
             out git_object* obj,
             out git_reference* reference,
             git_repository* repo,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string spec);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe void git_revwalk_free(git_revwalk* walker);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_revwalk_hide(git_revwalk* walker, ref GitOid commit_id);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_revwalk_new(out git_revwalk* walker, git_repository* repo);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_revwalk_next(out GitOid id, git_revwalk* walker);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_revwalk_push(git_revwalk* walker, ref GitOid id);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe void git_revwalk_reset(git_revwalk* walker);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe void git_revwalk_sorting(git_revwalk* walk, CommitSortStrategies sort);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe void git_revwalk_simplify_first_parent(git_revwalk* walk);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe void git_signature_free(git_signature* signature);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_signature_new(
             out git_signature* signature,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name,
@@ -1558,16 +1578,16 @@ namespace LibGit2Sharp.Core
             long time,
             int offset);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_signature_now(
             out git_signature* signature,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string email);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_signature_dup(out git_signature* dest, git_signature* sig);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_stash_save(
             out GitOid id,
             git_repository* repo,
@@ -1575,152 +1595,154 @@ namespace LibGit2Sharp.Core
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string message,
             StashModifiers flags);
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate int git_stash_cb(
             UIntPtr index,
             IntPtr message,
             ref GitOid stash_id,
             IntPtr payload);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_stash_foreach(
             git_repository* repo,
             git_stash_cb callback,
             IntPtr payload);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_stash_drop(git_repository* repo, UIntPtr index);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_stash_apply(
             git_repository* repo,
             UIntPtr index,
             GitStashApplyOpts opts);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_stash_pop(
             git_repository* repo,
             UIntPtr index,
             GitStashApplyOpts opts);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_status_file(
             out FileStatus statusflags,
             git_repository* repo,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath filepath);
 
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_status_list_new(
             out git_status_list* git_status_list,
             git_repository* repo,
             GitStatusOptions options);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_status_list_entrycount(
             git_status_list* statusList);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe git_status_entry* git_status_byindex(
             git_status_list* list,
             UIntPtr idx);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe void git_status_list_free(
             git_status_list* statusList);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void git_strarray_free(
             ref GitStrArray array);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_submodule_lookup(
             out git_submodule* reference,
             git_repository* repo,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_submodule_resolve_url(
             GitBuf buf,
             git_repository* repo,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string url);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_submodule_update(
             git_submodule* sm,
             [MarshalAs(UnmanagedType.Bool)] bool init,
             ref GitSubmoduleUpdateOptions submoduleUpdateOptions);
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate int submodule_callback(
             IntPtr sm,
             IntPtr name,
             IntPtr payload);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_submodule_foreach(
             git_repository* repo,
             submodule_callback callback,
             IntPtr payload);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_submodule_add_to_index(
             git_submodule* submodule,
             [MarshalAs(UnmanagedType.Bool)] bool write_index);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe void git_submodule_free(git_submodule* submodule);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))]
         internal static extern unsafe string git_submodule_path(
             git_submodule* submodule);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))]
         internal static extern unsafe string git_submodule_url(
             git_submodule* submodule);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe git_oid* git_submodule_index_id(
             git_submodule* submodule);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe git_oid* git_submodule_head_id(
             git_submodule* submodule);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe git_oid* git_submodule_wd_id(
             git_submodule* submodule);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe SubmoduleIgnore git_submodule_ignore(
             git_submodule* submodule);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe SubmoduleUpdate git_submodule_update_strategy(
             git_submodule* submodule);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe SubmoduleRecurse git_submodule_fetch_recurse_submodules(
             git_submodule* submodule);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_submodule_reload(
             git_submodule* submodule,
             [MarshalAs(UnmanagedType.Bool)] bool force);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_submodule_status(
             out SubmoduleStatus status,
             git_repository* repo,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath name,
             GitSubmoduleIgnore ignore);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_submodule_init(
             git_submodule* submodule,
             [MarshalAs(UnmanagedType.Bool)] bool overwrite);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_tag_annotation_create(
             out GitOid oid,
             git_repository* repo,
@@ -1729,7 +1751,7 @@ namespace LibGit2Sharp.Core
             git_signature* signature,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string message);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_tag_create(
             out GitOid oid,
             git_repository* repo,
@@ -1740,7 +1762,7 @@ namespace LibGit2Sharp.Core
             [MarshalAs(UnmanagedType.Bool)]
             bool force);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_tag_create_lightweight(
             out GitOid oid,
             git_repository* repo,
@@ -1749,113 +1771,117 @@ namespace LibGit2Sharp.Core
             [MarshalAs(UnmanagedType.Bool)]
             bool force);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_tag_delete(
             git_repository* repo,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string tagName);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_tag_list(out GitStrArray array, git_repository* repo);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))]
         internal static extern unsafe string git_tag_message(git_object* tag);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))]
         internal static extern unsafe string git_tag_name(git_object* tag);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe git_signature* git_tag_tagger(git_object* tag);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe git_oid* git_tag_target_id(git_object* tag);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe GitObjectType git_tag_target_type(git_object* tag);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_libgit2_init();
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_libgit2_shutdown();
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_openssl_set_locking();
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void git_trace_cb(LogLevel level, IntPtr message);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_trace_set(LogLevel level, git_trace_cb trace_cb);
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate int git_transfer_progress_callback(ref GitTransferProgress stats, IntPtr payload);
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate int git_transport_cb(out IntPtr transport, IntPtr remote, IntPtr payload);
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal unsafe delegate int git_transport_certificate_check_cb(git_certificate* cert, int valid, IntPtr hostname, IntPtr payload);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_transport_register(
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string prefix,
             IntPtr transport_cb,
             IntPtr payload);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_transport_smart(
             out IntPtr transport,
             IntPtr remote,
             IntPtr definition);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_transport_smart_certificate_check(
             IntPtr transport,
             IntPtr cert,
             int valid,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string hostname);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_transport_smart_credentials(
             out IntPtr cred_out,
             IntPtr transport,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string user,
             int methods);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_transport_unregister(
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string prefix);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe uint git_tree_entry_filemode(git_tree_entry* entry);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe git_tree_entry* git_tree_entry_byindex(git_object* tree, UIntPtr idx);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_tree_entry_bypath(
             out git_tree_entry* tree,
             git_object* root,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string treeentry_path);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe void git_tree_entry_free(git_tree_entry* treeEntry);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe git_oid* git_tree_entry_id(git_tree_entry* entry);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))]
         internal static extern unsafe string git_tree_entry_name(git_tree_entry* entry);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe GitObjectType git_tree_entry_type(git_tree_entry* entry);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe UIntPtr git_tree_entrycount(git_object* tree);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_treebuilder_new(out git_treebuilder* builder, git_repository* repo, IntPtr src);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_treebuilder_insert(
             IntPtr entry_out,
             git_treebuilder* builder,
@@ -1863,19 +1889,19 @@ namespace LibGit2Sharp.Core
             ref GitOid id,
             uint attributes);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_treebuilder_write(out GitOid id, git_treebuilder* bld);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe void git_treebuilder_free(git_treebuilder* bld);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_blob_is_binary(git_object* blob);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_cherrypick(git_repository* repo, git_object* commit, GitCherryPickOptions options);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_cherrypick_commit(out git_index* index,
             git_repository* repo,
             git_object* cherrypick_commit,
@@ -1883,50 +1909,50 @@ namespace LibGit2Sharp.Core
             uint mainline,
             ref GitMergeOpts options);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_transaction_commit(IntPtr txn);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void git_transaction_free(IntPtr txn);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe void git_worktree_free(git_worktree* worktree);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_worktree_lookup(
             out git_worktree* reference,
             git_repository* repo,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_worktree_list(
             out GitStrArray array,
             git_repository* repo);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_repository_open_from_worktree(
             out git_repository* repository,
             git_worktree* worktree);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_worktree_is_locked(
             GitBuf reason,
             git_worktree* worktree);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_worktree_validate(
             git_worktree* worktree);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_worktree_lock(
             git_worktree* worktree,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string reason);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_worktree_unlock(
             git_worktree* worktree);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_worktree_add (
             out git_worktree* reference,
             git_repository* repo,
@@ -1934,7 +1960,7 @@ namespace LibGit2Sharp.Core
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string path,
             git_worktree_add_options options);
 
-        [DllImport(libgit2)]
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_worktree_prune(
             git_worktree* worktree,
             git_worktree_prune_options options);

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="[1.0.260]" PrivateAssets="none" />
+    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="1.0.261-pre20190109112030" PrivateAssets="none" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="all" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.13" PrivateAssets="all" />
   </ItemGroup>


### PR DESCRIPTION
Join the rest of the world and use cdecl calling conventions to pinvoke libgit2.

This is not ready for merge, it depends on https://github.com/libgit2/libgit2sharp.nativebinaries/pull/86.