### PR TITLE
Simplify getting dirty files in repository

### DIFF
--- a/LibGit2Sharp.Tests/StatusFixture.cs
+++ b/LibGit2Sharp.Tests/StatusFixture.cs
@@ -120,6 +120,7 @@ namespace LibGit2Sharp.Tests
                 Assert.NotNull(status);
                 Assert.Equal(6 + unalteredCount, status.Count());
                 Assert.True(status.IsDirty);
+                Assert.Equal(6, status.Dirty.Count());
 
                 Assert.Equal("new_untracked_file.txt", status.Untracked.Select(s => s.FilePath).Single());
                 Assert.Equal("modified_unstaged_file.txt", status.Modified.Select(s => s.FilePath).Single());
@@ -139,6 +140,7 @@ namespace LibGit2Sharp.Tests
                 Assert.NotNull(status2);
                 Assert.Equal(6 + unalteredCount, status2.Count());
                 Assert.True(status2.IsDirty);
+                Assert.Equal(6, status2.Dirty.Count());
 
                 Assert.Equal("new_untracked_file.txt", status2.Untracked.Select(s => s.FilePath).Single());
                 Assert.Equal(new[] { file, "modified_unstaged_file.txt" }, status2.Modified.Select(s => s.FilePath));
@@ -146,6 +148,19 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal("new_tracked_file.txt", status2.Added.Select(s => s.FilePath).Single());
                 Assert.Equal(file, status2.Staged.Select(s => s.FilePath).Single());
                 Assert.Equal("deleted_staged_file.txt", status2.Removed.Select(s => s.FilePath).Single());
+            }
+        }
+
+        [Fact]
+        public void CanRetrieveListOfDirtyFilesInWorkDir()
+        {
+            string path = SandboxStandardTestRepo();
+            using (var repo = new Repository(path))
+            {
+                RepositoryStatus status = repo.RetrieveStatus();
+                Assert.True(status.IsDirty);
+                Assert.Equal(6, status.Dirty.Count());
+                Assert.Equal(status.Where(s => s.IsDirty).Select(s => s.FilePath), status.Dirty.Select(s => s.FilePath));
             }
         }
 
@@ -264,6 +279,7 @@ namespace LibGit2Sharp.Tests
                 Assert.Empty(status.Added);
                 Assert.Empty(status.Staged);
                 Assert.Empty(status.Removed);
+                Assert.Empty(status.Dirty);
             }
         }
 
@@ -657,6 +673,7 @@ namespace LibGit2Sharp.Tests
                 RepositoryStatus status = repo.RetrieveStatus(new StatusOptions() { IncludeUnaltered = true });
 
                 Assert.False(status.IsDirty);
+                Assert.Empty(status.Dirty);
                 Assert.Equal(9, status.Count());
             }
         }

--- a/LibGit2Sharp/RepositoryStatus.cs
+++ b/LibGit2Sharp/RepositoryStatus.cs
@@ -27,6 +27,7 @@ namespace LibGit2Sharp
         private readonly List<StatusEntry> renamedInIndex = new List<StatusEntry>();
         private readonly List<StatusEntry> renamedInWorkDir = new List<StatusEntry>();
         private readonly List<StatusEntry> unaltered = new List<StatusEntry>();
+        private readonly List<StatusEntry> dirty = new List<StatusEntry>();
         private readonly bool isDirty;
 
         private readonly IDictionary<FileStatus, Action<RepositoryStatus, StatusEntry>> dispatcher = Build();
@@ -68,7 +69,8 @@ namespace LibGit2Sharp
                     AddStatusEntryForDelta(entry->status, entry->head_to_index, entry->index_to_workdir);
                 }
 
-                isDirty = statusEntries.Any(entry => entry.IsDirty);
+                dirty = statusEntries.Where(entry => entry.IsDirty).ToList();
+                isDirty = dirty.Any();
             }
         }
 
@@ -307,6 +309,14 @@ namespace LibGit2Sharp
         public virtual IEnumerable<StatusEntry> Unaltered
         {
             get { return unaltered; }
+        }
+
+        /// <summary>
+        /// List of files that alter the index or the working directory since the last commit.
+        /// </summary>
+        public virtual IEnumerable<StatusEntry> Dirty
+        {
+            get { return dirty; }
         }
 
         /// <summary>

--- a/LibGit2Sharp/RepositoryStatus.cs
+++ b/LibGit2Sharp/RepositoryStatus.cs
@@ -68,7 +68,7 @@ namespace LibGit2Sharp
                     AddStatusEntryForDelta(entry->status, entry->head_to_index, entry->index_to_workdir);
                 }
 
-                isDirty = statusEntries.Any(entry => entry.State != FileStatus.Ignored && entry.State != FileStatus.Unaltered);
+                isDirty = statusEntries.Any(entry => entry.IsDirty);
             }
         }
 

--- a/LibGit2Sharp/StatusEntry.cs
+++ b/LibGit2Sharp/StatusEntry.cs
@@ -42,6 +42,17 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
+        /// True if the <see cref="StatusEntry"/> has been altered since the last commit. False otherwise.
+        /// </summary>
+        public virtual bool IsDirty
+        {
+            get
+            {
+                return State != FileStatus.Ignored && State != FileStatus.Unaltered;
+            }
+        }
+
+        /// <summary>
         /// Gets the relative new filepath to the working directory of the file.
         /// </summary>
         public virtual string FilePath


### PR DESCRIPTION
A simple PR to help getting the dirty files in the repository.

**Background**: When getting a `RepositoryStatus`, we can use the `IsDirty` property to tell if the repository is dirty.
However, we don't have the same convenience to get the list of those dirty files.

Indeed, getting the actual list of dirty files would imply some duplicated logic in the client code, the same code that is present in the `RepositoryStatus` ctor to initialize the `IsDirty` prop. 

What I propose is two parts (and 2 independent commits):

1. Most importantly, we move the `IsDirty` detection inside a StatusEntry, by adding a property of the same name. Before, the detection was done inside the `RepositoryStatus` ctor, analyzing each StatusEntry `FileStatus`. Now each StatusEntry has the responsibility of telling whether it is dirty.

2. Least importantly, but I think it's nice, we add a `Dirty` collection inside `RepositoryStatus`, that is initialized with all the `IsDirty` StatusEntries

Before thos changes, a client code working with dirty files could look like this:
```csharp
if(repositoryStatus.IsDirty)
{
    var dirtyFiles = repositoryStatus
                         .Where(file => file.State != FileStatus.Ignored
                                     && file.State != FileStatus.Unaltered) // Duplicated Logic
}
```

With those two modifications, the client code would look like this:
```csharp
if(repositoryStatus.IsDirty)
{
    var dirtyFiles = repositoryStatus.Dirty;
}
```

I appreciate any feedback, let me know if anything need to be changed.