### PR TITLE
Return all changes to a file when using Repository.Commits.QueryBy(path)

### DIFF
--- a/LibGit2Sharp/Core/FileHistory.cs
+++ b/LibGit2Sharp/Core/FileHistory.cs
@@ -120,13 +120,8 @@ namespace LibGit2Sharp.Core
                 var currentPath = map.Keys.Count > 0 ? map[currentCommit] : path;
                 var currentTreeEntry = currentCommit.Tree[currentPath];
 
-                if (currentTreeEntry == null)
-                {
-                    yield break;
-                }
-
                 var parentCount = currentCommit.Parents.Count();
-                if (parentCount == 0)
+                if (parentCount == 0 && currentTreeEntry != null)
                 {
                     yield return new LogEntry { Path = currentPath, Commit = currentCommit };
                 }
@@ -134,20 +129,18 @@ namespace LibGit2Sharp.Core
                 {
                     DetermineParentPaths(repo, currentCommit, currentPath, map);
 
-                    if (parentCount != 1)
-                    {
-                        continue;
-                    }
+                    foreach(var parentCommit in currentCommit.Parents)
+                    { 
+                        var parentPath = map[parentCommit];
+                        var parentTreeEntry = parentCommit.Tree[parentPath];
 
-                    var parentCommit = currentCommit.Parents.Single();
-                    var parentPath = map[parentCommit];
-                    var parentTreeEntry = parentCommit.Tree[parentPath];
-
-                    if (parentTreeEntry == null ||
-                        parentTreeEntry.Target.Id != currentTreeEntry.Target.Id ||
-                        parentPath != currentPath)
-                    {
-                        yield return new LogEntry { Path = currentPath, Commit = currentCommit };
+                        if (currentTreeEntry != null &&
+                            (parentTreeEntry == null ||
+                            parentTreeEntry.Target.Id != currentTreeEntry.Target.Id ||
+                            parentPath != currentPath))
+                        {
+                            yield return new LogEntry { Path = currentPath, Commit = currentCommit };
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Improves #963 and should fix #1752, #1401, #1591.

I think is is very much "to be discussed". There seems to be lots of discussion online around the fact that "git log --follow" has a broken history simplification and also ignores such merges as outlined in #1752. 
See e.g. https://stackoverflow.com/a/48819299, https://stackoverflow.com/questions/57457613/git-log-follow-always-ignore-merge-commit#comment101401337_57457613.

Note that some tests currently fail since QueryBy now in some cases finds _more_ than the expected number of commits. Looking forward to feedback.