### PR TITLE
Add support for git-merge-file

### DIFF
--- a/LibGit2Sharp.Tests/MergeFileFixture.cs
+++ b/LibGit2Sharp.Tests/MergeFileFixture.cs
@@ -1,0 +1,125 @@
+﻿using LibGit2Sharp.Tests.TestHelpers;
+using System;
+using System.IO;
+using Xunit;
+
+namespace LibGit2Sharp.Tests
+{
+    public class MergeFileFixture : BaseFixture
+    {
+        [Fact]
+        public void CanMergeZeroLengthBytes()
+        {
+            byte[] bytes = Array.Empty<byte>();
+            bool mergeable = Repository.MergeFile(bytes, bytes, bytes, out byte[] resultBytes, null);
+            Assert.True(mergeable);
+            Assert.Equal(bytes, resultBytes);
+        }
+
+        [Fact]
+        public void CanMergeIdenticalBytes()
+        {
+            byte[] bytes = new byte[] { 1 };
+            bool mergeable = Repository.MergeFile(bytes, bytes, bytes, out byte[] resultBytes, null);
+            Assert.True(mergeable);
+            Assert.Equal(bytes, resultBytes);
+        }
+
+        [Fact]
+        public void CanMergeRemovedBytes()
+        {
+            byte[] bytesRemoved = new byte[] { 1 };
+            byte[] bytes = new byte[] { 1, 2 };
+            bool mergeable = Repository.MergeFile(bytesRemoved, bytes, bytes, out byte[] resultBytes, null);
+            Assert.True(mergeable);
+            Assert.Equal(bytesRemoved, resultBytes);
+        }
+
+        [Fact]
+        public void BytesMergeConflict()
+        {
+            byte[] currentBytes = new byte[] { 1, 1 };
+            byte[] baseBytes = new byte[] { 1 };
+            byte[] otherBytes = new byte[] { 1, 2 };
+            bool mergeable = Repository.MergeFile(currentBytes, baseBytes, otherBytes, out byte[] resultBytes, null);
+            Assert.False(mergeable);
+            Assert.NotNull(resultBytes);
+        }
+
+        [Fact]
+        public void NullInputBytesHandledGracefully()
+        {
+            Assert.Throws<ArgumentNullException>(() => Repository.MergeFile(null, null, null, out byte[] resultBytes, null));
+        }
+
+        [Fact]
+        public void NullInputPathGracefully()
+        {
+            Assert.Throws<ArgumentNullException>(() => Repository.MergeFile(null, null, null, null, null));
+        }
+
+        [Fact]
+        public void EmptyStringInputPathHandledGracefully()
+        {
+            Assert.Throws<ArgumentException>(() => Repository.MergeFile("", "", "", "", null));
+        }
+
+        [Fact]
+        public void InputDoesntExistHandledGracefully()
+        {
+            Assert.Throws<FileNotFoundException>(() => Repository.MergeFile("test", "test", "test", "test", null));
+        }
+
+        [Theory]
+        [InlineData("line 1", "line 1", "line 1", false, null, null, null, MergeFileFavor.Normal, 0, MergeFileFlag.Default, true, "line 1")] // same file
+        [InlineData("line 1\nline a", "line 1", "line 1", false, null, null, null, MergeFileFavor.Normal, 0, MergeFileFlag.Default, true, "line 1\nline a")] // current changed        
+        [InlineData("line 1\nline a", "line 1", "line 1\nline b", true, "Ours", "Ancestor", "Theirs", MergeFileFavor.Normal, 0, MergeFileFlag.Default, false, "line 1\n<<<<<<< Ours\nline a\n=======\nline b\n>>>>>>> Theirs\n")] // conflict
+        [InlineData("line 1\nline a", "line 1", "line 1\nline b", true, null, null, null, MergeFileFavor.Ours, 0, MergeFileFlag.Default, true, "line 1\nline a")] // ours
+        [InlineData("line 1\nline a", "line 1", "line 1\nline b", true, null, null, null, MergeFileFavor.Theirs, 0, MergeFileFlag.Default, true, "line 1\nline b")] // theirs
+        [InlineData("line 1\nline a", "line 1", "line 1\nline b", true, null, null, null, MergeFileFavor.Union, 0, MergeFileFlag.Default, true, "line 1\nline a\nline b")] // union
+        [InlineData("line 1\nline a", "line 1", "line 1\nline b", true, "Ours", "Ancestor", "Theirs", MergeFileFavor.Normal, 3, MergeFileFlag.Default, false, "line 1\n<<< Ours\nline a\n===\nline b\n>>> Theirs\n")] // marker size        
+        public void CanMergeTextFiles(string currentText,
+                                      string baseText,
+                                      string otherText,
+                                      bool setOptions,
+                                      string currentLabel,
+                                      string baseLabel,
+                                      string otherLabel,
+                                      MergeFileFavor mergeFileFavor,
+                                      short markerSize,
+                                      MergeFileFlag mergeFileflags,
+                                      bool expectedResult,
+                                      string expectedResultText)
+        {
+
+            SelfCleaningDirectory scd = BuildSelfCleaningDirectory();
+            Directory.CreateDirectory(scd.RootedDirectoryPath);
+
+            string currentPath = Path.Combine(scd.RootedDirectoryPath, "current.txt");
+            string basePath = Path.Combine(scd.RootedDirectoryPath, "base.txt");
+            string otherPath = Path.Combine(scd.RootedDirectoryPath, "other.txt");
+            string resultPath = Path.Combine(scd.RootedDirectoryPath, "result.txt");
+
+            if (currentText != null) { File.WriteAllText(currentPath, currentText); }
+            if (baseText != null) { File.WriteAllText(basePath, baseText); }
+            if (otherText != null) { File.WriteAllText(otherPath, otherText); }
+
+            MergeFileOptions mergeFileOptions = new MergeFileOptions()
+            {
+                OurLabel = currentLabel,
+                AncestorLabel = baseLabel,
+                TheirLabel = otherLabel,
+                Favor = mergeFileFavor,
+                MarkerSize = markerSize,
+                Flags = mergeFileflags
+            };
+
+            bool result = Repository.MergeFile(currentPath, basePath, otherPath, resultPath, setOptions ? mergeFileOptions : null);
+            string resultText = null;
+            if (File.Exists(resultPath)) { resultText = File.ReadAllText(resultPath); }
+
+            Assert.Equal(expectedResult, result);
+            Assert.Equal(expectedResultText, resultText);
+        }
+    }
+}

