### PR TITLE
Fix typos in 'Optimizing unit testing'

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ More thorough information available in the [wiki][wiki].
  [wiki]: https://github.com/libgit2/libgit2sharp/wiki
 
 ## Optimizing unit testing
-LibGit2Sharp strives to have comprehensive and robust unit test suite to insure the quality of the software and to assist new contributors and users who can use the tests as sample to jump start development. There are over one-thousand unit-tests for LibGit2Sharp, this number will only grow as functionality is added.
+LibGit2Sharp strives to have comprehensive and robust unit test suite to ensure the quality of the software and to assist new contributors and users who can use the tests as sample to jump start development. There are over one thousand unit-tests for LibGit2Sharp, this number will only grow as functionality is added.
 
 You can do a few things to optimize running unit-tests on Windows:
 


### PR DESCRIPTION
"Insure" relates to having insurance. "ensure" means "to make sure of"
"One-thousand" shouldn't be hyphenated. It should only be hyphenated in the case of a compound modifier on the word "thousand" as in "forty-five thousand".