### PR TITLE
add Owner Validation switch

### DIFF
--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -3397,6 +3397,8 @@ namespace LibGit2Sharp.Core
             SetOdbLoosePriority,             // GIT_OPT_SET_ODB_LOOSE_PRIORITY,
             GetExtensions,                   // GIT_OPT_GET_EXTENSIONS,
             SetExtensions,                   // GIT_OPT_SET_EXTENSIONS
+            GetOwnerValidation,              // GIT_OPT_GET_OWNER_VALIDATION
+            SetOwnerValidation               // GIT_OPT_SET_OWNER_VALIDATION
         }
 
         /// <summary>
@@ -3569,6 +3571,41 @@ namespace LibGit2Sharp.Core
                 array.Dispose();
             }
         }
+
+        public static string git_libgit2_opts_get_owner_validation()
+        {
+            string userAgent;
+
+            using (var buf = new GitBuf())
+            {
+                int res;
+                if (isOSXArm64)
+                    res = NativeMethods.git_libgit2_opts_osxarm64((int)LibGit2Option.GetUserAgent, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, buf);
+                else
+                    res = NativeMethods.git_libgit2_opts((int)LibGit2Option.GetOwnerValidation, buf);
+                Ensure.ZeroResult(res);
+
+                userAgent = LaxUtf8Marshaler.FromNative(buf.ptr) ?? string.Empty;
+            }
+
+            return userAgent;
+        }
+
+        /// <summary>
+        /// Enable or disable the ownership validation
+        /// </summary>
+        /// <param name="enabled">true to enable the ownership validation capabilty, false otherwise</param>
+        public static void git_libgit2_opts_set_owner_validation(bool enabled)
+        {
+            // libgit2 expects non-zero value for true
+            int res;
+            if (isOSXArm64)
+                res = NativeMethods.git_libgit2_opts_osxarm64((int)LibGit2Option.SetOwnerValidation, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, enabled ? 1 : 0);
+            else
+                res = NativeMethods.git_libgit2_opts((int)LibGit2Option.SetOwnerValidation, enabled ? 1 : 0);
+            Ensure.ZeroResult(res);
+        }
+
 
         #endregion
 

--- a/LibGit2Sharp/GlobalSettings.cs
+++ b/LibGit2Sharp/GlobalSettings.cs
@@ -347,6 +347,15 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
+        /// Enable or disable dubious owner validation
+        /// </summary>
+        /// <param name="enabled">true to enable owner validation; false otherwise.</param>
+        public static void SetOwnerValidation(bool enabled)
+        {
+            Proxy.git_libgit2_opts_set_owner_validation(enabled);
+        }
+
+        /// <summary>
         /// Enable or disable the libgit2 cache
         /// </summary>
         /// <param name="enabled">true to enable the cache, false otherwise</param>


### PR DESCRIPTION
adds a switch to disable the Owner Validation, which (afaik) checks the filesystem permissions of the repository accessed.

this check imho increases security in already wacky edge-cases - just educate the user to use git with some caution. 

overall this check is a major annoyance on environments where you have little influence on that like Azure App Services.