### PR TITLE
In case of reabese of repository with submodules, submodules are left…

### DIFF
--- a/LibGit2Sharp/Rebase.cs
+++ b/LibGit2Sharp/Rebase.cs
@@ -119,6 +119,8 @@ namespace LibGit2Sharp
                                                                                       ontoRefAnnotatedCommitHandle,
                                                                                       gitRebaseOptions))
                 {
+                    this.repository.Submodules.UpdateAll(new SubmoduleUpdateOptions());
+
                     RebaseResult rebaseResult = RebaseOperationImpl.Run(rebaseOperationHandle,
                                                                         this.repository,
                                                                         committer,

--- a/LibGit2Sharp/SubmoduleCollection.cs
+++ b/LibGit2Sharp/SubmoduleCollection.cs
@@ -70,6 +70,13 @@ namespace LibGit2Sharp
             }
         }
 
+
+        public virtual void UpdateAll(SubmoduleUpdateOptions options)
+        {
+            foreach (var sm in this)
+                Update(sm.Name, options);
+        }
+
         /// <summary>
         /// Update specified submodule.
         /// <para>


### PR DESCRIPTION
… in non updatred state and prevent rebase from continuing.

Fixed that by updating submodules after rebase was initialized.