### PR TITLE
Adds OnPushRemoteProgress handler to PushOptions

### DIFF
--- a/LibGit2Sharp/PushOptions.cs
+++ b/LibGit2Sharp/PushOptions.cs
@@ -51,5 +51,10 @@ namespace LibGit2Sharp
         /// information about what updates will be performed.
         /// </summary>
         public PrePushHandler OnNegotiationCompletedBeforePush { get; set; }
+
+        /// <summary>
+        /// Handler for receiving textual progress from the remote.
+        /// </summary>
+        public ProgressHandler OnPushRemoteProgress { get; set; }
     }
 }

--- a/LibGit2Sharp/RemoteCallbacks.cs
+++ b/LibGit2Sharp/RemoteCallbacks.cs
@@ -30,6 +30,7 @@ namespace LibGit2Sharp
             CertificateCheck = pushOptions.CertificateCheck;
             PushStatusError = pushOptions.OnPushStatusError;
             PrePushCallback = pushOptions.OnNegotiationCompletedBeforePush;
+            Progress = pushOptions.OnPushRemoteProgress;
         }
 
         internal RemoteCallbacks(FetchOptionsBase fetchOptions)


### PR DESCRIPTION
The NativeMethods for receiving text updates from the remote already exists and are used in the `FetchOptions`. This simply adds the existing handler to `PushOptions` making it possible to configure a callback for receiving text updates from the remote.

No tests have been added for this PR, as its not possible to get remote updates when pushing to local bare repositories. I have integration tests locally that shows this working, but a remote repository is needed for it to be successful.
Hoping that the simplicity of this makes it straight forward to merge.

This is discussed here https://github.com/libgit2/libgit2sharp/issues/642