### PR TITLE
Include process-wide search path in default search

### DIFF
--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 using LibGit2Sharp.Core.Handles;
 
 // Restrict the set of directories where the native library is loaded from to safe directories.
-[assembly: DefaultDllImportSearchPaths(DllImportSearchPath.AssemblyDirectory | DllImportSearchPath.ApplicationDirectory | DllImportSearchPath.SafeDirectories)]
+[assembly: DefaultDllImportSearchPaths(DllImportSearchPath.AssemblyDirectory | DllImportSearchPath.ApplicationDirectory | DllImportSearchPath.UserDirectories | DllImportSearchPath.SafeDirectories)]
 
 namespace LibGit2Sharp.Core
 {


### PR DESCRIPTION
This PR adds process-wide search paths to the set of included default import search paths. This is considered part of the safe values for `DllImportSearchPath` as per [CA5393](https://learn.microsoft.com/th-th/dotnet/fundamentals/code-analysis/quality-rules/ca5393#how-to-fix-violations).

Fixes #2019 