### PR TITLE
Custom refdb backend support

### DIFF
--- a/LibGit2Sharp.Tests/Properties/launchSettings.json
+++ b/LibGit2Sharp.Tests/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "LibGit2Sharp.Tests": {
+      "commandName": "Project",
+      "nativeDebugging": true
+    }
+  }
+}

--- a/LibGit2Sharp.Tests/Properties/launchSettings.json
+++ b/LibGit2Sharp.Tests/Properties/launchSettings.json
@@ -1,8 +1,0 @@
-{
-  "profiles": {
-    "LibGit2Sharp.Tests": {
-      "commandName": "Project",
-      "nativeDebugging": true
-    }
-  }
-}

--- a/LibGit2Sharp.Tests/RefdbBackendFixture.cs
+++ b/LibGit2Sharp.Tests/RefdbBackendFixture.cs
@@ -76,6 +76,23 @@ namespace LibGit2Sharp.Tests
             }
         }
 
+        [Fact]
+        public void CanIterateRefdbBackend()
+        {
+            string path = SandboxStandardTestRepo();
+            using (Repository repo = new Repository(path))
+            {
+                var backend = new MockRefdbBackend(repo);
+                repo.Refs.SetBackend(backend);
+
+                backend.Refs["HEAD"] = new RefdbBackend.ReferenceData("HEAD", "refs/heads/testref");
+                backend.Refs["refs/heads/testref"] = new RefdbBackend.ReferenceData("refs/heads/testref", new ObjectId("be3563ae3f795b2b4353bcce3a527ad0a4f7f644"));
+                backend.Refs["refs/heads/othersymbolic"] = new RefdbBackend.ReferenceData("refs/heads/othersymbolic", "refs/heads/testref");
+
+                Assert.True(repo.Refs.Select(r => r.CanonicalName).SequenceEqual(backend.Refs.Keys));
+            }
+        }
+
         private class MockRefdbBackend : RefdbBackend
         {
             public MockRefdbBackend(Repository repository) : base(repository)

--- a/LibGit2Sharp.Tests/RefdbBackendFixture.cs
+++ b/LibGit2Sharp.Tests/RefdbBackendFixture.cs
@@ -1,0 +1,76 @@
+﻿using LibGit2Sharp.Tests.TestHelpers;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace LibGit2Sharp.Tests
+{
+    public class RefdbBackendFixture : BaseFixture
+    {
+        [Fact]
+        public void CanReadFromRefdbBackend()
+        {
+            var scd = new SelfCleaningDirectory(this);
+            Repository.Init(scd.RootedDirectoryPath);
+            using (var repo = new Repository(scd.RootedDirectoryPath))
+            {
+                var backend = new MockRefdbBackend(repo);
+                repo.Refs.SetBackend(backend);
+                backend.Refs["HEAD"] = new RefdbBackend.ReferenceData("HEAD", "refs/heads/testref");
+                backend.Refs["refs/heads/testref"] = new RefdbBackend.ReferenceData("refs/heads/testref", new ObjectId("be3563ae3f795b2b4353bcce3a527ad0a4f7f644"));
+
+                Assert.Equal("refs/heads/testref", repo.Refs["HEAD"].TargetIdentifier);
+                Assert.Equal("be3563ae3f795b2b4353bcce3a527ad0a4f7f644", repo.Refs["HEAD"].ResolveToDirectReference().TargetIdentifier);
+                Assert.Equal("refs/heads/testref", repo.Head.CanonicalName);
+            }
+        }
+
+        private class MockRefdbBackend : RefdbBackend
+        {
+            public MockRefdbBackend(Repository repository) : base(repository)
+            {
+            }
+
+            public SortedDictionary<string, ReferenceData> Refs { get; } = new SortedDictionary<string, ReferenceData>();
+
+            public override bool Exists(string refName)
+            {
+                return Refs.ContainsKey(refName);
+            }
+
+            public override RefIterator Iterate(string glob)
+            {
+                return new MockRefIterator(this);
+            }
+
+            public override bool Lookup(string refName, out ReferenceData data)
+            {
+                return Refs.TryGetValue(refName, out data);
+            }
+
+            private class MockRefIterator : RefIterator
+            {
+                private readonly IEnumerator<ReferenceData> enumerator;
+
+                public MockRefIterator(MockRefdbBackend parent)
+                {
+                    this.enumerator = parent.Refs.Values.GetEnumerator();
+                }
+
+                public override ReferenceData GetNext()
+                {
+                    if (this.enumerator.MoveNext())
+                    {
+                        return this.enumerator.Current;
+                    }
+
+                    return null;
+                }
+            }
+        }
+    }
+}

--- a/LibGit2Sharp.Tests/RefdbBackendFixture.cs
+++ b/LibGit2Sharp.Tests/RefdbBackendFixture.cs
@@ -122,7 +122,7 @@ namespace LibGit2Sharp.Tests
         public void CanIterateRefdbBackendWithGlob()
         {
             string path = SandboxStandardTestRepo();
-            using (Repository repo = new Repository(path))
+            using (var repo = new Repository(path))
             {
                 var backend = new MockRefdbBackend(repo);
                 repo.Refs.SetBackend(backend);
@@ -147,7 +147,7 @@ namespace LibGit2Sharp.Tests
                 backend.Refs["refs/tags/test"] = new RefdbBackend.ReferenceData("refs/tags/test", new ObjectId("be3563ae3f795b2b4353bcce3a527ad0a4f7f644"));
                 const string newName = "refs/tags/test/deep";
 
-                Reference renamed = repo.Refs.Rename("refs/tags/test", newName);
+                var renamed = repo.Refs.Rename("refs/tags/test", newName);
                 Assert.NotNull(renamed);
                 Assert.Equal(newName, renamed.CanonicalName);
             }
@@ -160,6 +160,11 @@ namespace LibGit2Sharp.Tests
             }
 
             public SortedDictionary<string, ReferenceData> Refs { get; } = new SortedDictionary<string, ReferenceData>();
+
+            protected override SupportedOperations OperationsSupported
+            {
+                get { return SupportedOperations.Minimum | SupportedOperations.LockUnlock; }
+            }
 
             public override bool Exists(string refName)
             {
@@ -235,6 +240,16 @@ namespace LibGit2Sharp.Tests
                 this.Refs.Remove(oldName);
                 this.Refs[newName] = newRef;
                 return newRef;
+            }
+
+            public override object Lock(string refName)
+            {
+                return base.Lock(refName);
+            }
+
+            public override void Unlock(object payload, ReferenceData reference, Signature sig, string message, bool success, bool updateReflog)
+            {
+                base.Unlock(payload, reference, sig, message, success, updateReflog);
             }
         }
     }