--- a/LibGit2Sharp/Core/GitMergeFile.cs
+++ b/LibGit2Sharp/Core/GitMergeFile.cs
@@ -1,0 +1,274 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace LibGit2Sharp.Core
+{
+    /// <summary>
+    /// The file inputs to git_merge_file. Callers should populate the git_merge_file_input structure
+    /// with descriptions of the files in each side of the conflict for use in producing the merge file.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    internal unsafe struct git_merge_file_input
+    {
+        public uint version;
+
+        /// <summary>
+        /// Pointer to the contents of the file.
+        /// </summary>
+        public IntPtr ptr;
+
+        /// <summary>
+        /// Size of the contents pointed to in ptr.
+        /// </summary>
+        public int size;
+
+        /// <summary>
+        /// File name of the conflicted file, or null to not merge the path.
+        /// </summary>
+        public char* path;
+
+        /// <summary>
+        /// File mode of the conflicted file, or 0 to not merge the mode.
+        /// </summary>
+        public uint mode;
+    }
+
+    /// <summary>
+    /// Information about file-level merging
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    internal unsafe struct git_merge_file_result
+    {
+        /// <summary>
+        /// 1 if the output was automerged, 0 if the output contains conflict markers.
+        /// </summary>
+        public int automergeable;
+
+        /// <summary>
+        /// The path that the resultant merge file should use, or null if a filename conflict would occur.
+        /// </summary>
+        public char* path;
+
+        /// <summary>
+        /// The mode that the resultant merge file should use.
+        /// </summary>
+        public uint mode;
+
+        /// <summary>
+        /// The contents of the merge.
+        /// </summary>
+        public IntPtr ptr;
+
+        /// <summary>
+        /// The length of the merge contents.
+        /// </summary>
+        public int len;
+    }
+
+    /// <summary>
+    /// Options for merging a file
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    internal unsafe struct git_merge_file_options
+    {
+        public uint version;
+
+        /// <summary>
+        /// Label for the ancestor file side of the conflict which will be
+        /// prepended to labels in diff3-format merge files.
+        /// </summary>
+        public char* ancestor_label;
+
+        /// <summary>
+        /// Label for our file side of the conflict which will be prepended to labels in merge files.
+        /// </summary>
+        public char* our_label;
+
+        /// <summary>
+        /// Label for their file side of the conflict which will be prepended to labels in merge files.
+        /// </summary>
+        public char* their_label;
+
+        /// <summary>
+        /// Flags for automerging content.
+        /// </summary>
+        public MergeFileFavor favor;
+
+        /// <summary>
+        /// File merging flags.
+        /// </summary>
+        public MergeFileFlag flags;
+
+        /// <summary>
+        /// The size of conflict markers (eg, " &lt; &lt; &lt; &lt; &lt; &lt; &lt; ").
+        /// Default is 7.
+        /// </summary>
+        public ushort marker_size;
+    }
+
+    /// <summary>
+    /// Wrapper for native merge file input object to handle initialization
+    /// and freeing.
+    /// </summary>
+    internal class GitMergeFileInputWrapper : IDisposable
+    {
+        private IntPtr ptr;
+
+        /// <summary>
+        /// Initialize the wrapper with the native object and marshal it
+        /// to a pointer.
+        /// </summary>
+        /// <param name="git_merge_file_input">The native merge file input object.</param>
+        public GitMergeFileInputWrapper(git_merge_file_input git_merge_file_input)
+        {
+            ptr = Marshal.AllocHGlobal(Marshal.SizeOf(git_merge_file_input));
+            Marshal.StructureToPtr(git_merge_file_input, ptr, false);
+        }
+
+        /// <summary>
+        /// Convert the wrapper to a pointer to the native structure.
+        /// </summary>
+        /// <param name="gitMergeFileInputWrapper">The wrapper.</param>
+        public unsafe static implicit operator git_merge_file_input* (GitMergeFileInputWrapper gitMergeFileInputWrapper)
+        {
+            return (git_merge_file_input*)gitMergeFileInputWrapper.ptr;
+        }
+
+        /// <summary>
+        /// Convert the native strucure to a wrapper.
+        /// </summary>
+        /// <param name="git_merge_file_input">The native structure.</param>
+        public static implicit operator GitMergeFileInputWrapper(git_merge_file_input git_merge_file_input)
+        {
+            return new GitMergeFileInputWrapper(git_merge_file_input);
+        }
+
+        /// <summary>
+        /// Free the native structure and the associated pointer.
+        /// </summary>
+        public unsafe void Dispose()
+        {
+            if (ptr == IntPtr.Zero) { return; }
+
+            var git_merge_file_input = Marshal.PtrToStructure<git_merge_file_input>(ptr);
+
+            EncodingMarshaler.Cleanup(new IntPtr(git_merge_file_input.path));
+            git_merge_file_input.path = (char*)IntPtr.Zero;
+
+            Marshal.FreeHGlobal(git_merge_file_input.ptr);
+            git_merge_file_input.ptr = IntPtr.Zero;
+
+            Marshal.FreeHGlobal(ptr);
+            ptr = IntPtr.Zero;
+        }
+    }
+
+    /// <summary>
+    /// Wrapper for native merge file result object to handle initialization
+    /// and freeing.
+    /// </summary>
+    internal class GitMergeFileResultWrapper : IDisposable
+    {
+        private IntPtr ptr;
+
+        /// <summary>
+        /// Initialize the wrapper with the native object and marshal it
+        /// to a pointer.
+        /// </summary>
+        /// <param name="git_merge_file_result">The native merge file result object.</param>
+        public GitMergeFileResultWrapper(git_merge_file_result git_merge_file_result)
+        {
+            ptr = Marshal.AllocHGlobal(Marshal.SizeOf(git_merge_file_result));
+            Marshal.StructureToPtr(git_merge_file_result, ptr, false);
+        }
+
+        /// <summary>
+        /// Convert the wrapper to a pointer to the native structure.
+        /// </summary>
+        /// <param name="gitMergeFileResultWrapper">The wrapper.</param>
+        public static implicit operator git_merge_file_result(GitMergeFileResultWrapper gitMergeFileResultWrapper)
+        {
+            return Marshal.PtrToStructure<git_merge_file_result>(gitMergeFileResultWrapper.ptr);
+        }
+
+        /// <summary>
+        /// Convert the native strucure to a wrapper.
+        /// </summary>
+        /// <param name="git_merge_file_result">The native structure.</param>
+        public static implicit operator GitMergeFileResultWrapper(git_merge_file_result git_merge_file_result)
+        {
+            return new GitMergeFileResultWrapper(git_merge_file_result);
+        }
+
+        /// <summary>
+        /// Free the native structure and the associated pointer.
+        /// </summary>
+        public unsafe void Dispose()
+        {
+            if (ptr == IntPtr.Zero) { return; }
+
+            Proxy.git_merge_file_result_free((git_merge_file_result*)ptr);
+            ptr = IntPtr.Zero;
+        }
+    }
+
+    /// <summary>
+    /// Wrapper for native merge file options object to handle initialization
+    /// and freeing.
+    /// </summary>
+    internal class GitMergeFileOptionsWrapper : IDisposable
+    {
+        private IntPtr ptr;
+
+        /// <summary>
+        /// Initialize the wrapper with the native object and marshal it
+        /// to a pointer.
+        /// </summary>
+        /// <param name="git_merge_file_options">The native merge file options object.</param>
+        public GitMergeFileOptionsWrapper(git_merge_file_options git_merge_file_options)
+        {
+            ptr = Marshal.AllocHGlobal(Marshal.SizeOf(git_merge_file_options));
+            Marshal.StructureToPtr(git_merge_file_options, ptr, false);
+        }
+
+        /// <summary>
+        /// Convert the wrapper to a pointer to the native structure.
+        /// </summary>
+        /// <param name="gitMergeFileOptionsWrapper">The wrapper.</param>
+        public unsafe static implicit operator git_merge_file_options* (GitMergeFileOptionsWrapper gitMergeFileOptionsWrapper)
+        {
+            return (git_merge_file_options*)gitMergeFileOptionsWrapper.ptr;
+        }
+
+        /// <summary>
+        /// Convert the native strucure to a wrapper.
+        /// </summary>
+        /// <param name="git_merge_file_options">The native structure.</param>
+        public static implicit operator GitMergeFileOptionsWrapper(git_merge_file_options git_merge_file_options)
+        {
+            return new GitMergeFileOptionsWrapper(git_merge_file_options);
+        }
+
+        /// <summary>
+        /// Free the native structure and the associated pointer.
+        /// </summary>
+        public unsafe void Dispose()
+        {
+            if (ptr == IntPtr.Zero) { return; }
+
+            var git_merge_file_options = Marshal.PtrToStructure<git_merge_file_options>(ptr);
+
+            EncodingMarshaler.Cleanup(new IntPtr(git_merge_file_options.ancestor_label));
+            git_merge_file_options.ancestor_label = (char*)IntPtr.Zero;
+
+            EncodingMarshaler.Cleanup(new IntPtr(git_merge_file_options.our_label));
+            git_merge_file_options.our_label = (char*)IntPtr.Zero;
+
+            EncodingMarshaler.Cleanup(new IntPtr(git_merge_file_options.their_label));
+            git_merge_file_options.their_label = (char*)IntPtr.Zero;
+
+            Marshal.FreeHGlobal(ptr);
+            ptr = IntPtr.Zero;
+        }
+    }
+}

