### PR TITLE
Workflow and TFM updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3.5.0
@@ -36,10 +36,10 @@ jobs:
     strategy:
       matrix:
         arch: [ amd64 ]
-        os: [ windows-2019, macos-10.15 ]
+        os: [ windows-2019, macos-11 ]
         tfm: [ net472, net6.0, net7.0 ]
         exclude:
-          - os: macos-10.15
+          - os: macos-11
             tfm: net472
       fail-fast: false
     steps:
@@ -57,24 +57,18 @@ jobs:
         run: dotnet test LibGit2Sharp.sln --configuration Release --framework ${{ matrix.tfm }} --logger "GitHubActions" /p:ExtraDefine=LEAKS_IDENTIFYING
   test-linux:
     name: Test / ${{ matrix.distro }} / ${{ matrix.arch }} / ${{ matrix.tfm }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         arch: [ amd64 ]
         # arch: [ amd64, arm64 ]
-        distro: [ alpine.3.12, alpine.3.13, alpine.3.14, centos.7, centos.8, debian.9, debian.10, debian.11, fedora.33, ubuntu.18.04, ubuntu.20.04 ]
+        distro: [ alpine.3.13, alpine.3.14, alpine.3.15, alpine.3.16, alpine.3.17, centos.7, centos.stream.8, debian.10, debian.11, fedora.36, ubuntu.18.04, ubuntu.20.04, ubuntu.22.04 ]
         sdk:  [ '6.0', '7.0' ]
         exclude:
-          - arch: arm64
-            distro: alpine.3.12
-          - arch: arm64
-            distro: alpine.3.13
-            sdk: '3.1'
-          - arch: arm64
-            distro: alpine.3.14
-            sdk: '3.1'
-          - arch: arm64
-            distro: centos.7
+          - distro: alpine.3.13
+            sdk: '7.0'
+          - distro: alpine.3.14
+            sdk: '7.0'
         include:
           - sdk: '6.0'
             tfm: net6.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,17 +15,17 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3.5.0
         with:
           fetch-depth: 0
       - name: Install .NET SDK
-        uses: actions/setup-dotnet@v1.8.1
+        uses: actions/setup-dotnet@v3.0.3
         with:
           dotnet-version: 6.0.x
       - name: Build
         run: dotnet build LibGit2Sharp.sln --configuration Release
       - name: Upload packages
-        uses: actions/upload-artifact@v2.2.4
+        uses: actions/upload-artifact@v3.1.2
         with:
           name: NuGet packages
           path: bin/Packages/
@@ -44,16 +44,16 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3.5.0
         with:
           fetch-depth: 0
       - name: Install .NET SDK
-        uses: actions/setup-dotnet@v1.8.1
+        uses: actions/setup-dotnet@v3.0.3
         with:
           dotnet-version: 6.0.x
       - name: Install .NET Core 3.1 runtime
         if: matrix.tfm == 'netcoreapp3.1'
-        uses: actions/setup-dotnet@v1.8.1
+        uses: actions/setup-dotnet@v3.0.3
         with:
           dotnet-version: 3.1.x
       - name: Run ${{ matrix.tfm }} tests
@@ -86,7 +86,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3.5.0
         with:
           fetch-depth: 0
       - name: Setup QEMU

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install .NET SDK
         uses: actions/setup-dotnet@v3.0.3
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 7.0.x
       - name: Build
         run: dotnet build LibGit2Sharp.sln --configuration Release
       - name: Upload packages
@@ -36,8 +36,8 @@ jobs:
     strategy:
       matrix:
         arch: [ amd64 ]
-        os: [windows-2019, macos-10.15]
-        tfm: [ net472, netcoreapp3.1, net6.0 ]
+        os: [ windows-2019, macos-10.15 ]
+        tfm: [ net472, net6.0, net7.0 ]
         exclude:
           - os: macos-10.15
             tfm: net472
@@ -50,12 +50,9 @@ jobs:
       - name: Install .NET SDK
         uses: actions/setup-dotnet@v3.0.3
         with:
-          dotnet-version: 6.0.x
-      - name: Install .NET Core 3.1 runtime
-        if: matrix.tfm == 'netcoreapp3.1'
-        uses: actions/setup-dotnet@v3.0.3
-        with:
-          dotnet-version: 3.1.x
+          dotnet-version: |
+            7.0.x
+            6.0.x
       - name: Run ${{ matrix.tfm }} tests
         run: dotnet test LibGit2Sharp.sln --configuration Release --framework ${{ matrix.tfm }} --logger "GitHubActions" /p:ExtraDefine=LEAKS_IDENTIFYING
   test-linux:
@@ -66,7 +63,7 @@ jobs:
         arch: [ amd64 ]
         # arch: [ amd64, arm64 ]
         distro: [ alpine.3.12, alpine.3.13, alpine.3.14, centos.7, centos.8, debian.9, debian.10, debian.11, fedora.33, ubuntu.18.04, ubuntu.20.04 ]
-        sdk:  [ '6.0', '3.1' ]
+        sdk:  [ '6.0', '7.0' ]
         exclude:
           - arch: arm64
             distro: alpine.3.12
@@ -81,8 +78,8 @@ jobs:
         include:
           - sdk: '6.0'
             tfm: net6.0
-          - sdk: '3.1'
-            tfm: netcoreapp3.1
+          - sdk: '7.0'
+            tfm: net7.0
       fail-fast: false
     steps:
       - name: Checkout

--- a/LibGit2Sharp.Tests/BlobFixture.cs
+++ b/LibGit2Sharp.Tests/BlobFixture.cs
@@ -45,7 +45,7 @@ namespace LibGit2Sharp.Tests
             }
         }
 
