### PR TITLE
Update `git_worktree_add_options` struct to include ref pointer

### DIFF
--- a/LibGit2Sharp/Core/GitWorktree.cs
+++ b/LibGit2Sharp/Core/GitWorktree.cs
@@ -33,8 +33,10 @@ namespace LibGit2Sharp.Core
     internal class git_worktree_add_options
     {
         public uint version = 1;
-        
+
         public int locked;
+
+        public IntPtr @ref = IntPtr.Zero;
     }
 
     [StructLayout(LayoutKind.Sequential)]


### PR DESCRIPTION
After a recent upgrade of .netcore to 5.0.7 the WorktreeCollection.Add method has begun failing. Testing against earlier .net versions indicate this was not previously a problem.

Digging around in the lib2git repo shows that this git_worktree_add_options struct actually expects a third property that acts as a pointer to the worktree head.

Where this property gets used we can see where the exception comes from that creates the issue surfaced through libgit2sharp.

When this property isn't included on the struct and zeroed out, the native code presumably (possibly?) finds another value in that memory location that doesn't actually point to anything valid, hence the 💥.

Confirmed as fixed in local testing with different frameworks

Fixes #1885