### PR TITLE
Add ARM64 Support & CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,15 @@
+kind: pipeline
+name: default
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: build
+  image: mcr.microsoft.com/dotnet/core/sdk:3.0-bionic-arm64v8
+  commands:
+  - date -u
+  - uname -a
+  - env | sort
+  - ./buildandtest.sh 'LEAKS_IDENTIFYING'

--- a/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
+++ b/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
@@ -1,7 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netcoreapp2.1</TargetFrameworks>
+    <TargetArchitecture Condition="'$(TargetArchitecture)' == ''">$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</TargetArchitecture>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetArchitecture)' != 'Arm64'">$(TargetFrameworks);net46</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
+++ b/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <TargetArchitecture Condition="'$(TargetArchitecture)' == ''">$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</TargetArchitecture>
-    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetArchitecture)' != 'Arm64'">netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetArchitecture)' == 'Arm64'">netcoreapp3.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(TargetArchitecture)' != 'Arm64'">$(TargetFrameworks);net46</TargetFrameworks>
   </PropertyGroup>
 

--- a/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
+++ b/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetArchitecture Condition="'$(TargetArchitecture)' == ''">$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</TargetArchitecture>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(TargetArchitecture)' != 'Arm64'">$(TargetFrameworks);net46</TargetFrameworks>
   </PropertyGroup>
 

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -16,6 +16,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\libgit2sharp.snk</AssemblyOriginatorKeyFile>
+    <DefineConstants Condition="'$(TargetArchitecture)' == 'Arm64'">$(DefineConstants);ARM64</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -1,7 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetArchitecture Condition="'$(TargetArchitecture)' == ''">$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</TargetArchitecture>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetArchitecture)' != 'Arm64'">$(TargetFrameworks);net46</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>LibGit2Sharp brings all the might and speed of libgit2, a native Git implementation, to the managed world of .Net and Mono.</Description>
     <Company>LibGit2Sharp contributors</Company>
@@ -27,9 +29,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="[2.0.278]" PrivateAssets="none" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="all" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.138" PrivateAssets="all" />
+    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="[2.0.280-armpreview01]" PrivateAssets="none" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="all"  Condition="'$(TargetArchitecture)' != 'Arm64'" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.138" PrivateAssets="all" Condition="'$(TargetArchitecture)' != 'Arm64'" />
   </ItemGroup>
 
   <Import Project="..\Targets\CodeGenerator.targets" />

--- a/LibGit2Sharp/Version.cs
+++ b/LibGit2Sharp/Version.cs
@@ -22,7 +22,12 @@ namespace LibGit2Sharp
         /// <summary>
         /// Returns version of the LibGit2Sharp library.
         /// </summary>
-        public virtual string InformationalVersion => ThisAssembly.AssemblyInformationalVersion;
+        public virtual string InformationalVersion
+#if !ARM64
+            => ThisAssembly.AssemblyInformationalVersion;
+#else
+            => string.Empty;
+#endif
 
         /// <summary>
         /// Returns all the optional features that were compiled into

--- a/NativeLibraryLoadTestApp/x64/NativeLibraryLoadTestApp.x64.csproj
+++ b/NativeLibraryLoadTestApp/x64/NativeLibraryLoadTestApp.x64.csproj
@@ -1,8 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetArchitecture Condition="'$(TargetArchitecture)' == ''">$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</TargetArchitecture>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework Condition="'$(TargetArchitecture)' != 'Arm64'">net46</TargetFramework>
+    <TargetFramework Condition="'$(TargetArchitecture)' == 'Arm64'">netcoreapp3.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 

--- a/NativeLibraryLoadTestApp/x86/NativeLibraryLoadTestApp.x86.csproj
+++ b/NativeLibraryLoadTestApp/x86/NativeLibraryLoadTestApp.x86.csproj
@@ -1,8 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetArchitecture Condition="'$(TargetArchitecture)' == ''">$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</TargetArchitecture>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework Condition="'$(TargetArchitecture)' != 'Arm64'">net46</TargetFramework>
+    <TargetFramework Condition="'$(TargetArchitecture)' == 'Arm64'">netcoreapp3.0</TargetFramework>
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
 

--- a/Targets/CodeGenerator.targets
+++ b/Targets/CodeGenerator.targets
@@ -12,7 +12,7 @@
   </Target>
 
 
-  <Target Name="GenerateUniqueIdentifierCs" Inputs="$(VersionSourceFile)" Outputs="$(UniqueIdentifierPath)" BeforeTargets="CoreCompile" AfterTargets="GenerateAssemblyVersionInfo" DependsOnTargets="DefineProperties">
+  <Target Name="GenerateUniqueIdentifierCs" Inputs="$(VersionSourceFile)" Outputs="$(UniqueIdentifierPath)" BeforeTargets="CoreCompile" DependsOnTargets="DefineProperties">
 
     <PropertyGroup>
       <UniqueIdentifier>$([System.Guid]::NewGuid())</UniqueIdentifier>

--- a/Targets/CodeGenerator.targets
+++ b/Targets/CodeGenerator.targets
@@ -12,7 +12,7 @@
   </Target>
 
 
-  <Target Name="GenerateUniqueIdentifierCs" Inputs="$(VersionSourceFile)" Outputs="$(UniqueIdentifierPath)" BeforeTargets="CoreCompile" DependsOnTargets="DefineProperties">
+  <Target Name="GenerateUniqueIdentifierCs" Inputs="$(libgit2_propsfile);$(VersionSourceFile)" Outputs="$(UniqueIdentifierPath)" BeforeTargets="CoreCompile" DependsOnTargets="DefineProperties">
 
     <PropertyGroup>
       <UniqueIdentifier>$([System.Guid]::NewGuid())</UniqueIdentifier>

--- a/buildandtest.sh
+++ b/buildandtest.sh
@@ -15,7 +15,7 @@ export Configuration=release
 # On linux we don't pack because we can't build for net40.
 # We just build for CoreCLR and run tests for it.
 dotnet restore
-dotnet build LibGit2Sharp.Tests -f netcoreapp2.1 -property:ExtraDefine="$EXTRADEFINE" -fl -flp:verbosity=detailed
-dotnet test LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj -f netcoreapp2.1 --no-restore --no-build 
+dotnet build LibGit2Sharp.Tests -f netcoreapp3.0 -property:ExtraDefine="$EXTRADEFINE" -fl -flp:verbosity=detailed
+dotnet test LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj -f netcoreapp3.0 --no-restore --no-build 
 
 exit $?


### PR DESCRIPTION
libgit2/libgit2sharp.nativebinaries#91 added support for building the native libraries for ARM64.

This PR adds support for building and testing libgit2sharp on ARM64. It uses Drone CI to build & test on native ARM64 hardware. It uses netcoreapp3.0 to run the tests.