### PR TITLE
Added ObjectDatabase.MergeTrees() 

### DIFF
--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -1952,6 +1952,15 @@ namespace LibGit2Sharp.Core
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string prefix);
 
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern unsafe int git_merge_trees(
+            out git_index* outIndex,
+            git_repository* repo,
+            git_object* ancestorTree,
+            git_object* ourTree,
+            git_object* theirTree,
+            ref GitMergeOpts options);
+
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe uint git_tree_entry_filemode(git_tree_entry* entry);
 
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -3245,6 +3245,24 @@ namespace LibGit2Sharp.Core
 
 #region git_tree_
 
+        public static unsafe IndexHandle git_merge_trees(RepositoryHandle repo, ObjectHandle ancestorTree,
+            ObjectHandle ourTree, ObjectHandle theirTree, GitMergeOpts opts, out bool earlyStop)
+        {
+            git_index* index;
+            int res = NativeMethods.git_merge_trees(out index, repo, ancestorTree, ourTree, theirTree, ref opts);
+            if (res == (int)GitErrorCode.MergeConflict)
+            {
+                earlyStop = true;
+            }
+            else
+            {
+                earlyStop = false;
+                Ensure.ZeroResult(res);
+            }
+
+            return new IndexHandle(index, true);
+        }
+
         public static unsafe Mode git_tree_entry_attributes(git_tree_entry* entry)
         {
             return (Mode)NativeMethods.git_tree_entry_filemode(entry);


### PR DESCRIPTION
This wraps the libgit2 function git_merge_trees() and so allows one to merge trees directly (specifying the ancestor tree to use in the 3-way merge). This functionality currently does not seem to be possible in libgit2sharp since the merge methods always take commits and _do not allow to specify the ancestor_. So, for instance, if I want to compute an octopus-merge ancestor and then iteratively merge N commits relative to this ancestor, then I cannot currently do this. With MergeTrees() one can. Later, one may write the resulting index to a tree via Index.WriteToTree() and create a commit with ObjectDatabase.CreateCommit().
Notes:
1) I added MergeTrees() to ObjectDatabase, not directly on Repository, because it seemed more low-level.
2) Internally I use ObjectHandle for trees (not a new "TreeHandle" via git_tree_lookup) - this seems to be how it's done everywhere else that uses Tree and it doesn't seem to matter in any case since libgit2 treats trees as objects.
3) I added 5 unit tests, which are basically the same unit tests as the existing merge ones for commits (I copied & adapted them), but with merging on the level of commits replaced with merging on the level of the corresponding trees.