### PR TITLE
Update LibGit2 to version 1.1.1

### DIFF
--- a/LibGit2Sharp.Tests/CloneFixture.cs
+++ b/LibGit2Sharp.Tests/CloneFixture.cs
@@ -70,7 +70,7 @@ namespace LibGit2Sharp.Tests
                 Assert.NotEqual(originalRepo.Info.Path, clonedRepo.Info.Path);
                 Assert.Equal(originalRepo.Head, clonedRepo.Head);
 
-                Assert.Equal(originalRepo.Branches.Count(), clonedRepo.Branches.Count(b => b.IsRemote));
+                Assert.Equal(originalRepo.Branches.Count(), clonedRepo.Branches.Count(b => b.IsRemote && b.FriendlyName != "origin/HEAD"));
                 Assert.Equal(isCloningAnEmptyRepository ? 0 : 1, clonedRepo.Branches.Count(b => !b.IsRemote));
 
                 Assert.Equal(originalRepo.Tags.Count(), clonedRepo.Tags.Count());

--- a/LibGit2Sharp.Tests/FetchFixture.cs
+++ b/LibGit2Sharp.Tests/FetchFixture.cs
@@ -215,7 +215,7 @@ namespace LibGit2Sharp.Tests
 
             using (var clonedRepo = new Repository(clonedRepoPath))
             {
-                Assert.Equal(5, clonedRepo.Branches.Count(b => b.IsRemote));
+                Assert.Equal(5, clonedRepo.Branches.Count(b => b.IsRemote && b.FriendlyName != "origin/HEAD"));
 
                 // Drop one of the branches in the remote repository
                 using (var sourceRepo = new Repository(source))
@@ -226,17 +226,17 @@ namespace LibGit2Sharp.Tests
                 // No pruning when the configuration entry isn't defined
                 Assert.Null(clonedRepo.Config.Get<bool>("fetch.prune"));
                 Commands.Fetch(clonedRepo, "origin", new string[0], null, null);
-                Assert.Equal(5, clonedRepo.Branches.Count(b => b.IsRemote));
+                Assert.Equal(5, clonedRepo.Branches.Count(b => b.IsRemote && b.FriendlyName != "origin/HEAD"));
 
                 // No pruning when the configuration entry is set to false
                 clonedRepo.Config.Set<bool>("fetch.prune", false);
                 Commands.Fetch(clonedRepo, "origin", new string[0], null, null);
-                Assert.Equal(5, clonedRepo.Branches.Count(b => b.IsRemote));
+                Assert.Equal(5, clonedRepo.Branches.Count(b => b.IsRemote && b.FriendlyName != "origin/HEAD"));
 
                 // Auto pruning when the configuration entry is set to true
                 clonedRepo.Config.Set<bool>("fetch.prune", true);
                 Commands.Fetch(clonedRepo, "origin", new string[0], null, null);
-                Assert.Equal(4, clonedRepo.Branches.Count(b => b.IsRemote));
+                Assert.Equal(4, clonedRepo.Branches.Count(b => b.IsRemote && b.FriendlyName != "origin/HEAD"));
             }
         }
 

--- a/LibGit2Sharp.Tests/RepositoryFixture.cs
+++ b/LibGit2Sharp.Tests/RepositoryFixture.cs
@@ -709,7 +709,7 @@ namespace LibGit2Sharp.Tests
         [Theory]
         [InlineData("http://github.com/libgit2/TestGitRepository")]
         [InlineData("https://github.com/libgit2/TestGitRepository")]
