### PR TITLE
Add support to pass "initial head" on repo init

### DIFF
--- a/LibGit2Sharp.Tests/RepositoryFixture.cs
+++ b/LibGit2Sharp.Tests/RepositoryFixture.cs
@@ -156,6 +156,27 @@ namespace LibGit2Sharp.Tests
             }
         }
 
+        [Fact]
+        public void CanCreateStandardRepoAndDefineCustomHead()
+        {
+            var scd1 = BuildSelfCleaningDirectory();
+            var scd2 = BuildSelfCleaningDirectory();
+
+            var gitDir = Path.Combine(scd2.DirectoryPath, ".git/");
+
+            string repoPath = Repository.Init(scd1.DirectoryPath, gitDir, new InitOptions(){ InitialHead = "monkey"});
+
+            Assert.True(Repository.IsValid(repoPath));
+
+            using (var repo = new Repository(repoPath))
+            {
+                Assert.True(Repository.IsValid(repo.Info.WorkingDirectory));
+                Assert.True(Repository.IsValid(repo.Info.Path));
+
+                Assert.Equal("monkey", repo.Head.FriendlyName);
+            }
+        }
+
         private static void CheckGitConfigFile(string dir)
         {
             string configFilePath = Path.Combine(dir, "config");

--- a/LibGit2Sharp/Core/GitRepositoryInitOptions.cs
+++ b/LibGit2Sharp/Core/GitRepositoryInitOptions.cs
@@ -16,7 +16,7 @@ namespace LibGit2Sharp.Core
         public IntPtr InitialHead;
         public IntPtr OriginUrl;
 
-        public static GitRepositoryInitOptions BuildFrom(FilePath workdirPath, bool isBare)
+        public static GitRepositoryInitOptions BuildFrom(FilePath workdirPath, bool isBare, string initialHead)
         {
             var opts = new GitRepositoryInitOptions
             {
@@ -29,6 +29,11 @@ namespace LibGit2Sharp.Core
                 Debug.Assert(!isBare);
 
                 opts.WorkDirPath = StrictFilePathMarshaler.FromManaged(workdirPath);
+            }
+
+            if (!string.IsNullOrEmpty(initialHead))
+            {
+                opts.InitialHead = StrictUtf8Marshaler.FromManaged(initialHead);
             }
 
             if (isBare)

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -2480,9 +2480,10 @@ namespace LibGit2Sharp.Core
         public static unsafe RepositoryHandle git_repository_init_ext(
             FilePath workdirPath,
             FilePath gitdirPath,
-            bool isBare)
+            bool isBare,
+            string initialHead)
         {
-            using (var opts = GitRepositoryInitOptions.BuildFrom(workdirPath, isBare))
+            using (var opts = GitRepositoryInitOptions.BuildFrom(workdirPath, isBare, initialHead))
             {
                 git_repository* repo;
                 int res = NativeMethods.git_repository_init_ext(out repo, gitdirPath, opts);

--- a/LibGit2Sharp/InitOptions.cs
+++ b/LibGit2Sharp/InitOptions.cs
@@ -1,0 +1,14 @@
+namespace LibGit2Sharp
+{
+    /// <summary>
+    /// Optional parameters when invoking Init.
+    /// </summary>
+    public sealed class InitOptions
+    {
+        /// <summary>
+        /// Use the specified name for the initial branch in the newly created repository.
+        /// If not specified, fall back to the default name
+        /// </summary>
+        public string InitialHead { get; set; }
+    }
+}

--- a/LibGit2Sharp/Repository.cs
+++ b/LibGit2Sharp/Repository.cs
@@ -482,7 +482,7 @@ namespace LibGit2Sharp
         /// <returns>The path to the created repository.</returns>
         public static string Init(string path)
         {
-            return Init(path, false);
+            return Init(path, false, new InitOptions());
         }
 
         /// <summary>
@@ -493,9 +493,33 @@ namespace LibGit2Sharp
         /// <returns>The path to the created repository.</returns>
         public static string Init(string path, bool isBare)
         {
+            return Init(path, isBare, new InitOptions());
+        }
+
+
+        /// <summary>
+        /// Initialize a repository by explictly setting the path to both the working directory and the git directory.
+        /// </summary>
+        /// <param name="workingDirectoryPath">The path to the working directory.</param>
+        /// <param name="gitDirectoryPath">The path to the git repository to be created.</param>
+        /// <returns>The path to the created repository.</returns>
+        public static string Init(string workingDirectoryPath, string gitDirectoryPath)
+        {
+            return Init(workingDirectoryPath, gitDirectoryPath, new InitOptions());
+        }
+
+        /// <summary>
+        /// Initialize a repository at the specified <paramref name="path"/>.
+        /// </summary>
+        /// <param name="path">The path to the working folder when initializing a standard ".git" repository. Otherwise, when initializing a bare repository, the path to the expected location of this later.</param>
+        /// <param name="isBare">true to initialize a bare repository. False otherwise, to initialize a standard ".git" repository.</param>
+        /// <param name="options">Additional optional parameters to be passed to the Init invocation</param>
+        /// <returns>The path to the created repository.</returns>
+        public static string Init(string path, bool isBare, InitOptions options)
+        {
             Ensure.ArgumentNotNullOrEmptyString(path, "path");
 
-            using (RepositoryHandle repo = Proxy.git_repository_init_ext(null, path, isBare))
+            using (RepositoryHandle repo = Proxy.git_repository_init_ext(null, path, isBare, options.InitialHead))
             {
                 FilePath repoPath = Proxy.git_repository_path(repo);
                 return repoPath.Native;
@@ -507,8 +531,9 @@ namespace LibGit2Sharp
         /// </summary>
         /// <param name="workingDirectoryPath">The path to the working directory.</param>
         /// <param name="gitDirectoryPath">The path to the git repository to be created.</param>
+        /// <param name="options">Additional optional parameters to be passed to the Init invocation</param>
         /// <returns>The path to the created repository.</returns>
-        public static string Init(string workingDirectoryPath, string gitDirectoryPath)
+        public static string Init(string workingDirectoryPath, string gitDirectoryPath, InitOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(workingDirectoryPath, "workingDirectoryPath");
             Ensure.ArgumentNotNullOrEmptyString(gitDirectoryPath, "gitDirectoryPath");
@@ -520,7 +545,7 @@ namespace LibGit2Sharp
 
             // TODO: Shouldn't we ensure that the working folder isn't under the gitDir?
 
-            using (RepositoryHandle repo = Proxy.git_repository_init_ext(wd, gitDirectoryPath, false))
+            using (RepositoryHandle repo = Proxy.git_repository_init_ext(wd, gitDirectoryPath, false, options.InitialHead))
             {
                 FilePath repoPath = Proxy.git_repository_path(repo);
                 return repoPath.Native;
@@ -1050,7 +1075,7 @@ namespace LibGit2Sharp
 
                 if (treesame && !amendMergeCommit)
                 {
-                    throw (options.AmendPreviousCommit ? 
+                    throw (options.AmendPreviousCommit ?
                         new EmptyCommitException("Amending this commit would produce a commit that is identical to its parent (id = {0})", parents[0].Id) :
                         new EmptyCommitException("No changes; nothing to commit."));
                 }
@@ -1241,7 +1266,7 @@ namespace LibGit2Sharp
             if (fetchHeads.Length == 0)
             {
                 var expectedRef = this.Head.UpstreamBranchCanonicalName;
-                throw new MergeFetchHeadNotFoundException("The current branch is configured to merge with the reference '{0}' from the remote, but this reference was not fetched.", 
+                throw new MergeFetchHeadNotFoundException("The current branch is configured to merge with the reference '{0}' from the remote, but this reference was not fetched.",
                     expectedRef);
             }
 


### PR DESCRIPTION
By default when initializing a new repository, the initial head is set to be whatever the globally configured value from `init.defaultBranch`. LibGit2Sharp was already exposing the `InitialHead` pointer to pass a value down to `libgit2` however it was not being exposed through the managed classes.
This change introduces an `InitOptions` class to provide this optional parameter.