### PR TITLE
 Housekeeping and cleanup updates

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,7 +1,0 @@
-<Project>
-
-  <PropertyGroup>
-    <PublicSign Condition=" '$(AssemblyOriginatorKeyFile)' != '' and '$(OS)' != 'Windows_NT' ">true</PublicSign>
-  </PropertyGroup>
-
-</Project>

--- a/LibGit2Sharp.Tests/GlobalSettingsFixture.cs
+++ b/LibGit2Sharp.Tests/GlobalSettingsFixture.cs
@@ -22,9 +22,9 @@ namespace LibGit2Sharp.Tests
         public void CanRetrieveValidVersionString()
         {
             // Version string format is:
-            //      Major.Minor.Patch[-previewTag]+g{LibGit2Sharp_abbrev_hash}.libgit2-{libgit2_abbrev_hash} (x86|x64 - features)
+            //      Major.Minor.Patch[-previewTag]+{LibGit2Sharp_abbrev_hash}.libgit2-{libgit2_abbrev_hash} (x86|x64 - features)
             // Example output:
-            //      "0.25.0-preview.52+g871d13a67f.libgit2-15e1193 (x86 - Threads, Https)"
+            //      "0.25.0-preview.52+871d13a67f.libgit2-15e1193 (x86 - Threads, Https)"
 
             string versionInfo = GlobalSettings.Version.ToString();
 
@@ -33,14 +33,14 @@ namespace LibGit2Sharp.Tests
             //      git2SharpHash: '871d13a67f' LibGit2Sharp hash.
             //      arch: 'x86' or 'x64' libgit2 target.
             //      git2Features: 'Threads, Ssh' libgit2 features compiled with.
-            string regex = @"^(?<version>\d+\.\d+\.\d+(-[\w\-\.]+)?\+(g(?<git2SharpHash>[a-f0-9]{10})\.)?libgit2-[a-f0-9]{7}) \((?<arch>\w+) - (?<git2Features>(?:\w*(?:, )*\w+)*)\)$";
+            string regex = @"^(?<version>\d+\.\d+\.\d+(-[\w\-\.]+)?\+((?<git2SharpHash>[a-f0-9]{10})\.)?libgit2-[a-f0-9]{7}) \((?<arch>\w+) - (?<git2Features>(?:\w*(?:, )*\w+)*)\)$";
 
             Assert.NotNull(versionInfo);
 
             Match regexResult = Regex.Match(versionInfo, regex);
 
             Assert.True(regexResult.Success, "The following version string format is enforced:" +
-                                             "Major.Minor.Patch[-previewTag]+g{LibGit2Sharp_abbrev_hash}.libgit2-{libgit2_abbrev_hash} (x86|x64 - features). " +
+                                             "Major.Minor.Patch[-previewTag]+{LibGit2Sharp_abbrev_hash}.libgit2-{libgit2_abbrev_hash} (x86|x64 - features). " +
                                              "But found \"" + versionInfo + "\" instead.");
         }
 

--- a/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
+++ b/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
@@ -23,10 +23,8 @@
   <ItemGroup>
     <Compile Include="..\LibGit2Sharp\Core\Platform.cs" Link="TestHelpers\Platform.cs" />
     <Compile Remove="desktop\**" Condition="'$(TargetFramework)' != 'net46'" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Content Include="Resources\**\*.*" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <Target Name="CopyTestAppExes" AfterTargets="ResolveProjectReferences">

--- a/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
+++ b/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net46;netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
+++ b/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
@@ -11,12 +11,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="Moq" Version="4.9.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.console" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="xunit.skippablefact" Version="1.3.6" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="Moq" Version="4.10.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.console" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="xunit.skippablefact" Version="1.3.12" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
+++ b/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
@@ -22,13 +22,11 @@
 
   <ItemGroup>
     <Compile Include="..\LibGit2Sharp\Core\Platform.cs" Link="TestHelpers\Platform.cs" />
