### PR TITLE
Adds .net 6 test target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,18 +28,18 @@ jobs:
         uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0
-      - name: Setup .NET Core 3.1 SDK
-        uses: actions/setup-dotnet@v1.8.1
-        with:
-          dotnet-version: 3.1.x
-      - name: Setup .NET 5.0 SDK
-        uses: actions/setup-dotnet@v1.8.1
-        with:
-          dotnet-version: 5.0.x
-      - name: Setup .NET 6.0 SDK
+      - name: Install .NET SDK
         uses: actions/setup-dotnet@v1.8.1
         with:
           dotnet-version: 6.0.x
+      - name: Install .NET 5 runtime
+        uses: actions/setup-dotnet@v1.8.1
+        with:
+          dotnet-version: 5.0.x
+      - name: Install .NET Core 3.1 runtime
+        uses: actions/setup-dotnet@v1.8.1
+        with:
+          dotnet-version: 3.1.x
       - name: Build
         run: dotnet build LibGit2Sharp.sln --configuration Release
       - name: Upload packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,14 +28,18 @@ jobs:
         uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0
-      - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v1.8.1
-        with:
-          dotnet-version: 5.0.x
-      - name: Setup .NET Core 3.1 runtime
+      - name: Setup .NET Core 3.1 SDK
         uses: actions/setup-dotnet@v1.8.1
         with:
           dotnet-version: 3.1.x
+      - name: Setup .NET 5.0 SDK
+        uses: actions/setup-dotnet@v1.8.1
+        with:
+          dotnet-version: 5.0.x
+      - name: Setup .NET 6.0 SDK
+        uses: actions/setup-dotnet@v1.8.1
+        with:
+          dotnet-version: 6.0.x
       - name: Build
         run: dotnet build LibGit2Sharp.sln --configuration Release
       - name: Upload packages
@@ -52,3 +56,5 @@ jobs:
         run: dotnet test LibGit2Sharp.sln --configuration Release --no-restore --framework netcoreapp3.1 --logger "GitHubActions" /p:ExtraDefine=LEAKS_IDENTIFYING
       - name: Run net5.0 tests
         run: dotnet test LibGit2Sharp.sln --configuration Release --no-restore --framework net5.0 --logger "GitHubActions" /p:ExtraDefine=LEAKS_IDENTIFYING
+      - name: Run net6.0 tests
+        run: dotnet test LibGit2Sharp.sln --configuration Release --no-restore --framework net6.0 --logger "GitHubActions" /p:ExtraDefine=LEAKS_IDENTIFYING

--- a/LibGit2Sharp.Tests/BlobFixture.cs
+++ b/LibGit2Sharp.Tests/BlobFixture.cs
@@ -43,7 +43,7 @@ namespace LibGit2Sharp.Tests
             }
         }
 
-#if NETFRAMEWORK || NETCOREAPP3_1 //UTF-7 is disabled in .NET 5
+#if NETFRAMEWORK || NETCOREAPP3_1 //UTF-7 is disabled in .NET 5+
         [Theory]
         [InlineData("ascii", 4, "31 32 33 34")]
         [InlineData("utf-7", 4, "31 32 33 34")]

--- a/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
+++ b/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
For now it uses the .net 6 RC2 sdk, but when the final release becomes available we can remove the `include-prerelease: true` from the workflow file