### PR TITLE
Simplify dealing with missing git objects

### DIFF
--- a/LibGit2Sharp.Tests/BlobFixture.cs
+++ b/LibGit2Sharp.Tests/BlobFixture.cs
@@ -15,6 +15,7 @@ namespace LibGit2Sharp.Tests
             using (var repo = new Repository(path))
             {
                 var blob = repo.Lookup<Blob>("a8233120f6ad708f843d861ce2b7228ec4e3dec6");
+                Assert.False(blob.IsMissing);
 
                 var text = blob.GetContentText();
 
@@ -36,6 +37,7 @@ namespace LibGit2Sharp.Tests
                 repo.Config.Set("core.autocrlf", autocrlf);
 
                 var blob = repo.Lookup<Blob>("a8233120f6ad708f843d861ce2b7228ec4e3dec6");
+                Assert.False(blob.IsMissing);
 
                 var text = blob.GetContentText(new FilteringOptions("foo.txt"));
 
@@ -67,6 +69,7 @@ namespace LibGit2Sharp.Tests
                 var commit = repo.Commit("bom", Constants.Signature, Constants.Signature);
 
                 var blob = (Blob)commit.Tree[bomFile].Target;
+                Assert.False(blob.IsMissing);
                 Assert.Equal(expectedContentBytes, blob.Size);
                 using (var stream = blob.GetContentStream())
                 {
@@ -92,6 +95,7 @@ namespace LibGit2Sharp.Tests
             using (var repo = new Repository(path))
             {
                 var blob = repo.Lookup<Blob>("a8233120f6ad708f843d861ce2b7228ec4e3dec6");
+                Assert.False(blob.IsMissing);
                 Assert.Equal(10, blob.Size);
             }
         }
@@ -104,6 +108,7 @@ namespace LibGit2Sharp.Tests
             {
                 var blob = repo.Lookup<Blob>("a8233120f6ad708f843d861ce2b7228ec4e3dec6");
                 Assert.NotNull(blob);
+                Assert.False(blob.IsMissing);
             }
         }
 
@@ -114,6 +119,7 @@ namespace LibGit2Sharp.Tests
             using (var repo = new Repository(path))
             {
                 var blob = repo.Lookup<Blob>("a8233120f6ad708f843d861ce2b7228ec4e3dec6");
+                Assert.False(blob.IsMissing);
 
                 var contentStream = blob.GetContentStream();
                 Assert.Equal(blob.Size, contentStream.Length);
@@ -140,6 +146,7 @@ namespace LibGit2Sharp.Tests
                 repo.Config.Set("core.autocrlf", autocrlf);
 
                 var blob = repo.Lookup<Blob>("a8233120f6ad708f843d861ce2b7228ec4e3dec6");
+                Assert.False(blob.IsMissing);
 
                 var contentStream = blob.GetContentStream(new FilteringOptions("foo.txt"));
                 Assert.Equal(expectedContent.Length, contentStream.Length);
@@ -164,6 +171,7 @@ namespace LibGit2Sharp.Tests
                 using (var stream = new MemoryStream(binaryContent))
                 {
                     Blob blob = repo.ObjectDatabase.CreateBlob(stream);
+                    Assert.False(blob.IsMissing);
 
                     using (var filtered = blob.GetContentStream(new FilteringOptions("foo.txt")))
                     {
@@ -196,6 +204,7 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal("baae1fb3760a73481ced1fa03dc15614142c19ef", entry.Id.Sha);
 
                 var blob = repo.Lookup<Blob>(entry.Id.Sha);
+                Assert.False(blob.IsMissing);
 
                 using (Stream stream = blob.GetContentStream())
                 using (Stream file = File.OpenWrite(Path.Combine(repo.Info.WorkingDirectory, "small.fromblob.txt")))
@@ -217,7 +226,32 @@ namespace LibGit2Sharp.Tests
             using (var repo = new Repository(path))
             {
                 var blob = repo.Lookup<Blob>("a8233120f6ad708f843d861ce2b7228ec4e3dec6");
+                Assert.False(blob.IsMissing);
                 Assert.False(blob.IsBinary);
+            }
+        }
+
+        [Fact]
+        public void CanTellIfABlobIsMissing()
+        {
+            string repoPath = SandboxBareTestRepo();
+
+            // Manually delete the objects directory to simulate a partial clone
+            Directory.Delete(Path.Combine(repoPath, "objects", "a8"), true);
+
+            using (var repo = new Repository(repoPath)) 
+            {
+                // Look up for the tree that reference the blob which is now missing
+                var tree = repo.Lookup<Tree>("fd093bff70906175335656e6ce6ae05783708765");
+                var blob = (Blob) tree["README"].Target;
+
+                Assert.Equal("a8233120f6ad708f843d861ce2b7228ec4e3dec6", blob.Sha);
+                Assert.NotNull(blob);
+                Assert.True(blob.IsMissing);
+                Assert.Throws<NotFoundException>(() => blob.Size);
+                Assert.Throws<NotFoundException>(() => blob.IsBinary);
+                Assert.Throws<NotFoundException>(() => blob.GetContentText());
+                Assert.Throws<NotFoundException>(() => blob.GetContentText(new FilteringOptions("foo.txt")));
             }
         }
 

--- a/LibGit2Sharp/Core/GitObjectLazyGroup.cs
+++ b/LibGit2Sharp/Core/GitObjectLazyGroup.cs
@@ -21,11 +21,11 @@ namespace LibGit2Sharp.Core
             }
         }
 
