### PR TITLE
Fix native library loading on Linux

### DIFF
--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -68,7 +68,7 @@ namespace LibGit2Sharp.Core
             {
                 return null;
             }
-            return Path.Combine(nativeLibraryDir, "lib" + libgit2 + Platform.GetNativeLibraryExtension());
+            return Path.Combine(nativeLibraryDir, Platform.GetNativeLibraryPrefix() + libgit2 + Platform.GetNativeLibraryExtension());
         }
 
         private delegate bool TryLoadLibraryByNameDelegate(string libraryName, Assembly assembly, DllImportSearchPath? searchPath, out IntPtr handle);

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -68,7 +68,7 @@ namespace LibGit2Sharp.Core
             {
                 return null;
             }
-            return Path.Combine(nativeLibraryDir, libgit2 + Platform.GetNativeLibraryExtension());
+            return Path.Combine(nativeLibraryDir, "lib" + libgit2 + Platform.GetNativeLibraryExtension());
         }
 
         private delegate bool TryLoadLibraryByNameDelegate(string libraryName, Assembly assembly, DllImportSearchPath? searchPath, out IntPtr handle);

--- a/LibGit2Sharp/Core/Platform.cs
+++ b/LibGit2Sharp/Core/Platform.cs
@@ -56,6 +56,21 @@ namespace LibGit2Sharp.Core
             }
         }
 
+        public static string GetNativeLibraryPrefix()
+        {
+            switch (OperatingSystem)
+            {
+                case OperatingSystemType.MacOSX:
+                case OperatingSystemType.Unix:
+                    return "lib";
+
+                case OperatingSystemType.Windows:
+                    return string.Empty;
+            }
+
+            throw new PlatformNotSupportedException();
+        }
+
         public static string GetNativeLibraryExtension()
         {
             switch (OperatingSystem)


### PR DESCRIPTION
-  `GetGlobalSettingsNativeLibraryPath` is currently broken because it never adds the `lib` prefix to the native library name (`libgit2` does not contain the lib prefix)
- In `ResolveDll`, check whether the runtimes directory exists before listing child directories. In some configurations (e.g. NerdBank.GitVersioning) this directory may not exist, and the code would throw an exception.