### PR TITLE
Remove git protocol from test data

### DIFF
--- a/LibGit2Sharp.Tests/CloneFixture.cs
+++ b/LibGit2Sharp.Tests/CloneFixture.cs
@@ -208,29 +208,29 @@ namespace LibGit2Sharp.Tests
             };
         }
 
-        [Theory]
-        [InlineData("https://libgit2@bitbucket.org/libgit2/testgitrepository.git", "libgit3", "libgit3", true)]
-        [InlineData("https://libgit2@bitbucket.org/libgit2/testgitrepository.git", "libgit3", "libgit3", false)]
-        public void CanCloneFromBBWithCredentials(string url, string user, string pass, bool secure)
-        {
-            var scd = BuildSelfCleaningDirectory();
+        //[Theory]
+        //[InlineData("https://libgit2@bitbucket.org/libgit2/testgitrepository.git", "libgit3", "libgit3", true)]
+        //[InlineData("https://libgit2@bitbucket.org/libgit2/testgitrepository.git", "libgit3", "libgit3", false)]
+        //public void CanCloneFromBBWithCredentials(string url, string user, string pass, bool secure)
+        //{
+        //    var scd = BuildSelfCleaningDirectory();
 
-            string clonedRepoPath = Repository.Clone(url, scd.DirectoryPath, new CloneOptions()
-            {
-                CredentialsProvider = (_url, _user, _cred) => CreateUsernamePasswordCredentials(user, pass, secure)
-            });
+        //    string clonedRepoPath = Repository.Clone(url, scd.DirectoryPath, new CloneOptions()
+        //    {
+        //        CredentialsProvider = (_url, _user, _cred) => CreateUsernamePasswordCredentials(user, pass, secure)
+        //    });
 
-            using (var repo = new Repository(clonedRepoPath))
-            {
-                string dir = repo.Info.Path;
-                Assert.True(Path.IsPathRooted(dir));
-                Assert.True(Directory.Exists(dir));
+        //    using (var repo = new Repository(clonedRepoPath))
+        //    {
+        //        string dir = repo.Info.Path;
+        //        Assert.True(Path.IsPathRooted(dir));
+        //        Assert.True(Directory.Exists(dir));
 
-                Assert.NotNull(repo.Info.WorkingDirectory);
-                Assert.Equal(Path.Combine(scd.RootedDirectoryPath, ".git" + Path.DirectorySeparatorChar), repo.Info.Path);
-                Assert.False(repo.Info.IsBare);
-            }
-        }
+        //        Assert.NotNull(repo.Info.WorkingDirectory);
+        //        Assert.Equal(Path.Combine(scd.RootedDirectoryPath, ".git" + Path.DirectorySeparatorChar), repo.Info.Path);
+        //        Assert.False(repo.Info.IsBare);
+        //    }
+        //}
 
         [SkippableTheory]
         [InlineData("https://github.com/libgit2/TestGitRepository.git", "github.com", typeof(CertificateX509))]

--- a/LibGit2Sharp.Tests/CloneFixture.cs
+++ b/LibGit2Sharp.Tests/CloneFixture.cs
@@ -13,8 +13,6 @@ namespace LibGit2Sharp.Tests
         [Theory]
         [InlineData("http://github.com/libgit2/TestGitRepository")]
         [InlineData("https://github.com/libgit2/TestGitRepository")]
