### PR TITLE
Add support for Alpine 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 
 language: csharp
 dist: trusty
-dotnet: 2.1.401
+dotnet: 2.1.506
 mono: none
 osx_image: xcode8.3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 # see travis-ci.org for details
 
 language: csharp
-dist: trusty
+dist: xenial
 dotnet: 2.1.506
 mono: none
 osx_image: xcode8.3

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="[2.0.267]" PrivateAssets="none" />
+    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="[2.0.278]" PrivateAssets="none" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="all" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.13" PrivateAssets="all" />
   </ItemGroup>


### PR DESCRIPTION
LibGit2Sharp.NativeBinaries 2.0.278 adds an Alpine 3.9 binary, which is needed because it includes OpenSSL 1.1.