### PR TITLE
Add support for adding and clearing multi-valued configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 
 language: csharp
 dist: xenial
-dotnet: 2.1.506
+dotnet: 2.1.802
 mono: none
 osx_image: xcode8.3
 

--- a/LibGit2Sharp.Tests/ConfigurationFixture.cs
+++ b/LibGit2Sharp.Tests/ConfigurationFixture.cs
@@ -51,6 +51,119 @@ namespace LibGit2Sharp.Tests
         }
 
         [Fact]
+        public void CanAddAndReadMultivarFromTheLocalConfiguration()
+        {
+            string path = SandboxStandardTestRepo();
+            using (var repo = new Repository(path))
+            {
+                Assert.Empty(repo.Config
+                    .OfType<ConfigurationEntry<string>>()
+                    .Where(x => x.Key == "unittests.plugin"));
+
+                repo.Config.Add("unittests.plugin", "value1", ConfigurationLevel.Local);
+                repo.Config.Add("unittests.plugin", "value2", ConfigurationLevel.Local);
+
+                Assert.Equal(new[] { "value1", "value2" }, repo.Config
+                    .OfType<ConfigurationEntry<string>>()
+                    .Where(x => x.Key == "unittests.plugin" && x.Level == ConfigurationLevel.Local)
+                    .Select(x => x.Value)
+                    .ToArray());
+            }
+        }
+
+        [Fact]
+        public void CanAddAndReadMultivarFromTheGlobalConfiguration()
+        {
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
+            {
+                Assert.True(repo.Config.HasConfig(ConfigurationLevel.Global));
+                Assert.Empty(repo.Config
+                    .OfType<ConfigurationEntry<string>>()
+                    .Where(x => x.Key == "unittests.plugin"));
+
+                repo.Config.Add("unittests.plugin", "value1", ConfigurationLevel.Global);
+                repo.Config.Add("unittests.plugin", "value2", ConfigurationLevel.Global);
+
+                Assert.Equal(new[] { "value1", "value2" }, repo.Config
+                    .OfType<ConfigurationEntry<string>>()
+                    .Where(x => x.Key == "unittests.plugin")
+                    .Select(x => x.Value)
+                    .ToArray());
+            }
+        }
+
+        [Fact]
+        public void CanUnsetAllFromTheGlobalConfiguration()
+        {
+            string path = SandboxBareTestRepo();
+            using (var repo = new Repository(path))
+            {
+                Assert.True(repo.Config.HasConfig(ConfigurationLevel.Global));
+                Assert.Empty(repo.Config
+                    .OfType<ConfigurationEntry<string>>()
+                    .Where(x => x.Key == "unittests.plugin")
+                    .Select(x => x.Value)
+                    .ToArray());
+
+                repo.Config.Add("unittests.plugin", "value1", ConfigurationLevel.Global);
+                repo.Config.Add("unittests.plugin", "value2", ConfigurationLevel.Global);
+
+                Assert.Equal(2, repo.Config
+                    .OfType<ConfigurationEntry<string>>()
+                    .Where(x => x.Key == "unittests.plugin" && x.Level == ConfigurationLevel.Global)
+                    .Select(x => x.Value)
+                    .Count());
+
+                repo.Config.UnsetAll("unittests.plugin");
+
+                Assert.Equal(2, repo.Config
+                    .OfType<ConfigurationEntry<string>>()
+                    .Where(x => x.Key == "unittests.plugin" && x.Level == ConfigurationLevel.Global)
+                    .Select(x => x.Value)
+                    .Count());
+
+                repo.Config.UnsetAll("unittests.plugin", ConfigurationLevel.Global);
+
+                Assert.Empty(repo.Config
+                    .OfType<ConfigurationEntry<string>>()
+                    .Where(x => x.Key == "unittests.plugin")
+                    .Select(x => x.Value)
+                    .ToArray());
+            }
+        }
+
+        [Fact]
+        public void CanUnsetAllFromTheLocalConfiguration()
+        {
+            string path = SandboxStandardTestRepo();
+            using (var repo = new Repository(path))
+            {
+                Assert.True(repo.Config.HasConfig(ConfigurationLevel.Global));
+                Assert.Empty(repo.Config
+                    .OfType<ConfigurationEntry<string>>()
+                    .Where(x => x.Key == "unittests.plugin")
+                    .Select(x => x.Value)
+                    .ToArray());
+
+                repo.Config.Add("unittests.plugin", "value1");
+                repo.Config.Add("unittests.plugin", "value2");
+
+                Assert.Equal(2, repo.Config
+                    .OfType<ConfigurationEntry<string>>()
+                    .Where(x => x.Key == "unittests.plugin" && x.Level == ConfigurationLevel.Local)
+                    .Select(x => x.Value)
+                    .Count());
+
+                repo.Config.UnsetAll("unittests.plugin");
+
+                Assert.Empty(repo.Config
+                    .OfType<ConfigurationEntry<string>>()
+                    .Where(x => x.Key == "unittests.plugin"));
+            }
+        }
+
+        [Fact]
         public void CanReadBooleanValue()
         {
             var path = SandboxStandardTestRepoGitDir();

--- a/LibGit2Sharp/Configuration.cs
+++ b/LibGit2Sharp/Configuration.cs
@@ -233,9 +233,9 @@ namespace LibGit2Sharp
         /// Unset a configuration variable (key and value) in the local configuration.
         /// </summary>
         /// <param name="key">The key to unset.</param>
-        public virtual void Unset(string key)
+        public virtual bool Unset(string key)
         {
-            Unset(key, ConfigurationLevel.Local);
+            return Unset(key, ConfigurationLevel.Local);
         }
 
         /// <summary>
@@ -243,23 +243,37 @@ namespace LibGit2Sharp
         /// </summary>
         /// <param name="key">The key to unset.</param>
         /// <param name="level">The configuration file which should be considered as the target of this operation</param>
-        public virtual void Unset(string key, ConfigurationLevel level)
+        public virtual bool Unset(string key, ConfigurationLevel level)
         {
             Ensure.ArgumentNotNullOrEmptyString(key, "key");
 
             using (ConfigurationHandle h = RetrieveConfigurationHandle(level, true, configHandle))
             {
-                Proxy.git_config_delete(h, key);
+                return Proxy.git_config_delete(h, key);
             }
         }
 
-        internal void UnsetMultivar(string key, ConfigurationLevel level)
+        /// <summary>
+        /// Unset a configuration values in a multivar variable (key and value) in the local configuration.
+        /// </summary>
+        /// <param name="key">The key to unset.</param>
+        public virtual bool UnsetAll(string key)
+        {
+            return UnsetAll(key, ConfigurationLevel.Local);
+        }
+
+        /// <summary>
+        /// Unset all configuration values in a multivar variable (key and value).
+        /// </summary>
+        /// <param name="key">The key to unset.</param>
+        /// <param name="level">The configuration file which should be considered as the target of this operation</param>
+        public virtual bool UnsetAll(string key, ConfigurationLevel level)
         {
             Ensure.ArgumentNotNullOrEmptyString(key, "key");
 
             using (ConfigurationHandle h = RetrieveConfigurationHandle(level, true, configHandle))
             {
-                Proxy.git_config_delete_multivar(h, key);
+                return Proxy.git_config_delete_multivar(h, key);
             }
         }
 
@@ -631,6 +645,55 @@ namespace LibGit2Sharp
                 }
 
                 configurationTypedUpdater[typeof(T)](key, value, h);
