### PR TITLE
Checkout branch looks to remote tracking branches as fallback

### DIFF
--- a/LibGit2Sharp/Commands/Checkout.cs
+++ b/LibGit2Sharp/Commands/Checkout.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using LibGit2Sharp.Core;
 
 namespace LibGit2Sharp
@@ -37,18 +38,47 @@ namespace LibGit2Sharp
             Ensure.ArgumentNotNullOrEmptyString(committishOrBranchSpec, "committishOrBranchSpec");
             Ensure.ArgumentNotNull(options, "options");
 
-            Reference reference;
-            GitObject obj;
+            Reference reference = null;
+            GitObject obj = null;
+            Branch branch = null;
 
-            repository.RevParse(committishOrBranchSpec, out reference, out obj);
+            try
+            {
+                repository.RevParse(committishOrBranchSpec, out reference, out obj);
+            }
+            catch (NotFoundException)
+            {
+                // If committishOrBranchSpec is not a local branch but matches a tracking branch
+                // in exactly one remote, use it. This is the "git checkout" command's default behavior.
+                // https://git-scm.com/docs/git-checkout#Documentation/git-checkout.txt-emgitcheckoutemltbranchgt
+                var remoteBranches = repository.Network.Remotes
+                    .SelectMany(r => repository.Branches.Where(b =>
+                        b.IsRemote &&
+                        b.CanonicalName == $"refs/remotes/{r.Name}/{committishOrBranchSpec}"))
+                    .ToList();
+
+                if (remoteBranches.Count == 1)
+                {
+                    branch = repository.CreateBranch(committishOrBranchSpec, remoteBranches[0].Tip);
+                    repository.Branches.Update(branch, b => b.TrackedBranch = remoteBranches[0].CanonicalName);
+                    return Checkout(repository, branch, options);
+                }
+
+                if (remoteBranches.Count > 1)
+                    throw new AmbiguousSpecificationException(
+                        $"'{committishOrBranchSpec}' matched multiple ({remoteBranches.Count}) remote tracking branches");
+
+                throw;
+            }
+
             if (reference != null && reference.IsLocalBranch)
             {
-                Branch branch = repository.Branches[reference.CanonicalName];
+                branch = repository.Branches[reference.CanonicalName];
                 return Checkout(repository, branch, options);
             }
 
             Commit commit = obj.Peel<Commit>(true);
-            Checkout(repository, commit.Tree,  options, committishOrBranchSpec);
+            Checkout(repository, commit.Tree, options, committishOrBranchSpec);
 
             return repository.Head;
         }

--- a/LibGit2Sharp/Commands/Checkout.cs
+++ b/LibGit2Sharp/Commands/Checkout.cs
@@ -61,12 +61,14 @@ namespace LibGit2Sharp
                 {
                     branch = repository.CreateBranch(committishOrBranchSpec, remoteBranches[0].Tip);
                     repository.Branches.Update(branch, b => b.TrackedBranch = remoteBranches[0].CanonicalName);
+
                     return Checkout(repository, branch, options);
                 }
 
                 if (remoteBranches.Count > 1)
-                    throw new AmbiguousSpecificationException(
-                        $"'{committishOrBranchSpec}' matched multiple ({remoteBranches.Count}) remote tracking branches");
+                {
+                    throw new AmbiguousSpecificationException($"'{committishOrBranchSpec}' matched multiple ({remoteBranches.Count}) remote tracking branches");
+                }
 
                 throw;
             }

--- a/LibGit2Sharp/Commands/Remove.cs
+++ b/LibGit2Sharp/Commands/Remove.cs
@@ -1,7 +1,6 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
 using System.IO;
-using System.Collections.Generic;
-using LibGit2Sharp;
+using System.Linq;
 using LibGit2Sharp.Core;
 
 namespace LibGit2Sharp


### PR DESCRIPTION
Resolves https://github.com/libgit2/libgit2sharp/issues/1564

When checking out a `<branch>`, do as what the [git checkout](https://git-scm.com/docs/git-checkout#Documentation/git-checkout.txt-emgitcheckoutemltbranchgt) command does:

> If \<branch> is not found but there does exist a tracking branch in exactly one remote (call it \<remote>) with a matching name and --no-guess is not specified, treat as equivalent to
>
> $ git checkout -b \<branch> --track \<remote>/\<branch>