--- a/LibGit2Sharp.Tests/RefdbBackendFixture.cs
+++ b/LibGit2Sharp.Tests/RefdbBackendFixture.cs
@@ -161,11 +161,6 @@ namespace LibGit2Sharp.Tests
 
             public SortedDictionary<string, ReferenceData> Refs { get; } = new SortedDictionary<string, ReferenceData>();
 
-            protected override SupportedOperations OperationsSupported
-            {
-                get { return SupportedOperations.Minimum | SupportedOperations.LockUnlock; }
-            }
-
             public override bool Exists(string refName)
             {
                 return Refs.ContainsKey(refName);
@@ -240,16 +235,6 @@ namespace LibGit2Sharp.Tests
                 this.Refs.Remove(oldName);
                 this.Refs[newName] = newRef;
                 return newRef;
-            }
-
-            public override object Lock(string refName)
-            {
-                return base.Lock(refName);
-            }
-
-            public override void Unlock(object payload, ReferenceData reference, Signature sig, string message, bool success, bool updateReflog)
-            {
-                base.Unlock(payload, reference, sig, message, success, updateReflog);
             }
         }
     }

--- a/LibGit2Sharp/Core/GitRefdbBackend.cs
+++ b/LibGit2Sharp/Core/GitRefdbBackend.cs
@@ -56,7 +56,7 @@ namespace LibGit2Sharp.Core
         public write_callback Write;
         public rename_callback Rename;
         public del_callback Del;
-        public IntPtr Compress;
+        public compress_callback Compress;
         public has_log_callback HasLog;
         public ensure_log_callback EnsureLog;
         public free_callback Free;
@@ -64,8 +64,8 @@ namespace LibGit2Sharp.Core
         public reflog_write_callback ReflogWrite;
         public reflog_rename_callback ReflogRename;
         public reflog_delete_callback ReflogDelete;
-        public IntPtr Lock;
-        public IntPtr Unlock;
+        public lock_callback Lock;
+        public unlock_callback Unlock;
 
         /* The libgit2 structure definition ends here. Subsequent fields are for libgit2sharp bookkeeping. */
 
@@ -121,6 +121,9 @@ namespace LibGit2Sharp.Core
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))] string oldTarget);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate int compress_callback(IntPtr backend);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int has_log_callback(
             IntPtr backend,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))] string refName);
@@ -154,5 +157,21 @@ namespace LibGit2Sharp.Core
         public delegate int reflog_delete_callback(
             IntPtr backend,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))] string name);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate int lock_callback(
+            out IntPtr payloadOut,
+            IntPtr backend,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))] string refName);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate int unlock_callback(
+            IntPtr backend,
+            IntPtr payload,
+            [MarshalAs(UnmanagedType.Bool)] bool success,
+            [MarshalAs(UnmanagedType.Bool)] bool updateRefLog,
+            git_reference* reference,
+            git_signature* who,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))] string message);
     }
 }

--- a/LibGit2Sharp/Core/GitRefdbBackend.cs
+++ b/LibGit2Sharp/Core/GitRefdbBackend.cs
@@ -100,7 +100,7 @@ namespace LibGit2Sharp.Core
             [MarshalAs(UnmanagedType.Bool)] bool force,
             git_signature* who,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))] string message,
-            ref git_oid oid,
+            ref GitOid oid,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))] string oldTarget);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -117,7 +117,7 @@ namespace LibGit2Sharp.Core
         public delegate int del_callback(
             IntPtr backend,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))] string refName,
-            ref git_oid oldId,
+            ref GitOid oldId,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))] string oldTarget);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]

--- a/LibGit2Sharp/Core/GitRefdbBackend.cs
+++ b/LibGit2Sharp/Core/GitRefdbBackend.cs
@@ -105,7 +105,7 @@ namespace LibGit2Sharp.Core
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int rename_callback(
-            git_reference* reference,
+            out IntPtr reference,
             IntPtr backend,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))] string oldName,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))] string newName,

--- a/LibGit2Sharp/Core/GitRefdbBackend.cs
+++ b/LibGit2Sharp/Core/GitRefdbBackend.cs
@@ -8,23 +8,36 @@ namespace LibGit2Sharp.Core
     [StructLayout(LayoutKind.Sequential)]
     internal unsafe struct GitRefdbIterator
     {
+        static GitRefdbIterator()
+        {
+            GCHandleOffset = Marshal.OffsetOf<GitRefdbIterator>(nameof(GCHandle)).ToInt32();
+        }
+
         public IntPtr Refdb;
         public next_callback Next;
         public next_name_callback NextName;
         public free_callback Free;
 
+        /* The libgit2 structure definition ends here. Subsequent fields are for libgit2sharp bookkeeping. */
+
+        public IntPtr GCHandle;
+
+        /* The following static fields are not part of the structure definition. */
+
+        public static int GCHandleOffset;
+
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int next_callback(
-            out git_reference* referencePtr,
+            out IntPtr referencePtr,
             IntPtr iterator);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int next_name_callback(
-             out IntPtr refNamePtr,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))] out string refName,
             IntPtr iterator);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        public delegate int free_callback(
+        public delegate void free_callback(
             IntPtr iterator);
     }
 
@@ -54,11 +67,19 @@ namespace LibGit2Sharp.Core
         public IntPtr Lock;
         public IntPtr Unlock;
 
+        /* The libgit2 structure definition ends here. Subsequent fields are for libgit2sharp bookkeeping. */
+
+        public IntPtr GCHandle;
+
+        /* The following static fields are not part of the structure definition. */
+
+        public static int GCHandleOffset;
+
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int exists_callback(
-            ref IntPtr exists,
+            [MarshalAs(UnmanagedType.Bool)] ref bool exists,
             IntPtr backend,
-            IntPtr refNamePtr);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string refNamePtr);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int lookup_callback(
@@ -133,13 +154,5 @@ namespace LibGit2Sharp.Core
         public delegate int reflog_delete_callback(
             IntPtr backend,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name);
-
-        /* The libgit2 structure definition ends here. Subsequent fields are for libgit2sharp bookkeeping. */
-
-        public IntPtr GCHandle;
-
-        /* The following static fields are not part of the structure definition. */
-
-        public static int GCHandleOffset;
     }
 }