+            }
+        }
+
+        /// <summary>
+        /// Adds a configuration value for a multivalue key in the local configuration. Keys are in the form 'section.name'.
+        /// <para>
+        ///   For example in order to add the value for this in a .git\config file:
+        ///
+        ///   [test]
+        ///   plugin = first
+        ///
+        ///   You would call:
+        ///
+        ///   repo.Config.Add("test.plugin", "first");
+        /// </para>
+        /// </summary>
+        /// <typeparam name="T">The configuration value type</typeparam>
+        /// <param name="key">The key parts</param>
+        /// <param name="value">The value</param>
+        public virtual void Add(string key, string value)
+        {
+            Add(key, value, ConfigurationLevel.Local);
+        }
+
+        /// <summary>
+        /// Adds a configuration value for a multivalue key. Keys are in the form 'section.name'.
+        /// <para>
+        ///   For example in order to add the value for this in a .git\config file:
+        ///
+        ///   [test]
+        ///   plugin = first
+        ///
+        ///   You would call:
+        ///
+        ///   repo.Config.Add("test.plugin", "first");
+        /// </para>
+        /// </summary>
+        /// <typeparam name="T">The configuration value type</typeparam>
+        /// <param name="key">The key parts</param>
+        /// <param name="value">The value</param>
+        /// <param name="level">The configuration file which should be considered as the target of this operation</param>
+        public virtual void Add(string key, string value, ConfigurationLevel level)
+        {
+            Ensure.ArgumentNotNull(value, "value");
+            Ensure.ArgumentNotNullOrEmptyString(key, "key");
+
+            using (ConfigurationHandle h = RetrieveConfigurationHandle(level, true, configHandle))
+            {
+                Proxy.git_config_add_string(h, key, value);
             }
         }
 

