### PR TITLE
Update to libgit2 v1.2.0

### DIFF
--- a/LibGit2Sharp/Core/GitOdbBackend.cs
+++ b/LibGit2Sharp/Core/GitOdbBackend.cs
@@ -33,6 +33,9 @@ namespace LibGit2Sharp.Core
         public exists_prefix_callback ExistsPrefix;
         public IntPtr Refresh;
         public foreach_callback Foreach;
+
+        private IntPtr Padding; // TODO: add writemidx
+
         public IntPtr Writepack;
         public IntPtr Freshen;
         public free_callback Free;

--- a/LibGit2Sharp/Core/GitRebaseOptions.cs
+++ b/LibGit2Sharp/Core/GitRebaseOptions.cs
@@ -18,6 +18,8 @@ namespace LibGit2Sharp.Core
 
         public GitCheckoutOpts checkout_options = new GitCheckoutOpts { version = 1 };
 
+        private IntPtr padding; // TODO: add git_commit_create_cb
+
         public NativeMethods.commit_signing_callback signing_callback;
     }
 }

--- a/LibGit2Sharp/Core/GitRemoteCallbacks.cs
+++ b/LibGit2Sharp/Core/GitRemoteCallbacks.cs
@@ -33,6 +33,8 @@ namespace LibGit2Sharp.Core
 
         internal IntPtr transport;
 
+        private IntPtr padding; // TODO: add git_remote_ready_cb
+
         internal IntPtr payload;
 
         internal NativeMethods.url_resolve_callback resolve_url;

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="[2.0.315-alpha.0.1]" PrivateAssets="none" />
+    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="[2.0.315-alpha.0.2]" PrivateAssets="none" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.220" PrivateAssets="all" />
   </ItemGroup>


### PR DESCRIPTION
- Update `LibGit2Sharp.NativeBinaries` to `2.0.315-alpha.0.2`
- Quickly fix some breaking changes introduced by:
  -  https://github.com/libgit2/libgit2/pull/6016
  - https://github.com/libgit2/libgit2/pull/6012
  - https://github.com/libgit2/libgit2/pull/5405