--- a/LibGit2Sharp/Core/GitRefdbBackend.cs
+++ b/LibGit2Sharp/Core/GitRefdbBackend.cs
@@ -33,7 +33,7 @@ namespace LibGit2Sharp.Core
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int next_name_callback(
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))] out string refName,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] out string refName,
             IntPtr iterator);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -46,7 +46,7 @@ namespace LibGit2Sharp.Core
     {
         static GitRefdbBackend()
         {
-            GCHandleOffset = Marshal.OffsetOf<GitOdbBackend>(nameof(GCHandle)).ToInt32();
+            GCHandleOffset = Marshal.OffsetOf<GitRefdbBackend>(nameof(GCHandle)).ToInt32();
         }
 
         public uint Version;
@@ -79,19 +79,19 @@ namespace LibGit2Sharp.Core
         public delegate int exists_callback(
             [MarshalAs(UnmanagedType.Bool)] ref bool exists,
             IntPtr backend,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string refNamePtr);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))] string refNamePtr);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int lookup_callback(
             out IntPtr referencePtr,
             IntPtr backend,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string refName);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))] string refName);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int iterator_callback(
             out IntPtr iteratorPtr,
             IntPtr backend,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string glob);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))] string glob);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int write_callback(
@@ -99,36 +99,36 @@ namespace LibGit2Sharp.Core
             git_reference* reference,
             [MarshalAs(UnmanagedType.Bool)] bool force,
             git_signature* who,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string message,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))] string message,
             ref git_oid oid,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string oldTarget);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))] string oldTarget);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int rename_callback(
             git_reference* reference,
             IntPtr backend,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string oldName,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string newName,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))] string oldName,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))] string newName,
             [MarshalAs(UnmanagedType.Bool)] bool force,
             git_signature* who,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string message);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))] string message);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int del_callback(
             IntPtr backend,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string refName,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))] string refName,
             ref git_oid oldId,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string oldTarget);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))] string oldTarget);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int has_log_callback(
             IntPtr backend,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string refName);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))] string refName);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int ensure_log_callback(
             IntPtr backend,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string refName);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))] string refName);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate void free_callback(IntPtr backend);
@@ -137,7 +137,7 @@ namespace LibGit2Sharp.Core
         public delegate int reflog_read_callback(
             out git_reflog* reflog,
             IntPtr backend,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))] string name);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int reflog_write_callback(
@@ -147,12 +147,12 @@ namespace LibGit2Sharp.Core
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int reflog_rename_callback(
             IntPtr backend,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string oldName,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string newName);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))] string oldName,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))] string newName);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int reflog_delete_callback(
             IntPtr backend,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))] string name);
     }
 }

--- a/LibGit2Sharp/Core/GitRefdbBackend.cs
+++ b/LibGit2Sharp/Core/GitRefdbBackend.cs
@@ -100,7 +100,7 @@ namespace LibGit2Sharp.Core
             [MarshalAs(UnmanagedType.Bool)] bool force,
             git_signature* who,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))] string message,
-            ref GitOid oid,
+            IntPtr oid,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))] string oldTarget);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]

--- a/LibGit2Sharp/Core/GitRefdbBackend.cs
+++ b/LibGit2Sharp/Core/GitRefdbBackend.cs
@@ -117,7 +117,7 @@ namespace LibGit2Sharp.Core
         public delegate int del_callback(
             IntPtr backend,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))] string refName,
-            ref GitOid oldId,
+            IntPtr oldId,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))] string oldTarget);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]

--- a/LibGit2Sharp/Core/GitRefdbBackend.cs
+++ b/LibGit2Sharp/Core/GitRefdbBackend.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace LibGit2Sharp.Core
+{
+    [StructLayout(LayoutKind.Sequential)]
+    internal unsafe struct GitRefdbIterator
+    {
+        public IntPtr Refdb;
+        public next_callback Next;
+        public next_name_callback NextName;
+        public free_callback Free;
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate int next_callback(
+            out git_reference* referencePtr,
+            IntPtr iterator);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate int next_name_callback(
+             out IntPtr refNamePtr,
+            IntPtr iterator);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate int free_callback(
+            IntPtr iterator);
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal unsafe struct GitRefdbBackend
+    {
+        static GitRefdbBackend()
+        {
+            GCHandleOffset = Marshal.OffsetOf<GitOdbBackend>(nameof(GCHandle)).ToInt32();
+        }
+
+        public uint Version;
+        public exists_callback Exists;
+        public lookup_callback Lookup;
+        public iterator_callback Iterator;
+        public write_callback Write;
+        public rename_callback Rename;
+        public del_callback Del;
+        public IntPtr Compress;
+        public has_log_callback HasLog;
+        public ensure_log_callback EnsureLog;
+        public free_callback Free;
+        public reflog_read_callback ReflogRead;
+        public reflog_write_callback ReflogWrite;
+        public reflog_rename_callback ReflogRename;
+        public reflog_delete_callback ReflogDelete;
+        public IntPtr Lock;
+        public IntPtr Unlock;
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate int exists_callback(
+            ref IntPtr exists,
+            IntPtr backend,
+            IntPtr refNamePtr);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate int lookup_callback(
+            out IntPtr referencePtr,
+            IntPtr backend,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string refName);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate int iterator_callback(
+            out IntPtr iteratorPtr,
+            IntPtr backend,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string glob);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate int write_callback(
+            IntPtr backend,
+            git_reference* reference,
+            [MarshalAs(UnmanagedType.Bool)] bool force,
+            git_signature* who,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string message,
+            ref git_oid oid,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string oldTarget);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate int rename_callback(
+            git_reference* reference,
+            IntPtr backend,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string oldName,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string newName,
+            [MarshalAs(UnmanagedType.Bool)] bool force,
+            git_signature* who,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string message);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate int del_callback(
+            IntPtr backend,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string refName,
+            ref git_oid oldId,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string oldTarget);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate int has_log_callback(
+            IntPtr backend,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string refName);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate int ensure_log_callback(
+            IntPtr backend,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string refName);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate void free_callback(IntPtr backend);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate int reflog_read_callback(
+            out git_reflog* reflog,
+            IntPtr backend,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate int reflog_write_callback(
+            IntPtr backend,
+            git_reflog* reflog);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate int reflog_rename_callback(
+            IntPtr backend,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string oldName,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string newName);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate int reflog_delete_callback(
+            IntPtr backend,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name);
+
+        /* The libgit2 structure definition ends here. Subsequent fields are for libgit2sharp bookkeeping. */
+
+        public IntPtr GCHandle;
+
+        /* The following static fields are not part of the structure definition. */
+
+        public static int GCHandleOffset;
+    }
+}

--- a/LibGit2Sharp/Core/Handles/Objects.cs
+++ b/LibGit2Sharp/Core/Handles/Objects.cs
@@ -441,6 +441,27 @@ namespace LibGit2Sharp.Core.Handles
         }
     }
 
