### PR TITLE
Set GitProxyOptions type to default to auto

### DIFF
--- a/LibGit2Sharp/Commands/Fetch.cs
+++ b/LibGit2Sharp/Commands/Fetch.cs
@@ -75,7 +75,7 @@ namespace LibGit2Sharp
                     fetchOptions.CustomHeaders = GitStrArrayManaged.BuildFrom(options.CustomHeaders);
                 }
 
-                fetchOptions.ProxyOptions = new GitProxyOptions { Version = 1 };
+                fetchOptions.ProxyOptions = GitProxyOptions.CreateGitProxyOptions();
 
                 Proxy.git_remote_fetch(remoteHandle, refspecs, fetchOptions, logMessage);
             }

--- a/LibGit2Sharp/Core/GitProxyOptions.cs
+++ b/LibGit2Sharp/Core/GitProxyOptions.cs
@@ -11,13 +11,18 @@ namespace LibGit2Sharp.Core
     }
 
     [StructLayout(LayoutKind.Sequential)]
-    internal sealed class GitProxyOptions
+    internal struct GitProxyOptions
     {
         public uint Version;
-        public GitProxyType Type = GitProxyType.Auto;
+        public GitProxyType Type;
         public IntPtr Url;
         public IntPtr CredentialsCb;
         public IntPtr CertificateCheck;
         public IntPtr CbPayload;
+
+        internal static GitProxyOptions CreateGitProxyOptions()
+        {
+            return new GitProxyOptions { Type = GitProxyType.Auto, Version = 1 };
+        }
     }
 }

--- a/LibGit2Sharp/Core/GitProxyOptions.cs
+++ b/LibGit2Sharp/Core/GitProxyOptions.cs
@@ -11,10 +11,10 @@ namespace LibGit2Sharp.Core
     }
 
     [StructLayout(LayoutKind.Sequential)]
-    internal struct GitProxyOptions
+    internal sealed class GitProxyOptions
     {
         public uint Version;
-        public GitProxyType Type;
+        public GitProxyType Type = GitProxyType.Auto;
         public IntPtr Url;
         public IntPtr CredentialsCb;
         public IntPtr CertificateCheck;

--- a/LibGit2Sharp/Network.cs
+++ b/LibGit2Sharp/Network.cs
@@ -118,7 +118,7 @@ namespace LibGit2Sharp
             using (RemoteHandle remoteHandle = BuildRemoteHandle(repository.Handle, url))
             {
                 GitRemoteCallbacks gitCallbacks = new GitRemoteCallbacks { version = 1 };
-                GitProxyOptions proxyOptions = new GitProxyOptions { Version = 1 };
+                GitProxyOptions proxyOptions = GitProxyOptions.CreateGitProxyOptions();
 
                 if (credentialsProvider != null)
                 {
@@ -375,7 +375,7 @@ namespace LibGit2Sharp
                                       {
                                           PackbuilderDegreeOfParallelism = pushOptions.PackbuilderDegreeOfParallelism,
                                           RemoteCallbacks = gitCallbacks,
-                                          ProxyOptions = new GitProxyOptions { Version = 1 },
+                                          ProxyOptions = GitProxyOptions.CreateGitProxyOptions(),
                                       });
             }
         }

--- a/LibGit2Sharp/Repository.cs
+++ b/LibGit2Sharp/Repository.cs
@@ -678,7 +678,7 @@ namespace LibGit2Sharp
             using (RemoteHandle remoteHandle = Proxy.git_remote_create_anonymous(repositoryHandle, url))
             {
                 var gitCallbacks = new GitRemoteCallbacks { version = 1 };
-                var proxyOptions = new GitProxyOptions { Version = 1 };
+                var proxyOptions = GitProxyOptions.CreateGitProxyOptions();
 
                 if (credentialsProvider != null)
                 {
@@ -768,7 +768,7 @@ namespace LibGit2Sharp
                 var gitCheckoutOptions = checkoutOptionsWrapper.Options;
 
                 var gitFetchOptions = fetchOptionsWrapper.Options;
-                gitFetchOptions.ProxyOptions = new GitProxyOptions { Version = 1 };
+                gitFetchOptions.ProxyOptions = GitProxyOptions.CreateGitProxyOptions();
                 gitFetchOptions.RemoteCallbacks = new RemoteCallbacks(options).GenerateCallbacks();
                 if (options.FetchOptions != null && options.FetchOptions.CustomHeaders != null)
                 {
@@ -1050,7 +1050,7 @@ namespace LibGit2Sharp
 
                 if (treesame && !amendMergeCommit)
                 {
-                    throw (options.AmendPreviousCommit ? 
+                    throw (options.AmendPreviousCommit ?
                         new EmptyCommitException("Amending this commit would produce a commit that is identical to its parent (id = {0})", parents[0].Id) :
                         new EmptyCommitException("No changes; nothing to commit."));
                 }
@@ -1241,7 +1241,7 @@ namespace LibGit2Sharp
             if (fetchHeads.Length == 0)
             {
                 var expectedRef = this.Head.UpstreamBranchCanonicalName;
-                throw new MergeFetchHeadNotFoundException("The current branch is configured to merge with the reference '{0}' from the remote, but this reference was not fetched.", 
+                throw new MergeFetchHeadNotFoundException("The current branch is configured to merge with the reference '{0}' from the remote, but this reference was not fetched.",
                     expectedRef);
             }
 

--- a/LibGit2Sharp/SubmoduleCollection.cs
+++ b/LibGit2Sharp/SubmoduleCollection.cs
@@ -104,7 +104,7 @@ namespace LibGit2Sharp
                     {
                         Version = 1,
                         CheckoutOptions = gitCheckoutOptions,
-                        FetchOptions = new GitFetchOptions { ProxyOptions = new GitProxyOptions { Version = 1 }, RemoteCallbacks = gitRemoteCallbacks },
+                        FetchOptions = new GitFetchOptions { ProxyOptions = GitProxyOptions.CreateGitProxyOptions(), RemoteCallbacks = gitRemoteCallbacks },
                         CloneCheckoutStrategy = CheckoutStrategy.GIT_CHECKOUT_SAFE
                     };
 


### PR DESCRIPTION

Fix for #1429.  

Currently `GitProxyOptions.Type` is set to `GitProxyType.none` and it is not possible to use  libgit2sharp through a proxy.  By setting `GitProxyOptions.Type` to `GitProxyType.Auto` git config settings for `http.proxy` and `https.proxy` work as expected in libgit2sharp.

PR https://github.com/libgit2/libgit2sharp/pull/1689 also attempts to address this, but is still open.  However, it is not legal to have a field initializer in a struct.

PR https://github.com/libgit2/libgit2sharp/pull/1708 did a nice job of fixing this issue, but it was closed by the author and not merged.

It would be *really* nice to have this feature in libgit2sharp.