### PR TITLE
Update LibGit2Sharp.NativeBinaries to 2.0.315

### DIFF
--- a/LibGit2Sharp/Core/GitFetchOptions.cs
+++ b/LibGit2Sharp/Core/GitFetchOptions.cs
@@ -11,6 +11,7 @@ namespace LibGit2Sharp.Core
         public bool UpdateFetchHead = true;
         public TagFetchMode download_tags;
         public GitProxyOptions ProxyOptions;
+        public RemoteFollowRedirects FollowRedirects;
         public GitStrArrayManaged CustomHeaders;
     }
 }

--- a/LibGit2Sharp/Core/GitPushOptions.cs
+++ b/LibGit2Sharp/Core/GitPushOptions.cs
@@ -9,6 +9,7 @@ namespace LibGit2Sharp.Core
         public int PackbuilderDegreeOfParallelism;
         public GitRemoteCallbacks RemoteCallbacks;
         public GitProxyOptions ProxyOptions;
+        public RemoteFollowRedirects FollowRedirects;
         public GitStrArrayManaged CustomHeaders;
     }
 }

--- a/LibGit2Sharp/Core/GitStatusOptions.cs
+++ b/LibGit2Sharp/Core/GitStatusOptions.cs
@@ -15,6 +15,8 @@ namespace LibGit2Sharp.Core
 
         public IntPtr Baseline = IntPtr.Zero;
 
+        public ushort RenameThreshold = 50;
+
         public void Dispose()
         {
             PathSpec.Dispose();

--- a/LibGit2Sharp/Core/GitWorktree.cs
+++ b/LibGit2Sharp/Core/GitWorktree.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace LibGit2Sharp.Core
 {
@@ -37,6 +35,8 @@ namespace LibGit2Sharp.Core
         public int locked;
 
         public IntPtr @ref = IntPtr.Zero;
+
+        public GitCheckoutOpts checkout_options;
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/LibGit2Sharp/Core/RemoteFollowRedirects.cs
+++ b/LibGit2Sharp/Core/RemoteFollowRedirects.cs
@@ -1,0 +1,10 @@
+﻿namespace LibGit2Sharp.Core
+{
+    internal enum RemoteFollowRedirects
+    {
+        Unspecified = 0,
+        None = 1,
+        Initial = 2,
+        All = 4
+    }
+}

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="[2.0.315-alpha.0.9]" PrivateAssets="none" />
+    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="[2.0.315]" PrivateAssets="none" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.220" PrivateAssets="all" />
   </ItemGroup>

--- a/LibGit2Sharp/WorktreeCollection.cs
+++ b/LibGit2Sharp/WorktreeCollection.cs
@@ -1,12 +1,10 @@
-﻿using LibGit2Sharp.Core;
-using LibGit2Sharp.Core.Handles;
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
-using System.IO;
 using System.Linq;
-using System.Text;
+using LibGit2Sharp.Core;
+using LibGit2Sharp.Core.Handles;
 
 namespace LibGit2Sharp
 {
@@ -48,7 +46,7 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="committishOrBranchSpec"></param>
         /// <param name="name"></param>
@@ -57,7 +55,7 @@ namespace LibGit2Sharp
         /// <returns></returns>
         public virtual Worktree Add(string committishOrBranchSpec, string name, string path, bool isLocked)
         {
-            if(string.Equals(committishOrBranchSpec, name))
+            if (string.Equals(committishOrBranchSpec, name))
             {
                 // Proxy.git_worktree_add() creates a new branch of name = name, so if we want to checkout a given branch then the 'name' cannot be the same as the target branch
                 return null;
@@ -66,7 +64,8 @@ namespace LibGit2Sharp
             git_worktree_add_options options = new git_worktree_add_options
             {
                 version = 1,
-                locked = Convert.ToInt32(isLocked)
+                locked = Convert.ToInt32(isLocked),
+                checkout_options = new GitCheckoutOpts { version = 1 }
             };
 
             using (var handle = Proxy.git_worktree_add(repo.Handle, name, path, options))
@@ -83,13 +82,13 @@ namespace LibGit2Sharp
                 }
             }
 
-            
 
-            return this[name]; 
+
+            return this[name];
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="name"></param>
         /// <param name="path"></param>
@@ -99,7 +98,8 @@ namespace LibGit2Sharp
             git_worktree_add_options options = new git_worktree_add_options
             {
                 version = 1,
-                locked = Convert.ToInt32(isLocked)
+                locked = Convert.ToInt32(isLocked),
+                checkout_options = new GitCheckoutOpts { version = 1 }
             };
 
             using (var handle = Proxy.git_worktree_add(repo.Handle, name, path, options))
@@ -112,7 +112,7 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="worktree"></param>
         /// <returns></returns>
@@ -122,7 +122,7 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="worktree"></param>
         /// <param name="ifLocked"></param>


### PR DESCRIPTION
This update is libgit2 [1.4.2](https://github.com/libgit2/libgit2/releases/tag/v1.4.2).