--- a/LibGit2Sharp/Core/GitMergeOpts.cs
+++ b/LibGit2Sharp/Core/GitMergeOpts.cs
@@ -49,7 +49,7 @@ namespace LibGit2Sharp.Core
         /// <summary>
         /// File merging flags.
         /// </summary>
-        public GitMergeFileFlag FileFlags;
+        public MergeFileFlag FileFlags;
     }
 
     /// <summary>
@@ -145,54 +145,5 @@ namespace LibGit2Sharp.Core
         /// merge base to `git-merge-resolve`.
         /// </summary>
         GIT_MERGE_NO_RECURSIVE = (1 << 3),
-    }
-
-    [Flags]
-    internal enum GitMergeFileFlag
-    {
-        /// <summary>
-        /// Defaults
-        /// </summary>
-        GIT_MERGE_FILE_DEFAULT = 0,
-
-        /// <summary>
-        /// Create standard conflicted merge files
-        /// </summary>
-        GIT_MERGE_FILE_STYLE_MERGE = (1 << 0),
-
-        /// <summary>
-        /// Create diff3-style files
-        /// </summary>
-        GIT_MERGE_FILE_STYLE_DIFF3 = (1 << 1),
-
-        /// <summary>
-        /// Condense non-alphanumeric regions for simplified diff file
-        /// </summary>
-        GIT_MERGE_FILE_SIMPLIFY_ALNUM = (1 << 2),
-
-        /// <summary>
-        /// Ignore all whitespace
-        /// </summary>
-        GIT_MERGE_FILE_IGNORE_WHITESPACE = (1 << 3),
-
-        /// <summary>
-        /// Ignore changes in amount of whitespace
-        /// </summary>
-        GIT_MERGE_FILE_IGNORE_WHITESPACE_CHANGE = (1 << 4),
-
-        /// <summary>
-        /// Ignore whitespace at end of line
-        /// </summary>
-        GIT_MERGE_FILE_IGNORE_WHITESPACE_EOL = (1 << 5),
-
-        /// <summary>
-        /// Use the "patience diff" algorithm
-        /// </summary>
-        GIT_MERGE_FILE_DIFF_PATIENCE = (1 << 6),
-
-        /// <summary>
-        /// Take extra time to find minimal diff
-        /// </summary>
-        GIT_MERGE_FILE_DIFF_MINIMAL = (1 << 7),
     }
 }

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -937,6 +937,23 @@ namespace LibGit2Sharp.Core
             [In] GitOid[] input_array);
 
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern unsafe int git_merge_file(
+            out git_merge_file_result @out,
+            [In] git_merge_file_input* ancestor,
+            [In] git_merge_file_input* ours,
+            [In] git_merge_file_input* theirs,
+            [In] git_merge_file_options* opts);
+
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern unsafe int git_merge_file_input_init(out git_merge_file_input input, uint version);
+
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern unsafe void git_merge_file_result_free(git_merge_file_result* result);
+
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern unsafe int git_merge_file_options_init(out git_merge_file_options opts, uint version);
+
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_annotated_commit_from_ref(
             out git_annotated_commit* annotatedCommit,
             git_repository* repo,

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -1247,6 +1247,45 @@ namespace LibGit2Sharp.Core
             return ret;
         }
 