-        [InlineData("git://github.com/libgit2/TestGitRepository")]
-        //[InlineData("git@github.com:libgit2/TestGitRepository")]
         public void CanClone(string url)
         {
             var scd = BuildSelfCleaningDirectory();
@@ -102,8 +100,6 @@ namespace LibGit2Sharp.Tests
         [Theory]
         [InlineData("http://github.com/libgit2/TestGitRepository")]
         [InlineData("https://github.com/libgit2/TestGitRepository")]
-        [InlineData("git://github.com/libgit2/TestGitRepository")]
-        //[InlineData("git@github.com:libgit2/TestGitRepository")]
         public void CanCloneBarely(string url)
         {
             var scd = BuildSelfCleaningDirectory();
@@ -126,7 +122,7 @@ namespace LibGit2Sharp.Tests
         }
 
         [Theory]
-        [InlineData("git://github.com/libgit2/TestGitRepository")]
+        [InlineData("https://github.com/libgit2/TestGitRepository")]
         public void WontCheckoutIfAskedNotTo(string url)
         {
             var scd = BuildSelfCleaningDirectory();
@@ -143,7 +139,7 @@ namespace LibGit2Sharp.Tests
         }
 
         [Theory]
-        [InlineData("git://github.com/libgit2/TestGitRepository")]
+        [InlineData("https://github.com/libgit2/TestGitRepository")]
         public void CallsProgressCallbacks(string url)
         {
             bool transferWasCalled = false;
@@ -301,7 +297,7 @@ namespace LibGit2Sharp.Tests
         }
 
         [Theory]
-        [InlineData("git://github.com/libgit2/TestGitRepository")]
+        [InlineData("https://github.com/libgit2/TestGitRepository")]
         public void CloningWithoutWorkdirPathThrows(string url)
         {
             Assert.Throws<ArgumentNullException>(() => Repository.Clone(url, null));

--- a/LibGit2Sharp.Tests/FetchFixture.cs
+++ b/LibGit2Sharp.Tests/FetchFixture.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using LibGit2Sharp.Tests.TestHelpers;
 using Xunit;
-using Xunit.Extensions;
 
 namespace LibGit2Sharp.Tests
 {
@@ -15,7 +14,6 @@ namespace LibGit2Sharp.Tests
         [Theory]
         [InlineData("http://github.com/libgit2/TestGitRepository")]
         [InlineData("https://github.com/libgit2/TestGitRepository")]
-        [InlineData("git://github.com/libgit2/TestGitRepository.git")]
         public void CanFetchIntoAnEmptyRepository(string url)
         {
             string path = InitNewRepository();
@@ -74,7 +72,6 @@ namespace LibGit2Sharp.Tests
         [Theory]
         [InlineData("http://github.com/libgit2/TestGitRepository")]
         [InlineData("https://github.com/libgit2/TestGitRepository")]
-        [InlineData("git://github.com/libgit2/TestGitRepository.git")]
         public void CanFetchAllTagsIntoAnEmptyRepository(string url)
         {
             string path = InitNewRepository();
@@ -101,7 +98,8 @@ namespace LibGit2Sharp.Tests
                 }
 
                 // Perform the actual fetch
-                Commands.Fetch(repo, remoteName, new string[0], new FetchOptions {
+                Commands.Fetch(repo, remoteName, new string[0], new FetchOptions
+                {
                     TagFetchMode = TagFetchMode.All,
                     OnUpdateTips = expectedFetchState.RemoteUpdateTipsHandler
                 }, null);
@@ -117,7 +115,6 @@ namespace LibGit2Sharp.Tests
         [Theory]
         [InlineData("http://github.com/libgit2/TestGitRepository", "test-branch", "master")]
         [InlineData("https://github.com/libgit2/TestGitRepository", "master", "master")]
-        [InlineData("git://github.com/libgit2/TestGitRepository.git", "master", "first-merge")]
         public void CanFetchCustomRefSpecsIntoAnEmptyRepository(string url, string localBranchName, string remoteBranchName)
         {
             string path = InitNewRepository();
@@ -147,7 +144,8 @@ namespace LibGit2Sharp.Tests
                 }
 
                 // Perform the actual fetch
-                Commands.Fetch(repo, remoteName, new string[] { refSpec }, new FetchOptions {
+                Commands.Fetch(repo, remoteName, new string[] { refSpec }, new FetchOptions
+                {
                     TagFetchMode = TagFetchMode.None,
                     OnUpdateTips = expectedFetchState.RemoteUpdateTipsHandler
                 }, null);

--- a/LibGit2Sharp.Tests/NetworkFixture.cs
+++ b/LibGit2Sharp.Tests/NetworkFixture.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using LibGit2Sharp.Tests.TestHelpers;
 using Xunit;
-using Xunit.Extensions;
 
 namespace LibGit2Sharp.Tests
 {
@@ -12,7 +11,6 @@ namespace LibGit2Sharp.Tests
         [Theory]
         [InlineData("http://github.com/libgit2/TestGitRepository")]
         [InlineData("https://github.com/libgit2/TestGitRepository")]
-        [InlineData("git://github.com/libgit2/TestGitRepository.git")]
         public void CanListRemoteReferences(string url)
         {
             string remoteName = "testRemote";
@@ -49,7 +47,6 @@ namespace LibGit2Sharp.Tests
         [Theory]
         [InlineData("http://github.com/libgit2/TestGitRepository")]
         [InlineData("https://github.com/libgit2/TestGitRepository")]
-        [InlineData("git://github.com/libgit2/TestGitRepository.git")]
         public void CanListRemoteReferencesFromUrl(string url)
         {
             string repoPath = InitNewRepository();
@@ -94,9 +91,9 @@ namespace LibGit2Sharp.Tests
                 Remote remote = repo.Network.Remotes[remoteName];
                 IEnumerable<Reference> references = repo.Network.ListReferences(remote).ToList();
 
-                var actualRefs = new List<Tuple<string,string>>();
+                var actualRefs = new List<Tuple<string, string>>();
 
-                foreach(Reference reference in references)
+                foreach (Reference reference in references)
                 {
                     Assert.NotNull(reference.CanonicalName);
 
@@ -166,7 +163,7 @@ namespace LibGit2Sharp.Tests
 
                 MergeResult mergeResult = Commands.Pull(repo, Constants.Signature, pullOptions);
 
-                if(fastForwardStrategy == FastForwardStrategy.Default || fastForwardStrategy == FastForwardStrategy.FastForwardOnly)
+                if (fastForwardStrategy == FastForwardStrategy.Default || fastForwardStrategy == FastForwardStrategy.FastForwardOnly)
                 {
                     Assert.Equal(MergeStatus.FastForward, mergeResult.Status);
                     Assert.Equal(mergeResult.Commit, repo.Branches["refs/remotes/origin/master"].Tip);
@@ -226,7 +223,7 @@ namespace LibGit2Sharp.Tests
                 {
                     Commands.Pull(repo, Constants.Signature, new PullOptions());
                 }
-                catch(MergeFetchHeadNotFoundException ex)
+                catch (MergeFetchHeadNotFoundException ex)
                 {
                     didPullThrow = true;
                     thrownException = ex;
@@ -293,7 +290,7 @@ namespace LibGit2Sharp.Tests
                 Assert.NotNull(repo.Refs["refs/remotes/pruner/master"]);
 
                 // but we do when asked by the user
-                Commands.Fetch(repo, "pruner", new string[0], new FetchOptions { Prune = true}, null);
+                Commands.Fetch(repo, "pruner", new string[0], new FetchOptions { Prune = true }, null);
                 Assert.Null(repo.Refs["refs/remotes/pruner/master"]);
             }
         }

--- a/LibGit2Sharp.Tests/RepositoryFixture.cs
+++ b/LibGit2Sharp.Tests/RepositoryFixture.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using LibGit2Sharp.Tests.TestHelpers;
 using Xunit;
-using Xunit.Extensions;
 
 namespace LibGit2Sharp.Tests
 {
@@ -709,7 +708,6 @@ namespace LibGit2Sharp.Tests
         [Theory]
         [InlineData("http://github.com/libgit2/TestGitRepository")]
         [InlineData("https://github.com/libgit2/TestGitRepository")]
-        [InlineData("git://github.com/libgit2/TestGitRepository.git")]
         public void CanListRemoteReferences(string url)
         {
             IEnumerable<Reference> references = Repository.ListRemoteReferences(url).ToList();

--- a/LibGit2Sharp.Tests/desktop/SmartSubtransportFixture.cs
+++ b/LibGit2Sharp.Tests/desktop/SmartSubtransportFixture.cs
@@ -4,9 +4,7 @@ using System.IO;
 using System.Net;
 using System.Net.Security;
 using LibGit2Sharp.Tests.TestHelpers;
-using LibGit2Sharp.Core;
 using Xunit;
-using Xunit.Extensions;
 
 namespace LibGit2Sharp.Tests
 {
@@ -79,58 +77,58 @@ namespace LibGit2Sharp.Tests
             }
         }
 
-        [Theory]
-        [InlineData("https", "https://bitbucket.org/libgit2/testgitrepository.git", "libgit3", "libgit3")]
-        public void CanUseCredentials(string scheme, string url, string user, string pass)
-        {
-            string remoteName = "testRemote";
+        //[Theory]
+        //[InlineData("https", "https://bitbucket.org/libgit2/testgitrepository.git", "libgit3", "libgit3")]
+        //public void CanUseCredentials(string scheme, string url, string user, string pass)
+        //{
+        //    string remoteName = "testRemote";
 
-            var scd = BuildSelfCleaningDirectory();
-            Repository.Init(scd.RootedDirectoryPath);
+        //    var scd = BuildSelfCleaningDirectory();
+        //    Repository.Init(scd.RootedDirectoryPath);
 
-            SmartSubtransportRegistration<MockSmartSubtransport> registration = null;
+        //    SmartSubtransportRegistration<MockSmartSubtransport> registration = null;
 
-            try
-            {
-                // Disable server certificate validation for testing.
-                // Do *NOT* enable this in production.
-                ServicePointManager.ServerCertificateValidationCallback = certificateValidationCallback;
+        //    try
+        //    {
+        //        // Disable server certificate validation for testing.
+        //        // Do *NOT* enable this in production.
+        //        ServicePointManager.ServerCertificateValidationCallback = certificateValidationCallback;
 
-                registration = GlobalSettings.RegisterSmartSubtransport<MockSmartSubtransport>(scheme);
-                Assert.NotNull(registration);
+        //        registration = GlobalSettings.RegisterSmartSubtransport<MockSmartSubtransport>(scheme);
+        //        Assert.NotNull(registration);
 
-                using (var repo = new Repository(scd.DirectoryPath))
-                {
-                    repo.Network.Remotes.Add(remoteName, url);
+        //        using (var repo = new Repository(scd.DirectoryPath))
+        //        {
+        //            repo.Network.Remotes.Add(remoteName, url);
 
-                    // Set up structures for the expected results
-                    // and verifying the RemoteUpdateTips callback.
-                    TestRemoteInfo expectedResults = TestRemoteInfo.TestRemoteInstance;
-                    ExpectedFetchState expectedFetchState = new ExpectedFetchState(remoteName);
+        //            // Set up structures for the expected results
+        //            // and verifying the RemoteUpdateTips callback.
+        //            TestRemoteInfo expectedResults = TestRemoteInfo.TestRemoteInstance;
+        //            ExpectedFetchState expectedFetchState = new ExpectedFetchState(remoteName);
 
-                    // Add expected branch objects
-                    foreach (KeyValuePair<string, ObjectId> kvp in expectedResults.BranchTips)
-                    {
-                        expectedFetchState.AddExpectedBranch(kvp.Key, ObjectId.Zero, kvp.Value);
-                    }
+        //            // Add expected branch objects
+        //            foreach (KeyValuePair<string, ObjectId> kvp in expectedResults.BranchTips)
+        //            {
+        //                expectedFetchState.AddExpectedBranch(kvp.Key, ObjectId.Zero, kvp.Value);
+        //            }
 
-                    // Perform the actual fetch
-                    Commands.Fetch(repo, remoteName, new string[0], new FetchOptions {
-                        OnUpdateTips = expectedFetchState.RemoteUpdateTipsHandler, TagFetchMode = TagFetchMode.Auto,
-                        CredentialsProvider = (_user, _valid, _hostname) => new UsernamePasswordCredentials() { Username = user, Password = pass },
-                    }, null);
+        //            // Perform the actual fetch
+        //            Commands.Fetch(repo, remoteName, new string[0], new FetchOptions {
+        //                OnUpdateTips = expectedFetchState.RemoteUpdateTipsHandler, TagFetchMode = TagFetchMode.Auto,
+        //                CredentialsProvider = (_user, _valid, _hostname) => new UsernamePasswordCredentials() { Username = user, Password = pass },
+        //            }, null);
 
-                    // Verify the expected
-                    expectedFetchState.CheckUpdatedReferences(repo);
-                }
-            }
-            finally
-            {
-                GlobalSettings.UnregisterSmartSubtransport(registration);
+        //            // Verify the expected
+        //            expectedFetchState.CheckUpdatedReferences(repo);
+        //        }
+        //    }
+        //    finally
+        //    {
+        //        GlobalSettings.UnregisterSmartSubtransport(registration);
 
-                ServicePointManager.ServerCertificateValidationCallback -= certificateValidationCallback;
-            }
-        }
+        //        ServicePointManager.ServerCertificateValidationCallback -= certificateValidationCallback;
+        //    }
+        //}
 
         [Fact]
         public void CannotReregisterScheme()


### PR DESCRIPTION
[GitHub disabled the git protocol on March 15, 2022](https://github.blog/2021-09-01-improving-git-protocol-security-github), so this PR removes it from the test data.

In theory, we could set up some non-GitHub repo to continue to test this, but it doesn't really seem worth the effort.

I've also commented out the Bitbucket tests because it appears something has changed in regards to the credentials required.