-#if NETFRAMEWORK || NETCOREAPP3_1 //UTF-7 is disabled in .NET 5+
+#if NETFRAMEWORK //UTF-7 is disabled in .NET 5+
         [Theory]
         [InlineData("ascii", 4, "31 32 33 34")]
         [InlineData("utf-7", 4, "31 32 33 34")]
@@ -239,11 +239,11 @@ namespace LibGit2Sharp.Tests
             // Manually delete the objects directory to simulate a partial clone
             Directory.Delete(Path.Combine(repoPath, "objects", "a8"), true);
 
-            using (var repo = new Repository(repoPath)) 
+            using (var repo = new Repository(repoPath))
             {
                 // Look up for the tree that reference the blob which is now missing
                 var tree = repo.Lookup<Tree>("fd093bff70906175335656e6ce6ae05783708765");
-                var blob = (Blob) tree["README"].Target;
+                var blob = (Blob)tree["README"].Target;
 
                 Assert.Equal("a8233120f6ad708f843d861ce2b7228ec4e3dec6", blob.Sha);
                 Assert.NotNull(blob);

--- a/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
+++ b/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
@@ -11,12 +11,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.console" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.console" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
     <PackageReference Include="xunit.skippablefact" Version="1.4.13" />
   </ItemGroup>
 

--- a/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
+++ b/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(TargetFrameworks)'==''">net472;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)'==''">net472;net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -66,7 +66,7 @@ namespace LibGit2Sharp.Core
             return Path.Combine(nativeLibraryDir, libgit2 + Platform.GetNativeLibraryExtension());
         }
 
-#if NETSTANDARD
+#if NETFRAMEWORK
         private static bool TryUseNativeLibrary() => false;
 #else
         private static bool TryUseNativeLibrary()

--- a/LibGit2Sharp/GlobalSettings.cs
+++ b/LibGit2Sharp/GlobalSettings.cs
@@ -20,7 +20,7 @@ namespace LibGit2Sharp
 
         private static string nativeLibraryPath;
         private static bool nativeLibraryPathLocked;
-        private static string nativeLibraryDefaultPath;
+        private static readonly string nativeLibraryDefaultPath = null;
 
         static GlobalSettings()
         {
@@ -29,19 +29,18 @@ namespace LibGit2Sharp
 
             nativeLibraryPathAllowed = netFX || netCore;
 
+#if NETFRAMEWORK
             if (netFX)
             {
                 // For .NET Framework apps the dependencies are deployed to lib/win32/{architecture} directory
                 nativeLibraryDefaultPath = Path.Combine(GetExecutingAssemblyDirectory(), "lib", "win32", Platform.ProcessorArchitecture);
             }
-            else
-            {
-                nativeLibraryDefaultPath = null;
-            }
+#endif
 
             registeredFilters = new Dictionary<Filter, FilterRegistration>();
         }
 
+#if NETFRAMEWORK
         private static string GetExecutingAssemblyDirectory()
         {
             // Assembly.CodeBase is not actually a correctly formatted
@@ -66,6 +65,7 @@ namespace LibGit2Sharp
             managedPath = Path.GetDirectoryName(managedPath);
             return managedPath;
         }
+#endif
 
         /// <summary>
         /// Returns information related to the current LibGit2Sharp

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -31,7 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="[2.0.319]" PrivateAssets="none" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.220" PrivateAssets="all" />
   </ItemGroup>
 

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>LibGit2Sharp brings all the might and speed of libgit2, a native Git implementation, to the managed world of .NET</Description>
     <Company>LibGit2Sharp contributors</Company>

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>LibGit2Sharp brings all the might and speed of libgit2, a native Git implementation, to the managed world of .NET</Description>
     <Company>LibGit2Sharp contributors</Company>

--- a/LibGit2Sharp/ObjectDatabase.cs
+++ b/LibGit2Sharp/ObjectDatabase.cs
@@ -315,10 +315,10 @@ namespace LibGit2Sharp
                     throw new EndOfStreamException("The stream ended unexpectedly");
                 }
             }
-            catch(Exception e)
+            catch (Exception)
             {
                 writestream.free(writestream_ptr);
-                throw e;
+                throw;
             }
 
             ObjectId id = Proxy.git_blob_create_fromstream_commit(writestream_ptr);


### PR DESCRIPTION
LibGit2Sharp now targets `net472` and `net6.0`.

The tests are also run against `net7.0`.