### PR TITLE
Adjust GitStatusOptions to match structure of native libgit2

### DIFF
--- a/LibGit2Sharp/Core/GitStatusOptions.cs
+++ b/LibGit2Sharp/Core/GitStatusOptions.cs
@@ -13,6 +13,8 @@ namespace LibGit2Sharp.Core
 
         public GitStrArrayManaged PathSpec;
 
+        public IntPtr Baseline = IntPtr.Zero;
+
         public void Dispose()
         {
             PathSpec.Dispose();


### PR DESCRIPTION
This fixes a marshaling bug that causes a segmentation fault

This mismatch caused dotdevelop's git module to crash.
More about this can be found here:
[https://github.com/dotdevelop/libgit2sharp/issues/2](https://github.com/dotdevelop/libgit2sharp/issues/2)