### PR TITLE
Setting Git proxy type auto where GitProxyOptions 

### DIFF
--- a/LibGit2Sharp/Commands/Fetch.cs
+++ b/LibGit2Sharp/Commands/Fetch.cs
@@ -75,7 +75,7 @@ namespace LibGit2Sharp
                     fetchOptions.CustomHeaders = GitStrArrayManaged.BuildFrom(options.CustomHeaders);
                 }
 
-                fetchOptions.ProxyOptions = new GitProxyOptions { Version = 1 };
+                fetchOptions.ProxyOptions = new GitProxyOptions { Version = 1, Type = GitProxyType.Auto };
 
                 Proxy.git_remote_fetch(remoteHandle, refspecs, fetchOptions, logMessage);
             }

--- a/LibGit2Sharp/Network.cs
+++ b/LibGit2Sharp/Network.cs
@@ -118,7 +118,7 @@ namespace LibGit2Sharp
             using (RemoteHandle remoteHandle = BuildRemoteHandle(repository.Handle, url))
             {
                 GitRemoteCallbacks gitCallbacks = new GitRemoteCallbacks { version = 1 };
-                GitProxyOptions proxyOptions = new GitProxyOptions { Version = 1 };
+                GitProxyOptions proxyOptions = new GitProxyOptions { Version = 1, Type = GitProxyType.Auto };
 
                 if (credentialsProvider != null)
                 {
@@ -375,7 +375,7 @@ namespace LibGit2Sharp
                                       {
                                           PackbuilderDegreeOfParallelism = pushOptions.PackbuilderDegreeOfParallelism,
                                           RemoteCallbacks = gitCallbacks,
-                                          ProxyOptions = new GitProxyOptions { Version = 1 },
+                                          ProxyOptions = new GitProxyOptions { Version = 1, Type = GitProxyType.Auto },
                                       });
             }
         }

--- a/LibGit2Sharp/Repository.cs
+++ b/LibGit2Sharp/Repository.cs
@@ -678,7 +678,7 @@ namespace LibGit2Sharp
             using (RemoteHandle remoteHandle = Proxy.git_remote_create_anonymous(repositoryHandle, url))
             {
                 var gitCallbacks = new GitRemoteCallbacks { version = 1 };
-                var proxyOptions = new GitProxyOptions { Version = 1 };
+                var proxyOptions = new GitProxyOptions { Version = 1, Type = GitProxyType.Auto };
 
                 if (credentialsProvider != null)
                 {
@@ -768,7 +768,7 @@ namespace LibGit2Sharp
                 var gitCheckoutOptions = checkoutOptionsWrapper.Options;
 
                 var gitFetchOptions = fetchOptionsWrapper.Options;
-                gitFetchOptions.ProxyOptions = new GitProxyOptions { Version = 1 };
+                gitFetchOptions.ProxyOptions = new GitProxyOptions { Version = 1, Type = GitProxyType.Auto };
                 gitFetchOptions.RemoteCallbacks = new RemoteCallbacks(options).GenerateCallbacks();
                 if (options.FetchOptions != null && options.FetchOptions.CustomHeaders != null)
                 {


### PR DESCRIPTION
Setting Git proxy type auto where GitProxyOptions version is set to 1 at object initialization

fix for https://github.com/libgit2/libgit2sharp/issues/1429 