### PR TITLE
Added CompareOptions argument to QueryBy method allowing to get git log

### DIFF
--- a/LibGit2Sharp/CommitLog.cs
+++ b/LibGit2Sharp/CommitLog.cs
@@ -96,13 +96,14 @@ namespace LibGit2Sharp
         /// </summary>
         /// <param name="path">The file's path.</param>
         /// <param name="filter">The options used to control which commits will be returned.</param>
+        /// <param name="compareOptions">Additional options to define comparison behavior.</param>
         /// <returns>A list of file history entries, ready to be enumerated.</returns>
-        public IEnumerable<LogEntry> QueryBy(string path, CommitFilter filter)
+        public IEnumerable<LogEntry> QueryBy(string path, CommitFilter filter, CompareOptions compareOptions = null)
         {
             Ensure.ArgumentNotNull(path, "path");
             Ensure.ArgumentNotNull(filter, "filter");
 
-            return new FileHistory(repo, path, filter);
+            return new FileHistory(repo, path, filter, compareOptions);
         }
 
         private class CommitEnumerator : IEnumerator<Commit>

--- a/LibGit2Sharp/IQueryableCommitLog.cs
+++ b/LibGit2Sharp/IQueryableCommitLog.cs
@@ -27,8 +27,9 @@ namespace LibGit2Sharp
         /// </summary>
         /// <param name="path">The file's path.</param>
         /// <param name="filter">The options used to control which commits will be returned.</param>
+        /// <param name="compareOptions">Additional options to define comparison behavior.</param>
         /// <returns>A list of file history entries, ready to be enumerated.</returns>
-        IEnumerable<LogEntry> QueryBy(string path, CommitFilter filter);
+        IEnumerable<LogEntry> QueryBy(string path, CommitFilter filter, CompareOptions compareOptions = null);
 
     }
 }


### PR DESCRIPTION
In the methods called when using QueryBy(path), there is a Diff, but we cannot specify CompareOptions for this Diff.
This pull request adds this possibility.