+    internal unsafe class ReferenceDatabaseHandle : Libgit2Object
+    {
+        public ReferenceDatabaseHandle(void* handle, bool owned) : base(handle, owned)
+        {
+        }
+
+        public ReferenceDatabaseHandle(IntPtr ptr, bool owned) : base(ptr, owned)
+        {
+        }
+
+        public override void Free()
+        {
+            NativeMethods.git_refdb_free((git_refdb*)ptr);
+        }
+
+        public static implicit operator git_refdb*(ReferenceDatabaseHandle handle)
+        {
+            return (git_refdb*)handle.Handle;
+        }
+    }
+
     internal unsafe class RevWalkerHandle : Libgit2Object
     {
         internal RevWalkerHandle(git_revwalk *ptr, bool owned)

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -2100,6 +2100,35 @@ namespace LibGit2Sharp.Core
         internal static extern unsafe int git_worktree_prune(
             git_worktree* worktree,
             git_worktree_prune_options options);
+
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern unsafe int git_repository_refdb(
+            out git_refdb* refdb,
+            git_repository* repo);
+
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern unsafe int git_refdb_new(
+            out git_refdb* refdb,
+            git_repository* repo);
+
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern unsafe int git_refdb_set_backend(
+            git_refdb* refdb,
+            IntPtr refdbBackend);
+
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern unsafe void git_refdb_free(git_refdb* refdb);
+
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern unsafe git_reference* git_reference__alloc(
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name,
+            ref GitOid oid,
+            IntPtr peel);
+
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern unsafe git_reference* git_reference__alloc_symbolic(
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string target);
     }
 }
 // ReSharper restore InconsistentNaming

--- a/LibGit2Sharp/Core/Opaques.cs
+++ b/LibGit2Sharp/Core/Opaques.cs
@@ -28,5 +28,6 @@ namespace LibGit2Sharp.Core
     internal struct git_rebase {}
     internal struct git_odb_stream {}
     internal struct git_worktree { }
+    internal struct git_refdb { };
 }
 

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 using System.Text;
 using LibGit2Sharp.Core.Handles;
 using LibGit2Sharp.Handlers;
@@ -1868,9 +1869,32 @@ namespace LibGit2Sharp.Core
             }
         }
 
-#endregion
+        #endregion
 
-#region git_reference_
+        #region git_refdb_
+
+        public static unsafe ReferenceDatabaseHandle git_repository_refdb(RepositoryHandle repo)
+        {
+            git_refdb* refdb;
+            Ensure.ZeroResult(NativeMethods.git_repository_refdb(out refdb, repo));
+            return new ReferenceDatabaseHandle(refdb, true);
+        }
+
+        public static unsafe ReferenceDatabaseHandle git_refdb_new(RepositoryHandle repo)
+        {
+            git_refdb* refdb;
+            Ensure.ZeroResult(NativeMethods.git_refdb_new(out refdb, repo));
+            return new ReferenceDatabaseHandle(refdb, true);
+        }
+
+        public static unsafe void git_refdb_set_backend(ReferenceDatabaseHandle refdb, IntPtr backend)
+        {
+            Ensure.ZeroResult(NativeMethods.git_refdb_set_backend(refdb, backend));
+        }
+
+        #endregion
+
+        #region git_reference_
 
         public static unsafe ReferenceHandle git_reference_create(
             RepositoryHandle repo,
@@ -2016,6 +2040,19 @@ namespace LibGit2Sharp.Core
         {
             int res = NativeMethods.git_reference_ensure_log(repo, refname);
             Ensure.ZeroResult(res);
+        }
+
+        public static unsafe ReferenceHandle git_reference__alloc(string name, ObjectId objectId)
+        {
+            var oid = objectId.Oid;
+            var referencePtr = NativeMethods.git_reference__alloc(name, ref oid, IntPtr.Zero);
+            return new ReferenceHandle(referencePtr, true);
+        }
+
+        public static unsafe ReferenceHandle git_reference__alloc_symbolic(string name, string target)
+        {
+            var referencePtr = NativeMethods.git_reference__alloc_symbolic(name, target);
+            return new ReferenceHandle(referencePtr, true);
         }
 
 #endregion

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -2046,13 +2046,13 @@ namespace LibGit2Sharp.Core
         {
             var oid = objectId.Oid;
             var referencePtr = NativeMethods.git_reference__alloc(name, ref oid, IntPtr.Zero);
-            return new ReferenceHandle(referencePtr, true);
+            return new ReferenceHandle(referencePtr, false);
         }
 
         public static unsafe ReferenceHandle git_reference__alloc_symbolic(string name, string target)
         {
             var referencePtr = NativeMethods.git_reference__alloc_symbolic(name, target);
-            return new ReferenceHandle(referencePtr, true);
+            return new ReferenceHandle(referencePtr, false);
         }
 
 #endregion

--- a/LibGit2Sharp/RefdbBackend.cs
+++ b/LibGit2Sharp/RefdbBackend.cs
@@ -129,7 +129,7 @@ namespace LibGit2Sharp
         /// <summary>
         /// Unlocks a single reference, given its payload object and operational details.
         /// </summary>
-        public virtual object Unlock(object payload, ReferenceData reference, Signature sig, string message, bool success, bool updateReflog)
+        public virtual void Unlock(object payload, ReferenceData reference, Signature sig, string message, bool success, bool updateReflog)
         {
             throw RefdbBackendException.NotImplemented("Unlock");
         }
@@ -282,6 +282,9 @@ namespace LibGit2Sharp
                 }
             }
 
