### PR TITLE
Add implementation for git_remote_default_branch

### DIFF
--- a/LibGit2Sharp.Tests/NetworkFixture.cs
+++ b/LibGit2Sharp.Tests/NetworkFixture.cs
@@ -11,6 +11,44 @@ namespace LibGit2Sharp.Tests
         [Theory]
         [InlineData("http://github.com/libgit2/TestGitRepository")]
         [InlineData("https://github.com/libgit2/TestGitRepository")]
+        public void CanFetchDefaultBranchName(string url)
+        {
+            string remoteName = "testRemote";
+
+            string expectedDefaultBranchName = TestRemoteRefs.ExpectedRemoteRefs
+                .First(remoteRef => remoteRef.Item3).Item1;
+
+            string repoPath = InitNewRepository();
+
+            using (var repo = new Repository(repoPath))
+            {
+                Remote remote = repo.Network.Remotes.Add(remoteName, url);
+
+                string defaultBranchName = repo.Network.DefaultBranchName(remote);
+                Assert.Equal(expectedDefaultBranchName, defaultBranchName);
+            }
+        }
+
+        [Theory]
+        [InlineData("http://github.com/libgit2/TestGitRepository")]
+        [InlineData("https://github.com/libgit2/TestGitRepository")]
+        public void CanFetchDefaultBranchNameFromUrl(string url)
+        {
+            string expectedDefaultBranchName = TestRemoteRefs.ExpectedRemoteRefs
+                .First(remoteRef => remoteRef.Item3).Item1;
+
+            string repoPath = InitNewRepository();
+
+            using (var repo = new Repository(repoPath))
+            {
+                string defaultBranchName = repo.Network.DefaultBranchName(url);
+                Assert.Equal(expectedDefaultBranchName, defaultBranchName);
+            }
+        }
+
+        [Theory]
+        [InlineData("http://github.com/libgit2/TestGitRepository")]
+        [InlineData("https://github.com/libgit2/TestGitRepository")]
         public void CanListRemoteReferences(string url)
         {
             string remoteName = "testRemote";

--- a/LibGit2Sharp.Tests/TestHelpers/TestRemoteRefs.cs
+++ b/LibGit2Sharp.Tests/TestHelpers/TestRemoteRefs.cs
@@ -20,17 +20,17 @@ namespace LibGit2Sharp.Tests.TestHelpers
         /// <summary>
         /// Expected references on http://github.com/libgit2/TestGitRepository
         /// </summary>
-        public static List<Tuple<string, string>> ExpectedRemoteRefs = new List<Tuple<string, string>>()
+        public static List<Tuple<string, string, bool>> ExpectedRemoteRefs = new List<Tuple<string, string, bool>>()
         {
-            new Tuple<string, string>("HEAD", "49322bb17d3acc9146f98c97d078513228bbf3c0"),
-            new Tuple<string, string>("refs/heads/first-merge", "0966a434eb1a025db6b71485ab63a3bfbea520b6"),
-            new Tuple<string, string>("refs/heads/master", "49322bb17d3acc9146f98c97d078513228bbf3c0"),
-            new Tuple<string, string>("refs/heads/no-parent", "42e4e7c5e507e113ebbb7801b16b52cf867b7ce1"),
-            new Tuple<string, string>("refs/tags/annotated_tag", "d96c4e80345534eccee5ac7b07fc7603b56124cb"),
-            new Tuple<string, string>("refs/tags/annotated_tag^{}", "c070ad8c08840c8116da865b2d65593a6bb9cd2a"),
-            new Tuple<string, string>("refs/tags/blob", "55a1a760df4b86a02094a904dfa511deb5655905"),
-            new Tuple<string, string>("refs/tags/commit_tree", "8f50ba15d49353813cc6e20298002c0d17b0a9ee"),
-            new Tuple<string, string>("refs/tags/nearly-dangling", "6e0c7bdb9b4ed93212491ee778ca1c65047cab4e"),
+            new Tuple<string, string, bool>("HEAD", "49322bb17d3acc9146f98c97d078513228bbf3c0", false),
+            new Tuple<string, string, bool>("refs/heads/first-merge", "0966a434eb1a025db6b71485ab63a3bfbea520b6", false),
+            new Tuple<string, string, bool>("refs/heads/master", "49322bb17d3acc9146f98c97d078513228bbf3c0", true),
+            new Tuple<string, string, bool>("refs/heads/no-parent", "42e4e7c5e507e113ebbb7801b16b52cf867b7ce1", false),
+            new Tuple<string, string, bool>("refs/tags/annotated_tag", "d96c4e80345534eccee5ac7b07fc7603b56124cb", false),
+            new Tuple<string, string, bool>("refs/tags/annotated_tag^{}", "c070ad8c08840c8116da865b2d65593a6bb9cd2a", false),
+            new Tuple<string, string, bool>("refs/tags/blob", "55a1a760df4b86a02094a904dfa511deb5655905", false),
+            new Tuple<string, string, bool>("refs/tags/commit_tree", "8f50ba15d49353813cc6e20298002c0d17b0a9ee", false),
+            new Tuple<string, string, bool>("refs/tags/nearly-dangling", "6e0c7bdb9b4ed93212491ee778ca1c65047cab4e", false),
         };
     }
 }

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -1392,6 +1392,9 @@ namespace LibGit2Sharp.Core
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string refspec);
 
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern unsafe int git_remote_default_branch(GitBuf buf, git_remote* remote);
+
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_remote_delete(
             git_repository* repo,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string name);

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -2179,6 +2179,23 @@ namespace LibGit2Sharp.Core
             }
         }
 
