### PR TITLE
Pack symbols in snupkg

### DIFF
--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -12,6 +12,8 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\libgit2sharp.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>


### PR DESCRIPTION
pdb's tucked inside a .nupkg don't get indexed by nuget.org, and as a result, customers who are debugging an application that includes this library won't be able to find symbols automagically.

I was a late holdout myself. But when I discovered that publishing snupkg allowed VS to automatically find PDBs for dll's (even without the nuget package itself present) I was sold.

Now, *technically* we could put symbols both in the nupkg and also upload an snupkg. I'm curious though whether there really is a use case for symbols remaining in the nupkg at this point.