-        public static ILazy<TResult> Singleton<TResult>(Repository repo, ObjectId id, Func<ObjectHandle, TResult> resultSelector)
+        public static ILazy<TResult> Singleton<TResult>(Repository repo, ObjectId id, Func<ObjectHandle, TResult> resultSelector, bool throwIfMissing = false)
         {
             return Singleton(() =>
             {
-                using (var osw = new ObjectSafeWrapper(id, repo.Handle))
+                using (var osw = new ObjectSafeWrapper(id, repo.Handle, throwIfMissing: throwIfMissing))
                 {
                     return resultSelector(osw.ObjectPtr);
                 }

--- a/LibGit2Sharp/Core/ObjectSafeWrapper.cs
+++ b/LibGit2Sharp/Core/ObjectSafeWrapper.cs
@@ -7,7 +7,7 @@ namespace LibGit2Sharp.Core
     {
         private readonly ObjectHandle objectPtr;
 
-        public unsafe ObjectSafeWrapper(ObjectId id, RepositoryHandle handle, bool allowNullObjectId = false)
+        public unsafe ObjectSafeWrapper(ObjectId id, RepositoryHandle handle, bool allowNullObjectId = false, bool throwIfMissing = false)
         {
             Ensure.ArgumentNotNull(handle, "handle");
 
@@ -20,12 +20,14 @@ namespace LibGit2Sharp.Core
                 Ensure.ArgumentNotNull(id, "id");
                 objectPtr = Proxy.git_object_lookup(handle, id, GitObjectType.Any);
             }
+
+            if (objectPtr == null && throwIfMissing)
+            {
+                throw new NotFoundException($"No valid git object identified by '{id}' exists in the repository.");
+            }
         }
 
-        public ObjectHandle ObjectPtr
-        {
-            get { return objectPtr; }
-        }
+        public ObjectHandle ObjectPtr => objectPtr;
 
         public void Dispose()
         {

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -72,7 +72,7 @@ namespace LibGit2Sharp.Core
         public static unsafe UnmanagedMemoryStream git_blob_filtered_content_stream(RepositoryHandle repo, ObjectId id, string path, bool check_for_binary_data)
         {
             var buf = new GitBuf();
-            var handle = new ObjectSafeWrapper(id, repo).ObjectPtr;
+            var handle = new ObjectSafeWrapper(id, repo, throwIfMissing: true).ObjectPtr;
 
             return new RawContentStream(handle, h =>
             {
@@ -85,7 +85,7 @@ namespace LibGit2Sharp.Core
 
         public static unsafe UnmanagedMemoryStream git_blob_rawcontent_stream(RepositoryHandle repo, ObjectId id, Int64 size)
         {
-            var handle = new ObjectSafeWrapper(id, repo).ObjectPtr;
+            var handle = new ObjectSafeWrapper(id, repo, throwIfMissing: true).ObjectPtr;
             return new RawContentStream(handle, h => NativeMethods.git_blob_rawcontent(h), h => size);
         }
 
@@ -3263,7 +3263,7 @@ namespace LibGit2Sharp.Core
 
         public static unsafe TreeEntryHandle git_tree_entry_bypath(RepositoryHandle repo, ObjectId id, string treeentry_path)
         {
-            using (var obj = new ObjectSafeWrapper(id, repo))
+            using (var obj = new ObjectSafeWrapper(id, repo, throwIfMissing: true))
             {
                 git_tree_entry* treeEntryPtr;
                 int res = NativeMethods.git_tree_entry_bypath(out treeEntryPtr, obj.ObjectPtr, treeentry_path);


### PR DESCRIPTION
- Add `IsMissing` on `GitObject` to know if a git objects is missing without any exception involved
- Make some methods on `Blob` and `Tree` explicitly throw a `NotFoundException` (rather than a `NullReferenceException` later on when accessing the `null` handle)