### PR TITLE
feat: Add CustomHeaders to PushOptions

### DIFF
--- a/LibGit2Sharp.Tests/PushFixture.cs
+++ b/LibGit2Sharp.Tests/PushFixture.cs
@@ -196,6 +196,33 @@ namespace LibGit2Sharp.Tests
             }
         }
 
+        [Fact]
+        public void CanPushWithCustomHeaders()
+        {
+            const string knownHeader = "X-Hello: mygit-201";
+            var options = new PushOptions { CustomHeaders = new string[] { knownHeader } };
+            AssertPush(repo =>
+                repo.Network.Push(repo.Network.Remotes["origin"], "HEAD", @"refs/heads/master", options));
+        }
+
+        [Fact]
+        public void CannotPushWithForbiddenCustomHeaders()
+        {
+            const string knownHeader = "User-Agent: mygit-201";
+            var options = new PushOptions { CustomHeaders = new string[] { knownHeader } };
+            Assert.Throws<LibGit2SharpException>(
+                () => AssertPush(repo => repo.Network.Push(repo.Network.Remotes["origin"], "HEAD", @"refs/heads/master", options)));
+        }
+
+        [Fact]
+        public void CannotPushWithMalformedCustomHeaders()
+        {
+            const string knownHeader = "Hello world";
+            var options = new PushOptions { CustomHeaders = new string[] { knownHeader } };
+            Assert.Throws<LibGit2SharpException>(
+                () => AssertPush(repo => repo.Network.Push(repo.Network.Remotes["origin"], "HEAD", @"refs/heads/master", options)));
+        }
+
         private static void AssertRemoteHeadTipEquals(IRepository localRepo, string sha)
         {
             var remoteReferences = localRepo.Network.ListReferences(localRepo.Network.Remotes.Single());

--- a/LibGit2Sharp/Core/GitPushOptionsWrapper.cs
+++ b/LibGit2Sharp/Core/GitPushOptionsWrapper.cs
@@ -1,0 +1,36 @@
+using System;
+
+namespace LibGit2Sharp.Core
+{
+    /// <summary>
+    /// Git push options wrapper. Disposable wrapper for <see cref="GitPushOptions"/>.
+    /// </summary>
+    internal class GitPushOptionsWrapper : IDisposable
+    {
+        public GitPushOptionsWrapper() : this(new GitPushOptions()) { }
+
+        public GitPushOptionsWrapper(GitPushOptions pushOptions)
+        {
+            this.Options = pushOptions;
+        }
+
+        public GitPushOptions Options { get; private set; }
+
+        #region IDisposable
+        private bool disposedValue = false; // To detect redundant calls
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposedValue)
+                return;
+
+            this.Options.CustomHeaders.Dispose();
+            disposedValue = true;
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+        #endregion
+    }
+}

--- a/LibGit2Sharp/PushOptions.cs
+++ b/LibGit2Sharp/PushOptions.cs
@@ -51,5 +51,25 @@ namespace LibGit2Sharp
         /// information about what updates will be performed.
         /// </summary>
         public PrePushHandler OnNegotiationCompletedBeforePush { get; set; }
+
+        /// <summary>
+        /// Get/Set the custom headers.
+        /// <para>
+        /// This allows you to set custom headers (e.g. X-Forwarded-For,
+        /// X-Request-Id, etc),
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// Libgit2 sets some headers for HTTP requests (User-Agent, Host,
+        /// Accept, Content-Type, Transfer-Encoding, Content-Length, Accept) that
+        /// cannot be overriden.
+        /// </remarks>
+        /// <example>
+        /// var pushOptions - new PushOptions() {
+        ///     CustomHeaders = new String[] {"X-Request-Id: 12345"}
+        /// };
+        /// </example>
+        /// <value>The custom headers string array</value>
+        public string[] CustomHeaders { get; set; }
     }
 }


### PR DESCRIPTION
Wires up CustomHeaders in PushOptions in the same vein as FetchOptions.

Libgit2 already supports CustomerHeaders on PushOptions, so might as well hook it up. Plus it's required for some git servers that require strange PAT token formats like Azure DevOps #2041.

This PR is similar to #2011 except it properly disposes the managed string array and it has some tests.