### PR TITLE
NativeMethods.ResolveDll: Avoid exceptions

### DIFF
--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -156,12 +156,17 @@ namespace LibGit2Sharp.Core
                     // The <rid> ends with the processor architecture. e.g. fedora-x64.
                     string assemblyDirectory = Path.GetDirectoryName(typeof(NativeMethods).Assembly.Location);
                     string processorArchitecture = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
-                    foreach (var runtimeFolder in Directory.GetDirectories(Path.Combine(assemblyDirectory, "runtimes"), $"*-{processorArchitecture}"))
+                    string runtimesDirectory = Path.Combine(assemblyDirectory, "runtimes");
+
+                    if (Directory.Exists(runtimesDirectory))
                     {
-                        string libPath = Path.Combine(runtimeFolder, "native", $"lib{libraryName}.so");
-                        if (TryLoadLibrary(libPath, out handle))
+                        foreach (var runtimeFolder in Directory.GetDirectories(runtimesDirectory, $"*-{processorArchitecture}"))
                         {
-                            return handle;
+                            string libPath = Path.Combine(runtimeFolder, "native", $"lib{libraryName}.so");
+                            if (TryLoadLibrary(libPath, out handle))
+                            {
+                                return handle;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
On .NET Core 3.0, LibGit2Sharp registers a per-assembly resolver using via `NativeLibrary.SetDllImportResolver`.

The [per-assembly resolver is the first attempt to resolve native library loads initiated by an assembly](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.nativelibrary.setdllimportresolver?view=netcore-3.0#remarks) and takes precedence over other mechanisms, such as `AssemblyLoadContext`.

The current implementation throws an exception if the `{assemblyDirectory}/runtimes` directory does not exist. In that case, the native load mechanism aborts, and `AssemblyLoadContext` never gets a chance to locate the native library.

This PR adds a `Directory.Exists` check to avoid that exception. `ResolveDll` will return `IntPtr.Zero`, and the `AssemblyLoadContext` is invoked next.