-    <Compile Remove="desktop\**" Condition=" '$(TargetFramework)' != 'net46' " />
+    <Compile Remove="desktop\**" Condition="'$(TargetFramework)' != 'net46'" />
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="Resources\**\*.*">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+    <Content Include="Resources\**\*.*" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <Target Name="CopyTestAppExes" AfterTargets="ResolveProjectReferences">

--- a/LibGit2Sharp.Tests/xunit.runner.json
+++ b/LibGit2Sharp.Tests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://xunit.github.io/schema/current/xunit.runner.schema.json",
+    "shadowCopy":  false
+}

--- a/LibGit2Sharp.sln
+++ b/LibGit2Sharp.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27009.1
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28803.202
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LibGit2Sharp", "LibGit2Sharp\LibGit2Sharp.csproj", "{EE6ED99F-CB12-4683-B055-D28FC7357A34}"
 EndProject
@@ -11,7 +11,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.gitignore = .gitignore
 		Targets\CodeGenerator.targets = Targets\CodeGenerator.targets
 		Directory.Build.props = Directory.Build.props
-		Directory.Build.targets = Directory.Build.targets
 		Targets\GenerateNativeDllName.targets = Targets\GenerateNativeDllName.targets
 		nuget.config = nuget.config
 		version.json = version.json

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -18,14 +18,12 @@
 
   <ItemGroup>
     <CodeAnalysisDictionary Include="CustomDictionary.xml" />
-    <None Include="Core\Handles\Objects.tt">
-      <Generator>TextTemplatingFileGenerator</Generator>
-      <LastGenOutput>Objects.cs</LastGenOutput>
-    </None>
     <None Include="..\README.md" Pack="true" PackagePath="App_Readme\" />
     <None Include="..\LICENSE.md" Pack="true" PackagePath="App_Readme\" />
     <None Include="..\CHANGES.md" Pack="true" PackagePath="App_Readme\" />
-    <Compile Update="Core\Handles\Objects.cs" DependentUpon="Objects.tt" />
+    <None Update="Core\Handles\Objects.tt" Generator="TextTemplatingFileGenerator" LastGenOutput="Objects.cs" />
+    <Compile Update="Core\Handles\Objects.cs" DependentUpon="Objects.tt" DesignTime="True" AutoGen="True" />
+    <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" /> <!-- Needed for T4 generation -->
   </ItemGroup>
 
   <ItemGroup>

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -29,7 +29,7 @@
   <ItemGroup>
     <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="[2.0.278]" PrivateAssets="none" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="all" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.13" PrivateAssets="all" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.138" PrivateAssets="all" />
   </ItemGroup>
 
   <Import Project="..\Targets\CodeGenerator.targets" />

--- a/LibGit2Sharp/Version.cs
+++ b/LibGit2Sharp/Version.cs
@@ -55,7 +55,7 @@ namespace LibGit2Sharp
         /// </summary>
         /// <para>
         ///   The format of the version number is as follows:
