### PR TITLE
Update libgit2 to ef5a385

### DIFF
--- a/LibGit2Sharp.Tests/CloneFixture.cs
+++ b/LibGit2Sharp.Tests/CloneFixture.cs
@@ -297,14 +297,6 @@ namespace LibGit2Sharp.Tests
             Assert.True(checksHappy);
         }
 
-        [Fact]
-        public void CloningAnUrlWithoutPathThrows()
-        {
-            var scd = BuildSelfCleaningDirectory();
-
-            Assert.Throws<InvalidSpecificationException>(() => Repository.Clone("http://github.com", scd.DirectoryPath));
-        }
-
         [Theory]
         [InlineData("git://github.com/libgit2/TestGitRepository")]
         public void CloningWithoutWorkdirPathThrows(string url)

--- a/LibGit2Sharp/Core/GitRebaseOptions.cs
+++ b/LibGit2Sharp/Core/GitRebaseOptions.cs
@@ -17,5 +17,7 @@ namespace LibGit2Sharp.Core
         public GitMergeOpts merge_options = new GitMergeOpts { Version = 1 };
 
         public GitCheckoutOpts checkout_options = new GitCheckoutOpts { version = 1 };
+
+        public NativeMethods.commit_signing_callback signing_callback;
     }
 }

--- a/LibGit2Sharp/Core/GitRemoteCallbacks.cs
+++ b/LibGit2Sharp/Core/GitRemoteCallbacks.cs
@@ -34,5 +34,7 @@ namespace LibGit2Sharp.Core
         internal IntPtr transport;
 
         internal IntPtr payload;
+
+        internal NativeMethods.url_resolve_callback resolve_url;
     }
 }

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -2037,6 +2037,13 @@ namespace LibGit2Sharp.Core
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void git_transaction_free(IntPtr txn);
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate int url_resolve_callback(
+            IntPtr url_resolved,
+            IntPtr url,
+            int direction,
+            IntPtr payload);
+
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe void git_worktree_free(git_worktree* worktree);
 

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -321,6 +321,13 @@ namespace LibGit2Sharp.Core
             git_repository* repo,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string canonical_branch_name);
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate int commit_signing_callback(
+            IntPtr signature,
+            IntPtr signature_field,
+            IntPtr commit_content,
+            IntPtr payload);
+
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_rebase_init(
             out git_rebase* rebase,

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="[2.0.289]" PrivateAssets="none" />
+    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="[2.0.298]" PrivateAssets="none" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="all" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.138" PrivateAssets="all" />
   </ItemGroup>


### PR DESCRIPTION
Although libgit2 hasn't yet started locking down for its next release, it should be 🔜 .  We can start readying our prereleases to match.