-        [InlineData("git://github.com/libgit2/TestGitRepository.git")]
+        //[InlineData("git://github.com/libgit2/TestGitRepository.git")]
         public void CanListRemoteReferences(string url)
         {
             IEnumerable<Reference> references = Repository.ListRemoteReferences(url).ToList();

--- a/LibGit2Sharp.Tests/RepositoryFixture.cs
+++ b/LibGit2Sharp.Tests/RepositoryFixture.cs
@@ -709,7 +709,7 @@ namespace LibGit2Sharp.Tests
         [Theory]
         [InlineData("http://github.com/libgit2/TestGitRepository")]
         [InlineData("https://github.com/libgit2/TestGitRepository")]
-        //[InlineData("git://github.com/libgit2/TestGitRepository.git")]
+        [InlineData("git://github.com/libgit2/TestGitRepository.git")]
         public void CanListRemoteReferences(string url)
         {
             IEnumerable<Reference> references = Repository.ListRemoteReferences(url).ToList();

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -227,7 +227,7 @@ namespace LibGit2Sharp.Core
         internal static extern unsafe GitError* git_error_last();
 
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern void git_error_set_str(
+        internal static extern int git_error_set_str(
             GitErrorCategory error_class,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string errorString);
 
@@ -252,25 +252,25 @@ namespace LibGit2Sharp.Core
         internal static extern unsafe void git_blame_free(git_blame* blame);
 
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern unsafe int git_blob_create_fromdisk(
+        internal static extern unsafe int git_blob_create_from_disk(
             ref GitOid id,
             git_repository* repo,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath path);
 
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern unsafe int git_blob_create_fromworkdir(
+        internal static extern unsafe int git_blob_create_from_workdir(
             ref GitOid id,
             git_repository* repo,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath relative_path);
 
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern unsafe int git_blob_create_fromstream(
+        internal static extern unsafe int git_blob_create_from_stream(
             out IntPtr stream,
             git_repository* repositoryPtr,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string hintpath);
 
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int git_blob_create_fromstream_commit(
+        internal static extern int git_blob_create_from_stream_commit(
             ref GitOid oid,
             IntPtr stream);
 
@@ -1616,7 +1616,7 @@ namespace LibGit2Sharp.Core
         internal static extern unsafe FilePath git_repository_path(git_repository* repository);
 
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern unsafe void git_repository_set_config(
+        internal static extern unsafe int git_repository_set_config(
             git_repository* repository,
             git_config* config);
 
@@ -1628,7 +1628,7 @@ namespace LibGit2Sharp.Core
 
 
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern unsafe void git_repository_set_index(
+        internal static extern unsafe int git_repository_set_index(
             git_repository* repository,
             git_index* index);
 
@@ -1710,13 +1710,13 @@ namespace LibGit2Sharp.Core
         internal static extern unsafe int git_revwalk_push(git_revwalk* walker, ref GitOid id);
 
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern unsafe void git_revwalk_reset(git_revwalk* walker);
+        internal static extern unsafe int git_revwalk_reset(git_revwalk* walker);
 
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern unsafe void git_revwalk_sorting(git_revwalk* walk, CommitSortStrategies sort);
+        internal static extern unsafe int git_revwalk_sorting(git_revwalk* walk, CommitSortStrategies sort);
 
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern unsafe void git_revwalk_simplify_first_parent(git_revwalk* walk);
+        internal static extern unsafe int git_revwalk_simplify_first_parent(git_revwalk* walk);
 
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe void git_signature_free(git_signature* signature);

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -36,34 +36,34 @@ namespace LibGit2Sharp.Core
 
         #region git_blob_
 
-        public static unsafe IntPtr git_blob_create_fromstream(RepositoryHandle repo, string hintpath)
+        public static unsafe IntPtr git_blob_create_from_stream(RepositoryHandle repo, string hintpath)
         {
             IntPtr writestream_ptr;
 
-            Ensure.ZeroResult(NativeMethods.git_blob_create_fromstream(out writestream_ptr, repo, hintpath));
+            Ensure.ZeroResult(NativeMethods.git_blob_create_from_stream(out writestream_ptr, repo, hintpath));
             return writestream_ptr;
         }
 
         public static unsafe ObjectId git_blob_create_fromstream_commit(IntPtr writestream_ptr)
         {
             var oid = new GitOid();
-            Ensure.ZeroResult(NativeMethods.git_blob_create_fromstream_commit(ref oid, writestream_ptr));
+            Ensure.ZeroResult(NativeMethods.git_blob_create_from_stream_commit(ref oid, writestream_ptr));
             return oid;
         }
 
-        public static unsafe ObjectId git_blob_create_fromdisk(RepositoryHandle repo, FilePath path)
+        public static unsafe ObjectId git_blob_create_from_disk(RepositoryHandle repo, FilePath path)
         {
             var oid = new GitOid();
-            int res = NativeMethods.git_blob_create_fromdisk(ref oid, repo, path);
+            int res = NativeMethods.git_blob_create_from_disk(ref oid, repo, path);
             Ensure.ZeroResult(res);
 
             return oid;
         }
 
-        public static unsafe ObjectId git_blob_create_fromfile(RepositoryHandle repo, FilePath path)
+        public static unsafe ObjectId git_blob_create_from_workdir(RepositoryHandle repo, FilePath path)
         {
             var oid = new GitOid();
-            int res = NativeMethods.git_blob_create_fromworkdir(ref oid, repo, path);
+            int res = NativeMethods.git_blob_create_from_workdir(ref oid, repo, path);
             Ensure.ZeroResult(res);
 
             return oid;
@@ -855,21 +855,22 @@ namespace LibGit2Sharp.Core
 
         #region git_error_
 
-        public static void git_error_set_str(GitErrorCategory error_class, Exception exception)
+        public static int git_error_set_str(GitErrorCategory error_class, Exception exception)
         {
             if (exception is OutOfMemoryException)
             {
                 NativeMethods.git_error_set_oom();
+                return 0;
             }
             else
             {
-                NativeMethods.git_error_set_str(error_class, ErrorMessageFromException(exception));
+                return NativeMethods.git_error_set_str(error_class, ErrorMessageFromException(exception));
             }
         }
 
-        public static void git_error_set_str(GitErrorCategory error_class, String errorString)
+        public static int git_error_set_str(GitErrorCategory error_class, String errorString)
         {
-            NativeMethods.git_error_set_str(error_class, errorString);
+            return NativeMethods.git_error_set_str(error_class, errorString);
         }
 
         /// <summary>
@@ -2589,9 +2590,9 @@ namespace LibGit2Sharp.Core
             return NativeMethods.git_repository_path(repo);
         }
 
-        public static unsafe void git_repository_set_config(RepositoryHandle repo, ConfigurationHandle config)
+        public static unsafe int git_repository_set_config(RepositoryHandle repo, ConfigurationHandle config)
         {
-            NativeMethods.git_repository_set_config(repo, config);
+            return NativeMethods.git_repository_set_config(repo, config);
         }
 
         public static unsafe void git_repository_set_ident(RepositoryHandle repo, string name, string email)
@@ -2600,9 +2601,9 @@ namespace LibGit2Sharp.Core
             Ensure.ZeroResult(res);
         }
 
-        public static unsafe void git_repository_set_index(RepositoryHandle repo, IndexHandle index)
+        public static unsafe int git_repository_set_index(RepositoryHandle repo, IndexHandle index)
         {
-            NativeMethods.git_repository_set_index(repo, index);
+            return NativeMethods.git_repository_set_index(repo, index);
         }
 
         public static unsafe void git_repository_set_workdir(RepositoryHandle repo, FilePath workdir)
@@ -2783,14 +2784,14 @@ namespace LibGit2Sharp.Core
             NativeMethods.git_revwalk_reset(walker);
         }
 
-        public static unsafe void git_revwalk_sorting(RevWalkerHandle walker, CommitSortStrategies options)
+        public static unsafe int git_revwalk_sorting(RevWalkerHandle walker, CommitSortStrategies options)
         {
-            NativeMethods.git_revwalk_sorting(walker, options);
+            return NativeMethods.git_revwalk_sorting(walker, options);
         }
 
-        public static unsafe void git_revwalk_simplify_first_parent(RevWalkerHandle walker)
+        public static unsafe int git_revwalk_simplify_first_parent(RevWalkerHandle walker)
         {
-            NativeMethods.git_revwalk_simplify_first_parent(walker);
+            return NativeMethods.git_revwalk_simplify_first_parent(walker);
         }
 
 #endregion

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="[2.0.314]" PrivateAssets="none" />
+    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="[2.0.315-alpha.0.1]" PrivateAssets="none" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.220" PrivateAssets="all" />
   </ItemGroup>

--- a/LibGit2Sharp/ObjectDatabase.cs
+++ b/LibGit2Sharp/ObjectDatabase.cs
@@ -104,8 +104,8 @@ namespace LibGit2Sharp
             }
 
             ObjectId id = Path.IsPathRooted(path)
-                ? Proxy.git_blob_create_fromdisk(repo.Handle, path)
-                : Proxy.git_blob_create_fromfile(repo.Handle, path);
+                ? Proxy.git_blob_create_from_disk(repo.Handle, path)
+                : Proxy.git_blob_create_from_workdir(repo.Handle, path);
 
             return repo.Lookup<Blob>(id);
         }
@@ -277,7 +277,7 @@ namespace LibGit2Sharp
                 throw new ArgumentException("The stream cannot be read from.", "stream");
             }
 
-            IntPtr writestream_ptr = Proxy.git_blob_create_fromstream(repo.Handle, hintpath);
+            IntPtr writestream_ptr = Proxy.git_blob_create_from_stream(repo.Handle, hintpath);
             GitWriteStream writestream = Marshal.PtrToStructure<GitWriteStream>(writestream_ptr);
 
             try


### PR DESCRIPTION
- Use package produced by https://github.com/libgit2/libgit2sharp.nativebinaries/pull/114
- Rename some native methods an change return type (see https://github.com/libgit2/libgit2/pull/5117 and https://github.com/libgit2/libgit2/pull/5365)
  -  Thanks @A-Ovchinnikov-mx for poviding the fix! (cherry-picked from https://github.com/mendix/libgit2sharp/commit/f958478f89fa37e80881a63a621b6a56712297ec)
- Update some tests to match the fact that "origin/HEAD" is now added when cloning (see libgit2/libgit2#5651) 