### PR TITLE
Read and write submodule branch Option #1301

### DIFF
--- a/LibGit2Sharp.Tests/SubmoduleFixture.cs
+++ b/LibGit2Sharp.Tests/SubmoduleFixture.cs
@@ -203,6 +203,26 @@ namespace LibGit2Sharp.Tests
         }
 
         [Fact]
+        public void CanChangeSubmoduleBranch()
+        {
+            var path = SandboxSubmoduleSmallTestRepo();
+            string submoduleName = "submodule_target_wd";
+            string expectedSubmoduleBranch = @"master";
+
+            using (var repo = new Repository(path))
+            {
+                var submodule = repo.Submodules[submoduleName];
+
+                Assert.Null(submodule.Branch);
+
+                submodule.Branch = expectedSubmoduleBranch;
+
+                Assert.NotNull(submodule.Branch);
+                Assert.Equal(submodule.Branch, expectedSubmoduleBranch);
+            }
+        }
+
+        [Fact]
         public void UpdatingUninitializedSubmoduleThrows()
         {
             var path = SandboxSubmoduleSmallTestRepo();

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -1853,6 +1853,17 @@ namespace LibGit2Sharp.Core
             git_submodule* submodule);
 
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
+        [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))]
+        internal static extern unsafe string git_submodule_branch(
+            git_submodule* submodule);
+
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern unsafe int git_submodule_set_branch(
+            git_repository* repo,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string branch);
+
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe git_oid* git_submodule_index_id(
             git_submodule* submodule);
 

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -3020,6 +3020,17 @@ namespace LibGit2Sharp.Core
             return NativeMethods.git_submodule_url(submodule);
         }
 
+        public static unsafe string git_submodule_branch(SubmoduleHandle submodule)
+        {
+            return NativeMethods.git_submodule_branch(submodule);
+        }
+
+        public static unsafe void git_submodule_set_branch(RepositoryHandle repo, string name, string branch)
+        {
+            var res = NativeMethods.git_submodule_set_branch(repo, name, branch);
+            Ensure.ZeroResult(res);
+        }
+
         public static unsafe ObjectId git_submodule_index_id(SubmoduleHandle submodule)
         {
             return ObjectId.BuildFromPtr(NativeMethods.git_submodule_index_id(submodule));

--- a/LibGit2Sharp/SubmoduleCollection.cs
+++ b/LibGit2Sharp/SubmoduleCollection.cs
@@ -43,7 +43,8 @@ namespace LibGit2Sharp
 
                 return Lookup(name, handle => new Submodule(repo, name,
                                                             Proxy.git_submodule_path(handle),
-                                                            Proxy.git_submodule_url(handle)));
+                                                            Proxy.git_submodule_url(handle),
+                                                            Proxy.git_submodule_branch(handle)));
             }
         }
 


### PR DESCRIPTION
Allows for reading and writing the branch option from .gitmodules
requested a while ago in #1301 

submodule.Branch can be read (string) and set (string) to change the branch option in .gitmodules
If a branch option was not set Branch will return null (libgit2 submodule_branch return value)

This helps in automated environments to checkout the correct tip (e.g. specific feature branch) and automatically publish changes back to the correct branch.