-        ///   <para>Major.Minor.Patch[-previewTag]+g{LibGit2Sharp_abbrev_hash}.libgit2-{libgit2_abbrev_hash} (x86|x64 - features)</para>
+        ///   <para>Major.Minor.Patch[-previewTag]+{LibGit2Sharp_abbrev_hash}.libgit2-{libgit2_abbrev_hash} (x86|x64 - features)</para>
         /// </para>
         /// <returns></returns>
         public override string ToString()

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -90,7 +90,7 @@ test_script:
       {
         .\packages\OpenCover\tools\OpenCover.Console.exe `
           -register:user `
-          "-target:""$Env:userprofile\.nuget\packages\xunit.runner.console\2.4.0\tools\net46\$runner""" `
+          "-target:""$Env:userprofile\.nuget\packages\xunit.runner.console\2.4.1\tools\net46\$runner""" `
           "-targetargs:""$Env:APPVEYOR_BUILD_FOLDER\bin\LibGit2Sharp.Tests\Release\net46\LibGit2Sharp.Tests.dll"" -noshadow" `
           "-filter:+[LibGit2Sharp]* -[LibGit2Sharp.Tests]*" `
           -hideskipped:All `
@@ -98,7 +98,7 @@ test_script:
       }
       ElseIf ($Env:SHOULD_RUN_COVERITY_ANALYSIS -eq $False)
       {
-        & "$Env:userprofile\.nuget\packages\xunit.runner.console\2.4.0\tools\net46\$runner" `
+        & "$Env:userprofile\.nuget\packages\xunit.runner.console\2.4.1\tools\net46\$runner" `
             "$Env:APPVEYOR_BUILD_FOLDER\bin\LibGit2Sharp.Tests\Release\net46\LibGit2Sharp.Tests.dll" -noshadow
       }
     }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -103,7 +103,7 @@ test_script:
       }
     }
 
-- dotnet test LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj -f netcoreapp2.0 --no-restore --no-build
+- dotnet test LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj -f netcoreapp2.1 --no-restore --no-build
 
 after_test:
 - ps: |

--- a/buildandtest.cmd
+++ b/buildandtest.cmd
@@ -31,7 +31,7 @@ dotnet build "%~dp0\" /v:minimal /nologo /property:ExtraDefine="%EXTRADEFINE%"
 @IF ERRORLEVEL 1 EXIT /B %ERRORLEVEL%
 
 :: Run tests on Desktop and CoreCLR
-"%userprofile%\.nuget\packages\xunit.runner.console\2.4.0\tools\net452\xunit.console.exe" "%~dp0bin\LibGit2Sharp.Tests\%Configuration%\net46\LibGit2Sharp.Tests.dll" -noshadow
+"%userprofile%\.nuget\packages\xunit.runner.console\2.4.1\tools\net46\xunit.console.exe" "%~dp0bin\LibGit2Sharp.Tests\%Configuration%\net46\LibGit2Sharp.Tests.dll" -noshadow
 @IF ERRORLEVEL 1 EXIT /B %ERRORLEVEL%
 dotnet test "%~dp0LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj" -f netcoreapp2.0 --no-restore --no-build
 @IF ERRORLEVEL 1 EXIT /B %ERRORLEVEL%

--- a/buildandtest.cmd
+++ b/buildandtest.cmd
@@ -33,7 +33,7 @@ dotnet build "%~dp0\" /v:minimal /nologo /property:ExtraDefine="%EXTRADEFINE%"
 :: Run tests on Desktop and CoreCLR
 "%userprofile%\.nuget\packages\xunit.runner.console\2.4.1\tools\net46\xunit.console.exe" "%~dp0bin\LibGit2Sharp.Tests\%Configuration%\net46\LibGit2Sharp.Tests.dll" -noshadow
 @IF ERRORLEVEL 1 EXIT /B %ERRORLEVEL%
-dotnet test "%~dp0LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj" -f netcoreapp2.0 --no-restore --no-build
+dotnet test "%~dp0LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj" -f netcoreapp2.1 --no-restore --no-build
 @IF ERRORLEVEL 1 EXIT /B %ERRORLEVEL%
 
 EXIT /B %ERRORLEVEL%

--- a/buildandtest.sh
+++ b/buildandtest.sh
@@ -15,7 +15,7 @@ export Configuration=release
 # On linux we don't pack because we can't build for net40.
 # We just build for CoreCLR and run tests for it.
 dotnet restore
-dotnet build LibGit2Sharp.Tests -f netcoreapp2.0 -property:ExtraDefine="$EXTRADEFINE" -fl -flp:verbosity=detailed
-dotnet test LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj -f netcoreapp2.0 --no-restore --no-build 
+dotnet build LibGit2Sharp.Tests -f netcoreapp2.1 -property:ExtraDefine="$EXTRADEFINE" -fl -flp:verbosity=detailed
+dotnet test LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj -f netcoreapp2.1 --no-restore --no-build 
 
 exit $?


### PR DESCRIPTION
This is primarily a bit of housekeeping and cleanup:

- Testing and build tool package updates
- Ensuring all tests can pass in the VS test runner by disabling shadow copying
- No need to disable signing since non-Windows platforms can sign now

It also includes a slight change to the version string introduced because of https://github.com/AArnott/Nerdbank.GitVersioning/pull/269
