### PR TITLE
Improve TruncateMilliseconds test helper

### DIFF
--- a/LibGit2Sharp.Tests/TestHelpers/DateTimeOffsetExtensions.cs
+++ b/LibGit2Sharp.Tests/TestHelpers/DateTimeOffsetExtensions.cs
@@ -4,11 +4,6 @@ namespace LibGit2Sharp.Tests.TestHelpers
 {
     public static class DateTimeOffsetExtensions
     {
-        public static DateTimeOffset TruncateMilliseconds(this DateTimeOffset dto)
-        {
-            // From http://stackoverflow.com/a/1005222/335418
-
-            return dto.AddTicks( - (dto.Ticks % TimeSpan.TicksPerSecond));
-        }
+        public static DateTimeOffset TruncateMilliseconds(this DateTimeOffset dto) => new DateTimeOffset(dto.Year, dto.Month, dto.Day, dto.Hour, dto.Minute, dto.Second, dto.Offset);
     }
 }


### PR DESCRIPTION
Looking at the flaky test failures, my theory is that the previous implementation of `TruncateMilliseconds` is the source of the problem. Let's see if this helps.