### PR TITLE
Make GIT_DIFF_SHOW_BINARY flag settable by users through CompareOptions

### DIFF
--- a/LibGit2Sharp/CompareOptions.cs
+++ b/LibGit2Sharp/CompareOptions.cs
@@ -50,5 +50,11 @@ namespace LibGit2Sharp
         /// By default, this option will be false.
         /// </summary>
         public bool IndentHeuristic { get; set; }
+
+        /// <summary>
+        /// Include the necessary deflate / delta information so that `git-apply`
+        /// can apply given diff information to binary files.
+        /// </summary>
+        public bool ShowBinary { get; set; }
     }
 }

--- a/LibGit2Sharp/Diff.cs
+++ b/LibGit2Sharp/Diff.cs
@@ -63,6 +63,11 @@ namespace LibGit2Sharp
                 options.Flags |= GitDiffOptionFlags.GIT_DIFF_DISABLE_PATHSPEC_MATCH;
             }
 
+            if (compareOptions.ShowBinary)
+            {
+                options.Flags |= GitDiffOptionFlags.GIT_DIFF_SHOW_BINARY;
+            }
+
             if (compareOptions.IndentHeuristic)
             {
                 options.Flags |= GitDiffOptionFlags.GIT_DIFF_INDENT_HEURISTIC;


### PR DESCRIPTION
Addresses [Bug#1966](https://github.com/libgit2/libgit2sharp/issues/1966) 
Scenario: 

Need to create a patch file that contains binary deltas using `Diff.Compare<T>` function.  This is needed for binary files to be created/updated when calling `git apply` using the generated patch file. 

Effort:

The necessary flag already existed in `Core.GitDiff.GitDiffOptionFlags` (`GIT_DIFF_SHOW_BINARY`) and some quick research showed that this flag is recognized by the `libgit2` library.   To give library users access to this flag I added it as a property of the `CompareOptions` class (`ShowBinary`) defaults false and maintains current expected functionality. Finally checking the value of `CompareOptions.ShowBinary` in the function `Diff.BuildOptions` so that the options are populated with this flag before being passed through to `libgit2`

Outcome: 

If an instance of `CompareOptions` with the `ShowBinary` flag set to true is passed to any overload of `Diff.Compare<Patch>` that takes `CompareOptions` as a parameter, the resulting patch will have the necessary delta to create/update binary files when it is applied.

Testing: 

Added 2 test scenarios: 

1. confirm that the default behaviour for binaries has not changed. 
2. confirm that if the ShowBinary flag is set to true that the diff contains delta information as expected

ran the full test suite to verify nothing was broken by this change.