+            /// <summary>
+            /// Allocates a native git_reference for the <see cref="ReferenceData"/> and returns a pointer.
+            /// </summary>
             internal IntPtr MarshalToPtr()
             {
                 if (IsSymbolic)
@@ -294,6 +297,9 @@ namespace LibGit2Sharp
                 }
             }
 
+            /// <summary>
+            /// Marshals a git_reference into a managed <see cref="ReferenceData"/>
+            /// </summary>
             internal static unsafe ReferenceData MarshalFromPtr(git_reference* ptr)
             {
                 var name = Proxy.git_reference_name(ptr);
@@ -328,6 +334,9 @@ namespace LibGit2Sharp
                 Code = code;
             }
 
+            /// <summary>
+            /// Git error code to return on exception.
+            /// </summary>
             internal GitErrorCode Code { get; private set; }
 
             /// <summary>
@@ -372,6 +381,9 @@ namespace LibGit2Sharp
                 return new RefdbBackendException(GitErrorCode.User, string.Format("operation '{0}' is unsupported by this refdb backend.", operation));
             }
 
+            /// <summary>
+            /// Transform an exception into an error code and message, which is logged.
+            /// </summary>
             internal static int GetCode(Exception ex)
             {
                 Proxy.git_error_set_str(GitErrorCategory.Reference, ex);
@@ -385,6 +397,9 @@ namespace LibGit2Sharp
             }
         }
 
+        /// <summary>
+        /// Wrapper to hold the state of the enumerator.
+        /// </summary>
         private class RefIterator
         {
             private readonly IEnumerator<ReferenceData> enumerator;
@@ -405,6 +420,9 @@ namespace LibGit2Sharp
             }
         }
 
+        /// <summary>
+        /// Static entrypoints that trampoline into the iterator.
+        /// </summary>
         private unsafe static class IteratorEntryPoints
         {
             public static readonly GitRefdbIterator.next_callback NextCallback = Next;
@@ -491,6 +509,9 @@ namespace LibGit2Sharp
             }
         }
 