+        public static unsafe string git_remote_default_branch(RemoteHandle remote)
+        {
+            using (var buf = new GitBuf())
+            {
+                int res = NativeMethods.git_remote_default_branch(buf, remote);
+
+                if (res == (int)GitErrorCode.NotFound)
+                {
+                    return null;
+                }
+
+                Ensure.ZeroResult(res);
+
+                return LaxUtf8Marshaler.FromNative(buf.ptr) ?? string.Empty;
+            }
+        }
+
         public static unsafe void git_remote_delete(RepositoryHandle repo, string name)
         {
             int res = NativeMethods.git_remote_delete(repo, name);

--- a/LibGit2Sharp/Network.cs
+++ b/LibGit2Sharp/Network.cs
@@ -38,6 +38,76 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
+        /// Lookup the default branch name in a Remote repository
+        /// </summary>
+        /// <param name="remote"><The <see cref="Remote"/> to get the default branch from.</param>
+        /// <returns>The canonical name of the Remote repository's default branch.</returns>
+        public virtual string DefaultBranchName(Remote remote)
+        {
+            Ensure.ArgumentNotNull(remote, "remote");
+
+            return DefaultBranchNameInternal(remote.Url, null);
+        }
+
+        /// <summary>
+        /// Lookup the default branch name in a Remote repository
+        /// </summary>
+        /// <param name="remote"><The <see cref="Remote"/> to get the default branch from.</param>
+        /// <param name="remote"><The <see cref="Func{Credentials}"/> used to connect to the remote repository.</param>
+        /// <returns>The canonical name of the Remote repository's default branch.</returns>
+        public virtual string DefaultBranchName(Remote remote, CredentialsHandler credentialsProvider)
+        {
+            Ensure.ArgumentNotNull(remote, "remote");
+            Ensure.ArgumentNotNull(credentialsProvider, "credentialsProvider");
+
+            return DefaultBranchNameInternal(remote.Url, credentialsProvider);
+        }
+
+        /// <summary>
+        /// Lookup the default branch name in a Remote repository
+        /// </summary>
+        /// <param name="remote"><The url to get the default branch from.</param>
+        /// <returns>The canonical name of the Remote repository's default branch.</returns>
+        public virtual string DefaultBranchName(string url)
+        {
+            Ensure.ArgumentNotNull(url, "url");
+
+            return DefaultBranchNameInternal(url, null);
+        }
+
+        /// <summary>
+        /// Lookup the default branch name in a Remote repository
+        /// </summary>
+        /// <param name="remote"><The url to get the default branch from.</param>
+        /// <param name="remote"><The <see cref="Func{Credentials}"/> used to connect to the remote repository.</param>
+        /// <returns>The canonical name of the Remote repository's default branch.</returns>
+        public virtual string DefaultBranchName(string url, CredentialsHandler credentialsProvider)
+        {
+            Ensure.ArgumentNotNull(url, "url");
+            Ensure.ArgumentNotNull(credentialsProvider, "credentialsProvider");
+
+            return DefaultBranchNameInternal(url, credentialsProvider);
+        }
+
+        private string DefaultBranchNameInternal(string url, CredentialsHandler credentialsProvider)
+        {
+            using (RemoteHandle remoteHandle = BuildRemoteHandle(repository.Handle, url))
+            {
+                GitRemoteCallbacks gitCallbacks = new GitRemoteCallbacks { version = 1 };
+                GitProxyOptions proxyOptions = new GitProxyOptions { Version = 1 };
+
+                if (credentialsProvider != null)
+                {
+                    var callbacks = new RemoteCallbacks(credentialsProvider);
+                    gitCallbacks = callbacks.GenerateCallbacks();
+                }
+
+                Proxy.git_remote_connect(remoteHandle, GitDirection.Fetch, ref gitCallbacks, ref proxyOptions);
+                return Proxy.git_remote_default_branch(remoteHandle);
+            }
+        }
+
+        /// <summary>
         /// List references in a <see cref="Remote"/> repository.
         /// <para>
         /// When the remote tips are ahead of the local ones, the retrieved


### PR DESCRIPTION
Implements the feature requested in #1796

This fetches the default branch from a remote repository. This is useful to detect changes, and when remotes are added following initialization.