### PR TITLE
Include merge commits in the file history

### DIFF
--- a/LibGit2Sharp.Tests/FileHistoryFixture.cs
+++ b/LibGit2Sharp.Tests/FileHistoryFixture.cs
@@ -104,11 +104,11 @@ namespace LibGit2Sharp.Tests
                 var timeCommits = new List<Commit>
                 {
                     master10, // master
-
+                    master9, // merge to master
                     master8, // master
                     nextfix7, // next-fix
                     master6, // master
-
+                    master5, // merge to master
                     master4, // master
                     fix3, // fix
                     master2, // master
@@ -123,11 +123,11 @@ namespace LibGit2Sharp.Tests
                 var topoCommits = new List<Commit>
                 {
                     master10, // master
-
+                    master9, // merge to master
                     nextfix7, // next-fix
                     master8, // master
                     master6, // master
-
+                    master5, // merge to master
                     fix3, // fix
                     fix1, // fix
                     master4, // master

--- a/LibGit2Sharp/Core/FileHistory.cs
+++ b/LibGit2Sharp/Core/FileHistory.cs
@@ -134,12 +134,7 @@ namespace LibGit2Sharp.Core
                 {
                     DetermineParentPaths(repo, currentCommit, currentPath, map);
 
-                    if (parentCount != 1)
-                    {
-                        continue;
-                    }
-
-                    var parentCommit = currentCommit.Parents.Single();
+                    var parentCommit = currentCommit.Parents.First();
                     var parentPath = map[parentCommit];
                     var parentTreeEntry = parentCommit.Tree[parentPath];
 


### PR DESCRIPTION
Currently when we use file history, it doesn't show any merge commits, which could be misleading, as it might contain changes for this specific file.
Also, the popular git providers show merge commits when showing the history of a single file.
Looks like the changes  in  this PR could fix it (currenlty it simply skips when there is more than one parent).
Eventually if we want to keep the old behavior, we may want to pass some kind of flag to the FileHistory class, maybe ``includeMergeCommits=false``