### PR TITLE
[Proposal] Add git_blame_buffer

### DIFF
--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -191,6 +191,13 @@ namespace LibGit2Sharp.Core
             git_blame_options options);
 
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern unsafe int git_blame_buffer(
+            out git_blame* blame,
+            git_blame* reference,
+            IntPtr buffer,
+            UIntPtr len);
+
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe void git_blame_free(git_blame* blame);
 
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -35,6 +35,27 @@ namespace LibGit2Sharp.Core
             return NativeMethods.git_blame_get_hunk_byindex(blame, idx);
         }
 
+        public static unsafe BlameHandle git_blame_buffer(
+            RepositoryHandle repo,
+            BlameHandle reference,
+            byte[] buffer)
+        {
+            git_blame* ptr;
+            int res;
+
+            unsafe
+            {
+                fixed (byte* p = buffer)
+                {
+                    res = NativeMethods.git_blame_buffer(out ptr, reference, (IntPtr)p, (UIntPtr)buffer.Length);
+                }
+            }
+
+            Ensure.ZeroResult(res);
+
+            return new BlameHandle(ptr, true);
+        }
+
         #endregion
 
         #region git_blob_


### PR DESCRIPTION
## Motivation and Background

I was trying to make a VS extension that implements something like GitLens on VSCode. If you don't know what that is that's ok. It has a lot of features, but the main thing that I use it for is to view per line blame along with the commit message like so:

<img width="738" alt="image" src="https://user-images.githubusercontent.com/8235156/181863190-3262b422-7bf4-461c-9335-10cf774f0c39.png">

I am using libgit2sharp to develop my extension. Currently I'm using `repo.Blame(filePath)` to get grab the `BlameHunkCollection` and display the message on a line using the VS extensibility api. `repo.Blame` uses `git_blame_file` under the hood and `git_blame_file` has a couple of issues for my usecase:

- It is really slow
- I can get an accurate blame result **only after** saving the file to disk. In other words, I cannot get the blame results for a file that is still being worked on/is open in memory

## Purpose of this PR

I am creating this PR to start a discussion for adding something similar to `git_blame_buffer` to `libgit2sharp`. There might be a better way to implement this functionality, and I would to get some feedback and bounce ideas to add this feature to the library in the best way possible.