+        /// <summary>
+        /// Static entry points that trampoline into the custom backend's implementation.
+        /// </summary>
         private unsafe static class BackendEntryPoints
         {
             public static readonly GitRefdbBackend.exists_callback ExistsCallback = Exists;

--- a/LibGit2Sharp/RefdbBackend.cs
+++ b/LibGit2Sharp/RefdbBackend.cs
@@ -1,0 +1,392 @@
+﻿using LibGit2Sharp.Core;
+using LibGit2Sharp.Core.Handles;
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace LibGit2Sharp
+{
+    public abstract class RefdbBackend
+    {
+        public class ReferenceData
+        {
+            public string RefName { get; private set; }
+            public bool IsSymbolic { get; private set; }
+            public ObjectId ObjectId { get; private set; }
+            public string SymbolicTarget { get; private set; }
+
+            public ReferenceData(string refName, ObjectId directTarget)
+            {
+                this.RefName = refName;
+                this.IsSymbolic = false;
+                this.ObjectId = directTarget;
+                this.SymbolicTarget = null;
+            }
+
+            public ReferenceData(string refName, string symbolicTarget)
+            {
+                this.RefName = refName;
+                this.IsSymbolic = true;
+                this.ObjectId = null;
+                this.SymbolicTarget = symbolicTarget;
+            }
+
+            internal IntPtr GetPtr()
+            {
+                if (IsSymbolic)
+                {
+                    return Proxy.git_reference__alloc_symbolic(RefName, SymbolicTarget).AsIntPtr();
+                }
+                else
+                {
+                    return Proxy.git_reference__alloc(RefName, ObjectId.Oid).AsIntPtr();
+                }
+            }
+        }
+
+        private IntPtr nativePointer;
+
+        protected Repository Repository { get; private set; }
+
+        protected RefdbBackend(Repository repository)
+        {
+            Ensure.ArgumentNotNull(repository, "repository");
+            this.Repository = repository;
+        }
+
+        public abstract bool Exists(string refName);
+
+        public abstract bool Lookup(string refName, out ReferenceData data);
+
+        public abstract RefIterator Iterate(string glob);
+
+        internal IntPtr RefdbBackendPointer
+        {
+            get
+            {
+                if (IntPtr.Zero == nativePointer)
+                {
+                    var nativeBackend = new GitRefdbBackend()
+                    {
+                        Version = 1,
+                        Compress = IntPtr.Zero,
+                        Lock = IntPtr.Zero,
+                        Unlock = IntPtr.Zero,
+                        Exists = BackendEntryPoints.ExistsCallback,
+                        Lookup = BackendEntryPoints.LookupCallback,
+                        Iterator = BackendEntryPoints.IteratorCallback,
+                        Write = BackendEntryPoints.WriteCallback,
+                        Rename = BackendEntryPoints.RenameCallback,
+                        Del = BackendEntryPoints.DelCallback,
+                        HasLog = BackendEntryPoints.HasLogCallback,
+                        EnsureLog = BackendEntryPoints.EnsureLogCallback,
+                        Free = BackendEntryPoints.FreeCallback,
+                        ReflogRead = BackendEntryPoints.ReflogReadCallback,
+                        ReflogWrite = BackendEntryPoints.ReflogWriteCallback,
+                        ReflogRename = BackendEntryPoints.ReflogRenameCallback,
+                        ReflogDelete = BackendEntryPoints.ReflogDeleteCallback,
+                        GCHandle = GCHandle.ToIntPtr(GCHandle.Alloc(this))
+                    };
+
+                    nativePointer = Marshal.AllocHGlobal(Marshal.SizeOf(nativeBackend));
+                    Marshal.StructureToPtr(nativeBackend, nativePointer, false);
+                }
+
+                return nativePointer;
+            }
+        }
+
+        public abstract class RefIterator
+        {
+            public abstract ReferenceData GetNext();
+        }
+
+        private unsafe static class IteratorEntryPoints
+        {
+            public static readonly GitRefdbIterator.next_callback NextCallback = Next;
+            public static readonly GitRefdbIterator.next_name_callback NextNameCallback = NextName;
+            public static readonly GitRefdbIterator.free_callback FreeCallback = Free;
+
+            public static int Next(
+                out IntPtr referencePtr,
+                IntPtr iterator)
+            {
+                referencePtr = IntPtr.Zero;
+                var backend = PtrToBackend(iterator);
+                if (backend == null)
+                {
+                    return (int)GitErrorCode.Error;
+                }
+
+                ReferenceData data;
+                try
+                {
+                    data = backend.GetNext();
+                }
+                catch (Exception ex)
+                {
+                    Proxy.git_error_set_str(GitErrorCategory.Reference, ex);
+                    return (int)GitErrorCode.Error;
+                }
+
+                if (data == null)
+                {
+                    return (int)GitErrorCode.IterOver;
+                }
+
+                referencePtr = data.GetPtr();
+                return (int)GitErrorCode.Ok;
+            }
+
+            public static int NextName(
+                out string refNamePtr,
+                IntPtr iterator)
+            {
+                refNamePtr = null;
+                var backend = PtrToBackend(iterator);
+                if (backend == null)
+                {
+                    return (int)GitErrorCode.Error;
+                }
+
+                ReferenceData data;
+                try
+                {
+                    data = backend.GetNext();
+                }
+                catch (Exception ex)
+                {
+                    Proxy.git_error_set_str(GitErrorCategory.Reference, ex);
+                    return (int)GitErrorCode.Error;
+                }
+
+                refNamePtr = data.RefName;
+                return (int)GitErrorCode.Ok;
+            }
+
+            public static void Free(IntPtr iterator)
+            {
+                Marshal.FreeHGlobal(iterator);
+            }
+
+            private static RefIterator PtrToBackend(IntPtr pointer)
+            {
+                var intPtr = Marshal.ReadIntPtr(pointer, GitRefdbBackend.GCHandleOffset);
+                var backend = GCHandle.FromIntPtr(intPtr).Target as RefIterator;
+
+                if (backend == null)
+                {
+                    Proxy.git_error_set_str(GitErrorCategory.Reference, "Cannot retrieve the managed RefIterator");
+                }
+
+                return backend;
+            }
+        }
+
+        private unsafe static class BackendEntryPoints
+        {
+            public static readonly GitRefdbBackend.exists_callback ExistsCallback = Exists;
+            public static readonly GitRefdbBackend.lookup_callback LookupCallback = Lookup;
+            public static readonly GitRefdbBackend.iterator_callback IteratorCallback = Iterator;
+            public static readonly GitRefdbBackend.write_callback WriteCallback = Write;
+            public static readonly GitRefdbBackend.rename_callback RenameCallback = Rename;
+            public static readonly GitRefdbBackend.del_callback DelCallback = Del;
+            public static readonly GitRefdbBackend.has_log_callback HasLogCallback = HasLog;
+            public static readonly GitRefdbBackend.ensure_log_callback EnsureLogCallback = EnsureLog;
+            public static readonly GitRefdbBackend.free_callback FreeCallback = Free;
+            public static readonly GitRefdbBackend.reflog_read_callback ReflogReadCallback = ReflogRead;
+            public static readonly GitRefdbBackend.reflog_write_callback ReflogWriteCallback = ReflogWrite;
+            public static readonly GitRefdbBackend.reflog_rename_callback ReflogRenameCallback = ReflogRename;
+            public static readonly GitRefdbBackend.reflog_delete_callback ReflogDeleteCallback = ReflogDelete;
+
+            public static int Exists(
+                ref bool exists,
+                IntPtr backendPtr,
+                string refName)
+            {
+                var backend = PtrToBackend(backendPtr);
+                if (backend == null)
+                {
+                    return (int)GitErrorCode.Error;
+                }
+
+                try
+                {
+                    exists = backend.Exists(refName);
+                }
+                catch (Exception ex)
+                {
+                    Proxy.git_error_set_str(GitErrorCategory.Reference, ex);
+                    return (int)GitErrorCode.Error;
+                }
+
+                return 0;
+            }
+
+            public static int Lookup(
+                out IntPtr referencePtr,
+                IntPtr backendPtr,
+                string refName)
+            {
+                referencePtr = IntPtr.Zero;
+                var backend = PtrToBackend(backendPtr);
+                if (backend == null)
+                {
+                    return (int)GitErrorCode.Error;
+                }
+
+                try
+                {
+                    ReferenceData data;
+                    if (!backend.Lookup(refName, out data))
+                    {
+                        return (int)GitErrorCode.NotFound;
+                    }
+
+                    referencePtr = data.GetPtr();
+                }
+                catch (Exception ex)
+                {
+                    Proxy.git_error_set_str(GitErrorCategory.Reference, ex);
+                    return (int)GitErrorCode.Error;
+                }
+
+                return 0;
+            }
+
+            public static int Iterator(
+                out IntPtr iteratorPtr,
+                IntPtr backendPtr,
+                string glob)
+            {
+                iteratorPtr = IntPtr.Zero;
+                var backend = PtrToBackend(backendPtr);
+                if (backend == null)
+                {
+                    return (int)GitErrorCode.Error;
+                }
+
+                RefIterator iterator;
+                try
+                {
+                    iterator = backend.Iterate(glob);
+                }
+                catch (Exception ex)
+                {
+                    Proxy.git_error_set_str(GitErrorCategory.Reference, ex);
+                    return (int)GitErrorCode.Error;
+                }
+
+                var nativeIterator = new GitRefdbIterator()
+                {
+                    Refdb = backendPtr,
+                    Next = IteratorEntryPoints.Next,
+                    NextName = IteratorEntryPoints.NextName,
+                    Free = IteratorEntryPoints.Free,
+                    GCHandle = GCHandle.ToIntPtr(GCHandle.Alloc(iterator))
+                };
+
+                iteratorPtr = Marshal.AllocHGlobal(Marshal.SizeOf(nativeIterator));
+                Marshal.StructureToPtr(nativeIterator, iteratorPtr, false);
+                return (int)GitErrorCode.Ok;
+            }
+
+            public static int Write(
+                IntPtr backendPtr,
+                git_reference* reference,
+                bool force,
+                git_signature* who,
+                string message,
+                ref git_oid oid,
+                string oldTarget)
+            {
+                return (int)GitErrorCode.Error;
+            }
+
+            public static int Rename(
+                git_reference* reference,
+                IntPtr backendPtr,
+                string oldName,
+                string newName,
+                bool force,
+                git_signature* who,
+                string message)
+            {
+                return (int)GitErrorCode.Error;
+            }
+
+            public static int Del(
+                IntPtr backendPtr,
+                string refName,
+                ref git_oid oldId,
+                string oldTarget)
+            {
+                return (int)GitErrorCode.Error;
+            }
+
+            public static int HasLog(
+                IntPtr backend,
+                string refName)
+            {
+                return (int)GitErrorCode.Error;
+            }
+
+            public static int EnsureLog(
+                IntPtr backend,
+                string refName)
+            {
+                return (int)GitErrorCode.Error;
+            }
+
+            public static void Free(IntPtr backend)
+            {
+                Marshal.FreeHGlobal(backend);
+            }
+
+            public static int ReflogRead(
+                out git_reflog* reflog,
+                IntPtr backend,
+                string name)
+            {
+                reflog = null;
+                return (int)GitErrorCode.Error;
+            }
+
+            public static int ReflogWrite(
+                IntPtr backend,
+                git_reflog* reflog)
+            {
+                return (int)GitErrorCode.Error;
+            }
+
+            public static int ReflogRename(
+                IntPtr backend,
+                string oldName,
+                string newName)
+            {
+                return (int)GitErrorCode.Error;
+            }
+
+            public static int ReflogDelete(
+                IntPtr backend,
+                string name)
+            {
+                return (int)GitErrorCode.Error;
+            }
+
+            private static RefdbBackend PtrToBackend(IntPtr pointer)
+            {
+                var intPtr = Marshal.ReadIntPtr(pointer, GitRefdbBackend.GCHandleOffset);
+                var backend = GCHandle.FromIntPtr(intPtr).Target as RefdbBackend;
+
+                if (backend == null)
+                {
+                    Proxy.git_error_set_str(GitErrorCategory.Reference, "Cannot retrieve the managed RefdbBackend");
+                }
+
+                return backend;
+            }
+        }
+    }
+}

--- a/LibGit2Sharp/RefdbBackend.cs
+++ b/LibGit2Sharp/RefdbBackend.cs
@@ -30,6 +30,8 @@ namespace LibGit2Sharp
 
         public abstract void Delete(ReferenceData existingRef);
 
+        public abstract ReferenceData Rename(string oldName, string newName, bool force, Signature signature, string message);
+
         internal IntPtr RefdbBackendPointer
         {
             get
@@ -447,7 +449,7 @@ namespace LibGit2Sharp
             }
 
             public static int Rename(
-                git_reference* reference,
+                out IntPtr reference,
                 IntPtr backendPtr,
                 string oldName,
                 string newName,
@@ -455,13 +457,27 @@ namespace LibGit2Sharp
                 git_signature* who,
                 string message)
             {
+                reference = IntPtr.Zero;
                 var backend = PtrToBackend(backendPtr);
                 if (backend == null)
                 {
                     return (int)GitErrorCode.Error;
                 }
 
-                return (int)GitErrorCode.Error;
+                var signature = new Signature(who);
+
+                ReferenceData newRef;
+                try
+                {
+                    newRef = backend.Rename(oldName, newName, force, signature, message);
+                }
+                catch (Exception ex)
+                {
+                    return RefdbBackendException.GetCode(ex);
+                }
+
+                reference = newRef.MarshalToPtr();
+                return (int)GitErrorCode.Ok;
             }
 
             public static int Del(

--- a/LibGit2Sharp/RefdbBackend.cs
+++ b/LibGit2Sharp/RefdbBackend.cs
@@ -97,6 +97,18 @@ namespace LibGit2Sharp
             }
         }
 
