### PR TITLE
Update macOS image on Azure Pipelines

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -17,7 +17,7 @@ jobs:
 
 - job: macOS
   pool:
-    vmImage: macOS 10.13
+    vmImage: macOS-10.15
   steps:
   - template: install-dependencies.yml
   - template: dotnet.yml


### PR DESCRIPTION
This resolves the warning we see on Azure Pipelines about the soon-to-be-removed image.

**Before**

![image](https://user-images.githubusercontent.com/3548/75688766-4fdfc380-5c5d-11ea-803c-17df904b59c0.png)

**After**

![image](https://user-images.githubusercontent.com/3548/75688784-566e3b00-5c5d-11ea-81f8-b5d05bf201d6.png)
