### PR TITLE
Make all Commands methods use IRepository for consistency

### DIFF
--- a/LibGit2Sharp/Commands/Fetch.cs
+++ b/LibGit2Sharp/Commands/Fetch.cs
@@ -32,7 +32,7 @@ namespace LibGit2Sharp
         /// <param name="options">Fetch options.</param>
         /// <param name="logMessage">Log message for any ref updates.</param>
         /// <param name="refspecs">List of refspecs to apply as active.</param>
-        public static void Fetch(Repository repository, string remote, IEnumerable<string> refspecs, FetchOptions options, string logMessage)
+        public static void Fetch(IRepository repository, string remote, IEnumerable<string> refspecs, FetchOptions options, string logMessage)
         {
             Ensure.ArgumentNotNull(remote, "remote");
 

--- a/LibGit2Sharp/Commands/Pull.cs
+++ b/LibGit2Sharp/Commands/Pull.cs
@@ -15,7 +15,7 @@ namespace LibGit2Sharp
         /// <param name="repository">The repository.</param>
         /// <param name="merger">The signature to use for the merge.</param>
         /// <param name="options">The options for fetch and merging.</param>
-        public static MergeResult Pull(Repository repository, Signature merger, PullOptions options)
+        public static MergeResult Pull(IRepository repository, Signature merger, PullOptions options)
         {
             Ensure.ArgumentNotNull(repository, "repository");
             Ensure.ArgumentNotNull(merger, "merger");


### PR DESCRIPTION
Make all `Commands` methods use `IRepository` for consistency.