+        internal void Free()
+        {
+            if (IntPtr.Zero == nativePointer)
+            {
+                return;
+            }
+
+            GCHandle.FromIntPtr(Marshal.ReadIntPtr(nativePointer, GitRefdbBackend.GCHandleOffset)).Free();
+            Marshal.FreeHGlobal(nativePointer);
+            nativePointer = IntPtr.Zero;
+        }
+
         public abstract class RefIterator
         {
             public abstract ReferenceData GetNext();
@@ -341,7 +353,7 @@ namespace LibGit2Sharp
 
             public static void Free(IntPtr backend)
             {
-                Marshal.FreeHGlobal(backend);
+                PtrToBackend(backend).Free();
             }
 
             public static int ReflogRead(

--- a/LibGit2Sharp/RefdbBackend.cs
+++ b/LibGit2Sharp/RefdbBackend.cs
@@ -9,42 +9,6 @@ namespace LibGit2Sharp
 {
     public abstract class RefdbBackend
     {
-        public class ReferenceData
-        {
-            public string RefName { get; private set; }
-            public bool IsSymbolic { get; private set; }
-            public ObjectId ObjectId { get; private set; }
-            public string SymbolicTarget { get; private set; }
-
-            public ReferenceData(string refName, ObjectId directTarget)
-            {
-                this.RefName = refName;
-                this.IsSymbolic = false;
-                this.ObjectId = directTarget;
-                this.SymbolicTarget = null;
-            }
-
-            public ReferenceData(string refName, string symbolicTarget)
-            {
-                this.RefName = refName;
-                this.IsSymbolic = true;
-                this.ObjectId = null;
-                this.SymbolicTarget = symbolicTarget;
-            }
-
-            internal IntPtr GetPtr()
-            {
-                if (IsSymbolic)
-                {
-                    return Proxy.git_reference__alloc_symbolic(RefName, SymbolicTarget).AsIntPtr();
-                }
-                else
-                {
-                    return Proxy.git_reference__alloc(RefName, ObjectId.Oid).AsIntPtr();
-                }
-            }
-        }
-
         private IntPtr nativePointer;
 
         protected Repository Repository { get; private set; }
@@ -107,6 +71,42 @@ namespace LibGit2Sharp
             GCHandle.FromIntPtr(Marshal.ReadIntPtr(nativePointer, GitRefdbBackend.GCHandleOffset)).Free();
             Marshal.FreeHGlobal(nativePointer);
             nativePointer = IntPtr.Zero;
+        }
+
+        public class ReferenceData
+        {
+            public string RefName { get; private set; }
+            public bool IsSymbolic { get; private set; }
+            public ObjectId ObjectId { get; private set; }
+            public string SymbolicTarget { get; private set; }
+
+            public ReferenceData(string refName, ObjectId directTarget)
+            {
+                this.RefName = refName;
+                this.IsSymbolic = false;
+                this.ObjectId = directTarget;
+                this.SymbolicTarget = null;
+            }
+
+            public ReferenceData(string refName, string symbolicTarget)
+            {
+                this.RefName = refName;
+                this.IsSymbolic = true;
+                this.ObjectId = null;
+                this.SymbolicTarget = symbolicTarget;
+            }
+
+            internal IntPtr GetPtr()
+            {
+                if (IsSymbolic)
+                {
+                    return Proxy.git_reference__alloc_symbolic(RefName, SymbolicTarget).AsIntPtr();
+                }
+                else
+                {
+                    return Proxy.git_reference__alloc(RefName, ObjectId.Oid).AsIntPtr();
+                }
+            }
         }
 
         public abstract class RefIterator

--- a/LibGit2Sharp/RefdbBackend.cs
+++ b/LibGit2Sharp/RefdbBackend.cs
@@ -233,18 +233,24 @@ namespace LibGit2Sharp
                     return (int)GitErrorCode.Error;
                 }
 
+                if (data == null)
+                {
+                    return (int)GitErrorCode.IterOver;
+                }
+
                 refNamePtr = data.RefName;
                 return (int)GitErrorCode.Ok;
             }
 
             public static void Free(IntPtr iterator)
             {
+                GCHandle.FromIntPtr(Marshal.ReadIntPtr(iterator, GitRefdbIterator.GCHandleOffset)).Free();
                 Marshal.FreeHGlobal(iterator);
             }
 
             private static RefIterator PtrToBackend(IntPtr pointer)
             {
-                var intPtr = Marshal.ReadIntPtr(pointer, GitRefdbBackend.GCHandleOffset);
+                var intPtr = Marshal.ReadIntPtr(pointer, GitRefdbIterator.GCHandleOffset);
                 var backend = GCHandle.FromIntPtr(intPtr).Target as RefIterator;
 
                 if (backend == null)

--- a/LibGit2Sharp/RefdbBackend.cs
+++ b/LibGit2Sharp/RefdbBackend.cs
@@ -99,6 +99,40 @@ namespace LibGit2Sharp
                 this.SymbolicTarget = symbolicTarget;
             }
 
+            public override bool Equals(object obj)
+            {
+                var other = obj as ReferenceData;
+                if (other == null)
+                {
+                    return false;
+                }
+
+                return other.RefName == this.RefName
+                    && other.IsSymbolic == this.IsSymbolic
+                    && other.ObjectId == this.ObjectId
+                    && other.SymbolicTarget == this.SymbolicTarget;
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    var accumulator = this.RefName.GetHashCode();
+                    accumulator = accumulator * 17 + this.IsSymbolic.GetHashCode();
+                    if (this.ObjectId != null)
+                    {
+                        accumulator = accumulator * 17 + this.ObjectId.GetHashCode();
+                    }
+
+                    if (this.SymbolicTarget != null)
+                    {
+                        accumulator = accumulator * 17 + this.SymbolicTarget.GetHashCode();
+                    }
+
+                    return accumulator;
+                }
+            }
+
             internal IntPtr MarshalToPtr()
             {
                 if (IsSymbolic)

--- a/LibGit2Sharp/RefdbBackend.cs
+++ b/LibGit2Sharp/RefdbBackend.cs
@@ -310,7 +310,7 @@ namespace LibGit2Sharp
                 bool force,
                 git_signature* who,
                 string message,
-                ref git_oid oid,
+                ref GitOid oid,
                 string oldTarget)
             {
                 return (int)GitErrorCode.Error;
@@ -331,7 +331,7 @@ namespace LibGit2Sharp
             public static int Del(
                 IntPtr backendPtr,
                 string refName,
-                ref git_oid oldId,
+                ref GitOid oldId,
                 string oldTarget)
             {
                 return (int)GitErrorCode.Error;

--- a/LibGit2Sharp/ReferenceCollection.cs
+++ b/LibGit2Sharp/ReferenceCollection.cs
@@ -16,6 +16,7 @@ namespace LibGit2Sharp
     public class ReferenceCollection : IEnumerable<Reference>
     {
         internal readonly Repository repo;
+        internal readonly ReferenceDatabaseHandle refdbHandle;
 
         /// <summary>
         /// Needed for mocking purposes.
@@ -30,6 +31,8 @@ namespace LibGit2Sharp
         internal ReferenceCollection(Repository repo)
         {
             this.repo = repo;
+            refdbHandle = Proxy.git_repository_refdb(repo.Handle);
+            repo.RegisterForCleanup(refdbHandle);
         }
 
         /// <summary>
@@ -840,6 +843,14 @@ namespace LibGit2Sharp
             var historyRewriter = new HistoryRewriter(repo, commitsToRewrite, options);
 
             historyRewriter.Execute();
+        }
+
+        public virtual void SetBackend(RefdbBackend backend)
+        {
+            Ensure.ArgumentNotNull(backend, "backend");
+
+            // Refdb takes ownership of the backend pointer, so don't free it!
+            Proxy.git_refdb_set_backend(refdbHandle, backend.RefdbBackendPointer);
         }
 
         /// <summary>

--- a/LibGit2Sharp/ReferenceCollection.cs
+++ b/LibGit2Sharp/ReferenceCollection.cs
@@ -845,6 +845,10 @@ namespace LibGit2Sharp
             historyRewriter.Execute();
         }
 
+        /// <summary>
+        /// Replaces the Refdb backend with a custom backend. 
+        /// </summary>
+        /// <param name="backend">Custom backend to use.</param>
         public virtual void SetBackend(RefdbBackend backend)
         {
             Ensure.ArgumentNotNull(backend, "backend");


### PR DESCRIPTION
This is a rewrite of zoxiv's refdb backend PR #1482 ([their code here](https://github.com/Zoxive/libgit2sharp/commit/8efb8e9e0cf4ab0ac154739c19edc9f62fb1eb06)), since that targeted an ancient libgit2 with substantial API changes since then.

# Changes due to libgit2:
- Iterators had to be completely reworked, since `foreach` and `foreach_glob` were replaced with a new `iterator` callback in libgit2. Replaced them with a method that returns `IEnumerable<ReferenceData>`.
- libgit2 now "requires" reflog support for backends. I've created stubs for these callbacks, since those APIs are cumbersome, they're not called unless reflog tracking is opted into, and most use cases for custom RefDbs don't require reflog support.

# Other changes:
- Added rename support.
- Used `RefdbBackendExceptions` to signal errors, which simplifies the glue and lets native libgit2 error codes be returned.