+        public static unsafe GitMergeFileResultWrapper git_merge_file(GitMergeFileInputWrapper ancestor, GitMergeFileInputWrapper ours, GitMergeFileInputWrapper theirs, GitMergeFileOptionsWrapper options)
+        {
+            try
+            {
+                int result = NativeMethods.git_merge_file(out git_merge_file_result git_merge_file_result, ancestor, ours, theirs, options);
+                Ensure.Int32Result(result);
+
+                return new GitMergeFileResultWrapper(git_merge_file_result);
+            }
+            finally
+            {
+                ancestor?.Dispose();
+                ours?.Dispose();
+                theirs?.Dispose();
+                options?.Dispose();
+            }
+        }
+
+        public unsafe static git_merge_file_input git_merge_file_input_init()
+        {
+            const uint version = 1;
+            int result = NativeMethods.git_merge_file_input_init(out git_merge_file_input git_merge_file_input, version);
+            Ensure.Int32Result(result);
+            return git_merge_file_input;
+        }
+
+        public static git_merge_file_options git_merge_file_options_init()
+        {
+            const uint version = 1;
+            int result = NativeMethods.git_merge_file_options_init(out git_merge_file_options git_merge_file_options, version);
+            Ensure.Int32Result(result);
+            return git_merge_file_options;
+        }
+
+        public static unsafe void git_merge_file_result_free(git_merge_file_result* git_merge_file_result)
+        {
+            NativeMethods.git_merge_file_result_free(git_merge_file_result);
+        }
+
         public static unsafe AnnotatedCommitHandle git_annotated_commit_from_fetchhead(RepositoryHandle repo, string branchName, string remoteUrl, GitOid oid)
         {
             git_annotated_commit* commit;

--- a/LibGit2Sharp/MergeFile.cs
+++ b/LibGit2Sharp/MergeFile.cs
@@ -1,0 +1,208 @@
+﻿using LibGit2Sharp.Core;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace LibGit2Sharp
+{
+    /// <summary>
+    /// Options for merging a file.
+    /// </summary>
+    public sealed class MergeFileOptions
+    {
+        /// <summary>
+        /// Label for the ancestor file side of the conflict which will be
+        /// prepended to labels in diff3-format merge files.
+        /// </summary>
+        public string AncestorLabel { get; set; }
+
+        /// <summary>
+        /// Label for our file side of the conflict which will be prepended to labels in merge files.
+        /// </summary>
+        public string OurLabel { get; set; }
+
+        /// <summary>
+        /// Label for their file side of the conflict which will be prepended to labels in merge files.
+        /// </summary>
+        public string TheirLabel { get; set; }
+
+        /// <summary>
+        /// Flags for automerging content.
+        /// </summary>
+        public MergeFileFavor Favor { get; set; }
+
+        /// <summary>
+        /// The size of conflict markers (eg, " &lt; &lt; &lt; &lt; &lt; &lt; &lt; ").
+        /// Default is 7.
+        /// </summary>
+        public short MarkerSize { get; set; }
+
+        /// <summary>
+        /// File merging flags.
+        /// </summary>
+        public MergeFileFlag Flags { get; set; }
+    }
+
+    /// <summary>
+    /// Internal class to read, or specify directly, the bytes
+    /// to use for merging files.
+    /// </summary>
+    internal class MergeFileInput
+    {
+        private git_merge_file_input input;
+        private byte[] bytes;
+
+        /// <summary>
+        /// The bytes to use for merging files.  Marshals the bytes
+        /// to the native pointer.
+        /// </summary>
+        public byte[] Bytes
+        {
+            get
+            {
+                return bytes;
+            }
+            set
+            {
+                bytes = value;
+                input.size = bytes.Length;
+                input.ptr = Marshal.AllocHGlobal(input.size);
+                if (input.size > 0) { Marshal.Copy(bytes, 0, input.ptr, input.size); }
+            }
+        }
+
+        /// <summary>
+        /// Initialize the native merge file input object from managed
+        /// sources.
+        /// </summary>
+        public MergeFileInput()
+        {
+            input = Proxy.git_merge_file_input_init();
+        }
+
+        /// <summary>
+        /// Read the bytes from a file from disk and marshal to the
+        /// native pointer.  
+        /// </summary>
+        /// <param name="path">The path to the input file.</param>
+        /// <returns>The current object for chaining.</returns>
+        public MergeFileInput Read(FilePath path)
+        {
+            string fullNativePath = Path.GetFullPath(path.Native);
+            try
+            {
+                if (!File.Exists(fullNativePath)) { throw new FileNotFoundException("Cannot find input file", fullNativePath); }
+                Bytes = File.ReadAllBytes(fullNativePath);
+                return this;
+            }
+            catch (FileNotFoundException)
+            {
+                throw;
+            }
+            catch (IOException ex)
+            {
+                throw new LibGit2SharpException($"Unable to read input file '{fullNativePath}'", ex);
+            }
+        }
+
+        /// <summary>
+        /// Convert to a wrapper for the native structure.
+        /// </summary>
+        /// <param name="mergeFileInput">The internal class.</param>
+        public static implicit operator GitMergeFileInputWrapper(MergeFileInput mergeFileInput)
+        {
+            return new GitMergeFileInputWrapper(mergeFileInput.input);
+        }
+    }
+
+    /// <summary>
+    /// Give managed access to a native merge file results object.
+    /// </summary>
+    internal class MergeFileResult
+    {
+        private git_merge_file_result result;
+
+        /// <summary>
+        /// Whether the file merge was successful without conflicts.
+        /// </summary>
+        public readonly bool Automergeable;
+
+        /// <summary>
+        /// The bytes of the merged file.
+        /// </summary>
+        public readonly byte[] Bytes;
+
+        /// <summary>
+        /// Create the object from the native wrapper.
+        /// </summary>
+        /// <param name="wrapper">The merge file result wrapper.</param>
+        public MergeFileResult(GitMergeFileResultWrapper wrapper)
+        {
+            result = wrapper;
+
+            Bytes = new byte[result.len];
+            if (result.len > 0) { Marshal.Copy(result.ptr, Bytes, 0, result.len); }
+
+            Automergeable = result.automergeable == 1;
+        }
+
+        /// <summary>
+        /// Write the bytes of the merged file to disk.  Create the file and/or directory
+        /// if it doesn't exist.
+        /// </summary>
+        /// <param name="path">The output file path.</param>
+        /// <returns>The current object for chaining.</returns>
+        public MergeFileResult Write(FilePath path)
+        {
+            string fullNativePath = Path.GetFullPath(path.Native);
+            try
+            {
+                string resultDir = Path.GetDirectoryName(fullNativePath);
+                if (!Directory.Exists(resultDir)) { Directory.CreateDirectory(resultDir); }
+                if (File.Exists(fullNativePath)) { File.Delete(fullNativePath); }
+                if (Bytes.Length > 0) { File.WriteAllBytes(fullNativePath, Bytes); }
+            }
+            catch (IOException ex)
+            {
+                throw new LibGit2SharpException($"Unable to write result file '{fullNativePath}'", ex);
+            }
+            return this;
+        }
+    }
+
+    /// <summary>
+    /// Internal extension methods to add to the public MergeFileOptions class.
+    /// </summary>
+    internal static class MergeFileOptionsExtensions
+    {
+        /// <summary>
+        /// Create a native merge file options structure from the public merge file options.
+        /// </summary>
+        /// <param name="mergeFileOptions">The public merge file options class.</param>
+        /// <returns>The native merge file options structure.</returns>
+        public static unsafe git_merge_file_options ToNative(this MergeFileOptions mergeFileOptions)
+        {
+            git_merge_file_options git_merge_file_options = Proxy.git_merge_file_options_init();
+            if (mergeFileOptions == null) { return git_merge_file_options; }
+
+            if (!string.IsNullOrEmpty(mergeFileOptions.AncestorLabel))
+            {
+                git_merge_file_options.ancestor_label = (char*)StrictUtf8Marshaler.FromManaged(mergeFileOptions.AncestorLabel);
+            }
+            if (!string.IsNullOrEmpty(mergeFileOptions.OurLabel))
+            {
+                git_merge_file_options.our_label = (char*)StrictUtf8Marshaler.FromManaged(mergeFileOptions.OurLabel);
+            }
+            if (!string.IsNullOrEmpty(mergeFileOptions.TheirLabel))
+            {
+                git_merge_file_options.their_label = (char*)StrictUtf8Marshaler.FromManaged(mergeFileOptions.TheirLabel);
+            }
+            git_merge_file_options.favor = mergeFileOptions.Favor;
+            git_merge_file_options.flags = mergeFileOptions.Flags;
+            if (mergeFileOptions.MarkerSize > 0)
+            {
+                git_merge_file_options.marker_size = (ushort)mergeFileOptions.MarkerSize;
+            }
+            return git_merge_file_options;
+        }
+    }
+}

--- a/LibGit2Sharp/MergeOptionsBase.cs
+++ b/LibGit2Sharp/MergeOptionsBase.cs
@@ -1,4 +1,6 @@
-﻿namespace LibGit2Sharp
+﻿using System;
+
+namespace LibGit2Sharp
 {
     /// <summary>
     /// Options controlling the behavior of actions that use merge (merge
@@ -92,5 +94,57 @@
         /// record a conflict.
         /// </summary>
         Union = 3,
+    }
+
+    /// <summary>
+    /// File merging flags.
+    /// </summary>
+    [Flags]
+    public enum MergeFileFlag
+    {
+        /// <summary>
+        /// Defaults
+        /// </summary>
+        Default = 0,
+
+        /// <summary>
+        /// Create standard conflicted merge files
+        /// </summary>
+        StyleMerge = (1 << 0),
+
+        /// <summary>
+        /// Create diff3-style files
+        /// </summary>
+        Diff3 = (1 << 1),
+
+        /// <summary>
+        /// Condense non-alphanumeric regions for simplified diff file
+        /// </summary>
+        SimplifyAlnum = (1 << 2),
+
+        /// <summary>
+        /// Ignore all whitespace
+        /// </summary>
+        IgnoreWhitespace = (1 << 3),
+
+        /// <summary>
+        /// Ignore changes in amount of whitespace
+        /// </summary>
+        IgnoreWhitespaceChange = (1 << 4),
+
+        /// <summary>
+        /// Ignore whitespace at end of line
+        /// </summary>
+        IgnoreWhitespace_Eol = (1 << 5),
+
+        /// <summary>
+        /// Use the "patience diff" algorithm
+        /// </summary>
+        DiffPatience = (1 << 6),
+
+        /// <summary>
+        /// Take extra time to find minimal diff
+        /// </summary>
+        DiffMinimal = (1 << 7),
     }
 }