--- a/LibGit2Sharp/Configuration.cs
+++ b/LibGit2Sharp/Configuration.cs
@@ -254,7 +254,7 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
-        /// Unset a configuration values in a multivar variable (key and value) in the local configuration.
+        /// Unset all configuration values in a multivar variable (key and value) in the local configuration.
         /// </summary>
         /// <param name="key">The key to unset.</param>
         public virtual bool UnsetAll(string key)

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -498,6 +498,13 @@ namespace LibGit2Sharp.Core
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string regexp);
 
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern unsafe int git_config_set_multivar(
+            git_config* cfg,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string regexp,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string value);
+
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_config_find_global(GitBuf global_config_path);
 
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -601,6 +601,14 @@ namespace LibGit2Sharp.Core
             Ensure.ZeroResult(res);
         }
 
+        static readonly string non_existing_regex = Guid.NewGuid().ToString();
+
+        public static unsafe void git_config_add_string(ConfigurationHandle config, string name, string value)
+        {
+            int res = NativeMethods.git_config_set_multivar(config, name, non_existing_regex, value);
+            Ensure.ZeroResult(res);
+        }
+
         public static unsafe ICollection<TResult> git_config_foreach<TResult>(
             ConfigurationHandle config,
             Func<IntPtr, TResult> resultSelector)

--- a/LibGit2Sharp/RemoteUpdater.cs
+++ b/LibGit2Sharp/RemoteUpdater.cs
@@ -56,7 +56,7 @@ namespace LibGit2Sharp
 
         private void SetFetchRefSpecs(IEnumerable<string> value)
         {
-            repo.Config.UnsetMultivar(string.Format("remote.{0}.fetch", remoteName), ConfigurationLevel.Local);
+            repo.Config.UnsetAll(string.Format("remote.{0}.fetch", remoteName), ConfigurationLevel.Local);
 
             foreach (var url in value)
             {
@@ -74,7 +74,7 @@ namespace LibGit2Sharp
 
         private void SetPushRefSpecs(IEnumerable<string> value)
         {
-            repo.Config.UnsetMultivar(string.Format("remote.{0}.push", remoteName), ConfigurationLevel.Local);
+            repo.Config.UnsetAll(string.Format("remote.{0}.push", remoteName), ConfigurationLevel.Local);
 
             foreach (var url in value)
             {


### PR DESCRIPTION
Implement value adding by exposing the underlying `set_multivar`,
which supports only string values in the underlying libgit2, so no
other typed overloads are provided at this point.

The counterpart for deleting keys exposes the underlying `delete_multivar`.
No regex-based overload is exposed for consistency with the existing `Set<T>`
overloads which don't expose it either.

Also exposed the boolean return value from the `Unset` calls which
is already present in the Proxy API.

Fixes #1719.