--- a/LibGit2Sharp/Repository.cs
+++ b/LibGit2Sharp/Repository.cs
@@ -1536,8 +1536,8 @@ namespace LibGit2Sharp
             }
 
             var fileFlags = options.IgnoreWhitespaceChange
-                ? GitMergeFileFlag.GIT_MERGE_FILE_IGNORE_WHITESPACE_CHANGE
-                : GitMergeFileFlag.GIT_MERGE_FILE_DEFAULT;
+                ? MergeFileFlag.IgnoreWhitespaceChange
+                : MergeFileFlag.Default;
 
             var mergeOptions = new GitMergeOpts
             {
@@ -1755,6 +1755,60 @@ namespace LibGit2Sharp
             {
                 reference = refH.IsNull ? null : Reference.BuildFromPtr<Reference>(refH, this);
                 obj = GitObject.BuildFrom(this, Proxy.git_object_id(objH), Proxy.git_object_type(objH), PathFromRevparseSpec(revision));
+            }
+        }
+
+        /// <summary>
+        /// Run a three-way file merge.
+        /// Merge two files using the common ancestor as the baseline, producing a merge result.
+        /// </summary>
+        /// <param name="basePath">Path to a common ancestor.</param>
+        /// <param name="currentPath">Path to the current file.</param>
+        /// <param name="otherPath">Path to the file to merge in.</param>
+        /// <param name="resultPath">Path specifying where to write the merged file.</param>
+        /// <param name="options">The merge file options or null for defaults</param>
+        /// <returns>Returns true if the merge was successful and no conflicts occurred, false otherwise.</returns>
+        public static bool MergeFile(string currentPath, string basePath, string otherPath, string resultPath, MergeFileOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(basePath, "basePath");
+            Ensure.ArgumentNotNullOrEmptyString(currentPath, "currentPath");
+            Ensure.ArgumentNotNullOrEmptyString(otherPath, "otherPath");
+
+            using (var resultWrapper = Proxy.git_merge_file(new MergeFileInput().Read(basePath),
+                                                            new MergeFileInput().Read(currentPath),
+                                                            new MergeFileInput().Read(otherPath),
+                                                            options.ToNative()))
+            {
+                MergeFileResult result = new MergeFileResult(resultWrapper);
+                result.Write(resultPath);
+                return result.Automergeable;
+            }
+        }
+
+        /// <summary>
+        /// Run a three-way file merge.
+        /// Merge two file's bytes using the common ancestor as the baseline, producing the bytes of the merge result.
+        /// </summary>
+        /// <param name="baseBytes">Bytes of a common ancestor.</param>
+        /// <param name="currentBytes">Bytes of the current file.</param>
+        /// <param name="otherBytes">Bytes of the file to merge in.</param>
+        /// <param name="resultBytes">The merged file bytes.</param>
+        /// <param name="options">The merge file options or null for defaults</param>
+        /// <returns>Returns true if the merge was successful and no conflicts occurred, false otherwise.</returns>
+        public static bool MergeFile(byte[] currentBytes, byte[] baseBytes, byte[] otherBytes, out byte[] resultBytes, MergeFileOptions options)
+        {
+            Ensure.ArgumentNotNull(baseBytes, "baseBytes");
+            Ensure.ArgumentNotNull(currentBytes, "currentBytes");
+            Ensure.ArgumentNotNull(otherBytes, "otherBytes");
+
+            using (var resultWrapper = Proxy.git_merge_file(new MergeFileInput() { Bytes = baseBytes },
+                                                            new MergeFileInput() { Bytes = currentBytes },
+                                                            new MergeFileInput() { Bytes = otherBytes },
+                                                            options.ToNative()))
+            {
+                MergeFileResult result = new MergeFileResult(resultWrapper);
+                resultBytes = result.Bytes;
+                return result.Automergeable;
             }
         }
 


### PR DESCRIPTION
Add support for [git-merge-file](https://github.com/libgit2/libgit2sharp/wiki/LibGit2Sharp-Hitchhiker%27s-Guide-to-Git#manipulation-commands) (Run a three-way file merge.)
- Add static `MergeFile` method on `Repository`
- Merge files on disk or in memory
- Native is libgit2 `git_merge_file`
- Supports options
- Does _not_ support merging file names or modes