### PR TITLE
Modernized argument checks in several files by using `nameof()`

### DIFF
--- a/LibGit2Sharp/Blob.cs
+++ b/LibGit2Sharp/Blob.cs
@@ -62,7 +62,7 @@ namespace LibGit2Sharp
         /// <exception cref="NotFoundException">Throws if blob is missing</exception>
         public virtual Stream GetContentStream(FilteringOptions filteringOptions)
         {
-            Ensure.ArgumentNotNull(filteringOptions, "filteringOptions");
+            Ensure.ArgumentNotNull(filteringOptions, nameof(filteringOptions));
 
             return Proxy.git_blob_filtered_content_stream(repo.Handle, Id, filteringOptions.HintPath, false);
         }
@@ -86,7 +86,7 @@ namespace LibGit2Sharp
         /// <exception cref="NotFoundException">Throws if blob is missing</exception>
         public virtual string GetContentText(Encoding encoding)
         {
-            Ensure.ArgumentNotNull(encoding, "encoding");
+            Ensure.ArgumentNotNull(encoding, nameof(encoding));
 
             return ReadToEnd(GetContentStream(), encoding);
         }
@@ -114,7 +114,7 @@ namespace LibGit2Sharp
         /// <exception cref="NotFoundException">Throws if blob is missing</exception>
         public virtual string GetContentText(FilteringOptions filteringOptions, Encoding encoding)
         {
-            Ensure.ArgumentNotNull(filteringOptions, "filteringOptions");
+            Ensure.ArgumentNotNull(filteringOptions, nameof(filteringOptions));
 
             return ReadToEnd(GetContentStream(filteringOptions), encoding);
         }

--- a/LibGit2Sharp/BranchCollection.cs
+++ b/LibGit2Sharp/BranchCollection.cs
@@ -39,7 +39,7 @@ namespace LibGit2Sharp
         {
             get
             {
-                Ensure.ArgumentNotNullOrEmptyString(name, "name");
+                Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
                 if (LooksLikeABranchName(name))
                 {
@@ -138,7 +138,7 @@ namespace LibGit2Sharp
         /// <returns>A new <see cref="Branch"/>.</returns>
         public virtual Branch Add(string name, Commit commit, bool allowOverwrite)
         {
-            Ensure.ArgumentNotNull(commit, "commit");
+            Ensure.ArgumentNotNull(commit, nameof(commit));
 
             return Add(name, commit.Sha, allowOverwrite);
         }
@@ -152,8 +152,8 @@ namespace LibGit2Sharp
         /// <returns>A new <see cref="Branch"/>.</returns>
         public virtual Branch Add(string name, string committish, bool allowOverwrite)
         {
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");
-            Ensure.ArgumentNotNullOrEmptyString(committish, "committish");
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
+            Ensure.ArgumentNotNullOrEmptyString(committish, nameof(committish));
 
             using (Proxy.git_branch_create_from_annotated(repo.Handle, name, committish, allowOverwrite))
             { }
@@ -178,7 +178,7 @@ namespace LibGit2Sharp
         /// <param name="isRemote">True if the provided <paramref name="name"/> is the name of a remote branch, false otherwise.</param>
         public virtual void Remove(string name, bool isRemote)
         {
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
             string branchName = isRemote ? Reference.RemoteTrackingBranchPrefix + name : name;
 
@@ -197,7 +197,7 @@ namespace LibGit2Sharp
         /// <param name="branch">The branch to delete.</param>
         public virtual void Remove(Branch branch)
         {
-            Ensure.ArgumentNotNull(branch, "branch");
+            Ensure.ArgumentNotNull(branch, nameof(branch));
 
             using (ReferenceHandle referencePtr = repo.Refs.RetrieveReferencePtr(branch.CanonicalName))
             {
@@ -225,8 +225,8 @@ namespace LibGit2Sharp
         /// <returns>A new <see cref="Branch"/>.</returns>
         public virtual Branch Rename(string currentName, string newName, bool allowOverwrite)
         {
-            Ensure.ArgumentNotNullOrEmptyString(currentName, "currentName");
-            Ensure.ArgumentNotNullOrEmptyString(newName, "newName");
+            Ensure.ArgumentNotNullOrEmptyString(currentName, nameof(currentName));
+            Ensure.ArgumentNotNullOrEmptyString(newName, nameof(newName));
 
             Branch branch = this[currentName];
 
@@ -258,8 +258,8 @@ namespace LibGit2Sharp
         /// <returns>A new <see cref="Branch"/>.</returns>
         public virtual Branch Rename(Branch branch, string newName, bool allowOverwrite)
         {
-            Ensure.ArgumentNotNull(branch, "branch");
-            Ensure.ArgumentNotNullOrEmptyString(newName, "newName");
+            Ensure.ArgumentNotNull(branch, nameof(branch));
+            Ensure.ArgumentNotNullOrEmptyString(newName, nameof(newName));
 
             if (branch.IsRemote)
             {

--- a/LibGit2Sharp/BranchUpdater.cs
+++ b/LibGit2Sharp/BranchUpdater.cs
@@ -20,8 +20,8 @@ namespace LibGit2Sharp
 
         internal BranchUpdater(Repository repo, Branch branch)
         {
-            Ensure.ArgumentNotNull(repo, "repo");
-            Ensure.ArgumentNotNull(branch, "branch");
+            Ensure.ArgumentNotNull(repo, nameof(repo));
+            Ensure.ArgumentNotNull(branch, nameof(branch));
 
             this.repo = repo;
             this.branch = branch;

--- a/LibGit2Sharp/Commands/Checkout.cs
+++ b/LibGit2Sharp/Commands/Checkout.cs
@@ -35,7 +35,7 @@ namespace LibGit2Sharp
         public static Branch Checkout(IRepository repository, string committishOrBranchSpec, CheckoutOptions options)
         {
             Ensure.ArgumentNotNull(repository, nameof(repository));
-            Ensure.ArgumentNotNullOrEmptyString(committishOrBranchSpec, "committishOrBranchSpec");
+            Ensure.ArgumentNotNullOrEmptyString(committishOrBranchSpec, nameof(committishOrBranchSpec));
             Ensure.ArgumentNotNull(options, nameof(options));
 
             Reference reference = null;

--- a/LibGit2Sharp/Commands/Checkout.cs
+++ b/LibGit2Sharp/Commands/Checkout.cs
@@ -34,9 +34,9 @@ namespace LibGit2Sharp
         /// <returns>The <see cref="Branch"/> that was checked out.</returns>
         public static Branch Checkout(IRepository repository, string committishOrBranchSpec, CheckoutOptions options)
         {
-            Ensure.ArgumentNotNull(repository, "repository");
+            Ensure.ArgumentNotNull(repository, nameof(repository));
             Ensure.ArgumentNotNullOrEmptyString(committishOrBranchSpec, "committishOrBranchSpec");
-            Ensure.ArgumentNotNull(options, "options");
+            Ensure.ArgumentNotNull(options, nameof(options));
 
             Reference reference = null;
             GitObject obj = null;
@@ -109,9 +109,9 @@ namespace LibGit2Sharp
         /// <returns>The <see cref="Branch"/> that was checked out.</returns>
         public static Branch Checkout(IRepository repository, Branch branch, CheckoutOptions options)
         {
-            Ensure.ArgumentNotNull(repository, "repository");
-            Ensure.ArgumentNotNull(branch, "branch");
-            Ensure.ArgumentNotNull(options, "options");
+            Ensure.ArgumentNotNull(repository, nameof(repository));
+            Ensure.ArgumentNotNull(branch, nameof(branch));
+            Ensure.ArgumentNotNull(options, nameof(options));
 
             // Make sure this is not an unborn branch.
             if (branch.Tip == null)
@@ -160,9 +160,9 @@ namespace LibGit2Sharp
         /// <returns>The <see cref="Branch"/> that was checked out.</returns>
         public static Branch Checkout(IRepository repository, Commit commit, CheckoutOptions options)
         {
-            Ensure.ArgumentNotNull(repository, "repository");
-            Ensure.ArgumentNotNull(commit, "commit");
-            Ensure.ArgumentNotNull(options, "options");
+            Ensure.ArgumentNotNull(repository, nameof(repository));
+            Ensure.ArgumentNotNull(commit, nameof(commit));
+            Ensure.ArgumentNotNull(options, nameof(options));
 
             Checkout(repository, commit.Tree, options, commit.Id.Sha);
 

--- a/LibGit2Sharp/Commands/Fetch.cs
+++ b/LibGit2Sharp/Commands/Fetch.cs
@@ -34,7 +34,7 @@ namespace LibGit2Sharp
         /// <param name="refspecs">List of refspecs to apply as active.</param>
         public static void Fetch(Repository repository, string remote, IEnumerable<string> refspecs, FetchOptions options, string logMessage)
         {
-            Ensure.ArgumentNotNull(remote, "remote");
+            Ensure.ArgumentNotNull(remote, nameof(remote));
 
             options = options ?? new FetchOptions();
             using (var remoteHandle = RemoteFromNameOrUrl(repository.Handle, remote))

--- a/LibGit2Sharp/Commands/Pull.cs
+++ b/LibGit2Sharp/Commands/Pull.cs
@@ -17,8 +17,8 @@ namespace LibGit2Sharp
         /// <param name="options">The options for fetch and merging.</param>
         public static MergeResult Pull(Repository repository, Signature merger, PullOptions options)
         {
-            Ensure.ArgumentNotNull(repository, "repository");
-            Ensure.ArgumentNotNull(merger, "merger");
+            Ensure.ArgumentNotNull(repository, nameof(repository));
+            Ensure.ArgumentNotNull(merger, nameof(merger));
 
 
             options = options ?? new PullOptions();

--- a/LibGit2Sharp/Commands/Remove.cs
+++ b/LibGit2Sharp/Commands/Remove.cs
@@ -68,8 +68,8 @@ namespace LibGit2Sharp
         /// </param>
         public static void Remove(IRepository repository, string path, bool removeFromWorkingDirectory, ExplicitPathsOptions explicitPathsOptions)
         {
-            Ensure.ArgumentNotNull(repository, "repository");
-            Ensure.ArgumentNotNull(path, "path");
+            Ensure.ArgumentNotNull(repository, nameof(repository));
+            Ensure.ArgumentNotNull(path, nameof(path));
 
             Remove(repository, new[] { path }, removeFromWorkingDirectory, explicitPathsOptions);
         }
@@ -115,7 +115,7 @@ namespace LibGit2Sharp
         /// </param>
         public static void Remove(IRepository repository, IEnumerable<string> paths, bool removeFromWorkingDirectory, ExplicitPathsOptions explicitPathsOptions)
         {
-            Ensure.ArgumentNotNull(repository, "repository");
+            Ensure.ArgumentNotNull(repository, nameof(repository));
             Ensure.ArgumentNotNullOrEmptyEnumerable<string>(paths, "paths");
 
             var pathsToDelete = paths.Where(p => Directory.Exists(Path.Combine(repository.Info.WorkingDirectory, p))).ToList();

--- a/LibGit2Sharp/Commands/Stage.cs
+++ b/LibGit2Sharp/Commands/Stage.cs
@@ -19,8 +19,8 @@ namespace LibGit2Sharp
         /// <param name="path">The path of the file within the working directory.</param>
         public static void Stage(IRepository repository, string path)
         {
-            Ensure.ArgumentNotNull(repository, "repository");
-            Ensure.ArgumentNotNull(path, "path");
+            Ensure.ArgumentNotNull(repository, nameof(repository));
+            Ensure.ArgumentNotNull(path, nameof(path));
 
             Stage(repository, new[] { path }, null);
         }
@@ -35,8 +35,8 @@ namespace LibGit2Sharp
         /// <param name="stageOptions">Determines how paths will be staged.</param>
         public static void Stage(IRepository repository, string path, StageOptions stageOptions)
         {
-            Ensure.ArgumentNotNull(repository, "repository");
-            Ensure.ArgumentNotNull(path, "path");
+            Ensure.ArgumentNotNull(repository, nameof(repository));
+            Ensure.ArgumentNotNull(path, nameof(path));
 
             Stage(repository, new[] { path }, stageOptions);
         }
@@ -63,8 +63,8 @@ namespace LibGit2Sharp
         /// <param name="stageOptions">Determines how paths will be staged.</param>
         public static void Stage(IRepository repository, IEnumerable<string> paths, StageOptions stageOptions)
         {
-            Ensure.ArgumentNotNull(repository, "repository");
-            Ensure.ArgumentNotNull(paths, "paths");
+            Ensure.ArgumentNotNull(repository, nameof(repository));
+            Ensure.ArgumentNotNull(paths, nameof(paths));
 
             DiffModifiers diffModifiers = DiffModifiers.IncludeUntracked;
             ExplicitPathsOptions explicitPathsOptions = stageOptions != null ? stageOptions.ExplicitPathsOptions : null;
@@ -160,8 +160,8 @@ namespace LibGit2Sharp
         /// </param>
         public static void Unstage(IRepository repository, string path, ExplicitPathsOptions explicitPathsOptions)
         {
-            Ensure.ArgumentNotNull(repository, "repository");
-            Ensure.ArgumentNotNull(path, "path");
+            Ensure.ArgumentNotNull(repository, nameof(repository));
+            Ensure.ArgumentNotNull(path, nameof(path));
 
             Unstage(repository, new[] { path }, explicitPathsOptions);
         }
@@ -187,8 +187,8 @@ namespace LibGit2Sharp
         /// </param>
         public static void Unstage(IRepository repository, IEnumerable<string> paths, ExplicitPathsOptions explicitPathsOptions)
         {
-            Ensure.ArgumentNotNull(repository, "repository");
-            Ensure.ArgumentNotNull(paths, "paths");
+            Ensure.ArgumentNotNull(repository, nameof(repository));
+            Ensure.ArgumentNotNull(paths, nameof(paths));
 
             if (repository.Info.IsHeadUnborn)
             {
@@ -222,9 +222,9 @@ namespace LibGit2Sharp
         /// <param name="destinationPaths">The target paths of the files within the working directory.</param>
         public static void Move(IRepository repository, IEnumerable<string> sourcePaths, IEnumerable<string> destinationPaths)
         {
-            Ensure.ArgumentNotNull(repository, "repository");
-            Ensure.ArgumentNotNull(sourcePaths, "sourcePaths");
-            Ensure.ArgumentNotNull(destinationPaths, "destinationPaths");
+            Ensure.ArgumentNotNull(repository, nameof(repository));
+            Ensure.ArgumentNotNull(sourcePaths, nameof(sourcePaths));
+            Ensure.ArgumentNotNull(destinationPaths, nameof(destinationPaths));
 
             //TODO: Move() should support following use cases:
             // - Moving a file under a directory ('file' and 'dir' -> 'dir/file')

--- a/LibGit2Sharp/Commit.cs
+++ b/LibGit2Sharp/Commit.cs
@@ -185,12 +185,12 @@ namespace LibGit2Sharp
         /// <returns>The contents of the commit object.</returns>
         public static string CreateBuffer(Signature author, Signature committer, string message, Tree tree, IEnumerable<Commit> parents, bool prettifyMessage, char? commentChar)
         {
-            Ensure.ArgumentNotNull(message, "message");
-            Ensure.ArgumentDoesNotContainZeroByte(message, "message");
-            Ensure.ArgumentNotNull(author, "author");
-            Ensure.ArgumentNotNull(committer, "committer");
-            Ensure.ArgumentNotNull(tree, "tree");
-            Ensure.ArgumentNotNull(parents, "parents");
+            Ensure.ArgumentNotNull(message, nameof(message));
+            Ensure.ArgumentDoesNotContainZeroByte(message, nameof(message));
+            Ensure.ArgumentNotNull(author, nameof(author));
+            Ensure.ArgumentNotNull(committer, nameof(committer));
+            Ensure.ArgumentNotNull(tree, nameof(tree));
+            Ensure.ArgumentNotNull(parents, nameof(parents));
 
             if (prettifyMessage)
             {

--- a/LibGit2Sharp/CommitLog.cs
+++ b/LibGit2Sharp/CommitLog.cs
@@ -72,9 +72,9 @@ namespace LibGit2Sharp
         /// <returns>A list of commits, ready to be enumerated.</returns>
         public ICommitLog QueryBy(CommitFilter filter)
         {
-            Ensure.ArgumentNotNull(filter, "filter");
-            Ensure.ArgumentNotNull(filter.IncludeReachableFrom, "filter.IncludeReachableFrom");
-            Ensure.ArgumentNotNullOrEmptyString(filter.IncludeReachableFrom.ToString(), "filter.IncludeReachableFrom");
+            Ensure.ArgumentNotNull(filter, nameof(filter));
+            Ensure.ArgumentNotNull(filter.IncludeReachableFrom, $"{nameof(filter)}.{nameof(filter.IncludeReachableFrom)}");
+            Ensure.ArgumentNotNullOrEmptyString(filter.IncludeReachableFrom.ToString(), $"{nameof(filter)}.{nameof(filter.IncludeReachableFrom)}");
 
             return new CommitLog(repo, filter);
         }
@@ -86,7 +86,7 @@ namespace LibGit2Sharp
         /// <returns>A list of file history entries, ready to be enumerated.</returns>
         public IEnumerable<LogEntry> QueryBy(string path)
         {
-            Ensure.ArgumentNotNull(path, "path");
+            Ensure.ArgumentNotNull(path, nameof(path));
 
             return new FileHistory(repo, path);
         }
@@ -99,8 +99,8 @@ namespace LibGit2Sharp
         /// <returns>A list of file history entries, ready to be enumerated.</returns>
         public IEnumerable<LogEntry> QueryBy(string path, CommitFilter filter)
         {
-            Ensure.ArgumentNotNull(path, "path");
-            Ensure.ArgumentNotNull(filter, "filter");
+            Ensure.ArgumentNotNull(path, nameof(path));
+            Ensure.ArgumentNotNull(filter, nameof(filter));
 
             return new FileHistory(repo, path, filter);
         }

--- a/LibGit2Sharp/Configuration.cs
+++ b/LibGit2Sharp/Configuration.cs
@@ -245,7 +245,7 @@ namespace LibGit2Sharp
         /// <param name="level">The configuration file which should be considered as the target of this operation</param>
         public virtual bool Unset(string key, ConfigurationLevel level)
         {
-            Ensure.ArgumentNotNullOrEmptyString(key, "key");
+            Ensure.ArgumentNotNullOrEmptyString(key, nameof(key));
 
             using (ConfigurationHandle h = RetrieveConfigurationHandle(level, true, configHandle))
             {
@@ -269,7 +269,7 @@ namespace LibGit2Sharp
         /// <param name="level">The configuration file which should be considered as the target of this operation</param>
         public virtual bool UnsetAll(string key, ConfigurationLevel level)
         {
-            Ensure.ArgumentNotNullOrEmptyString(key, "key");
+            Ensure.ArgumentNotNullOrEmptyString(key, nameof(key));
 
             using (ConfigurationHandle h = RetrieveConfigurationHandle(level, true, configHandle))
             {
@@ -307,7 +307,7 @@ namespace LibGit2Sharp
         /// <returns>The <see cref="ConfigurationEntry{T}"/>, or null if not set</returns>
         public virtual ConfigurationEntry<T> Get<T>(string[] keyParts)
         {
-            Ensure.ArgumentNotNull(keyParts, "keyParts");
+            Ensure.ArgumentNotNull(keyParts, nameof(keyParts));
 
             return Get<T>(string.Join(".", keyParts));
         }
@@ -336,9 +336,9 @@ namespace LibGit2Sharp
         /// <returns>The <see cref="ConfigurationEntry{T}"/>, or null if not set</returns>
         public virtual ConfigurationEntry<T> Get<T>(string firstKeyPart, string secondKeyPart, string thirdKeyPart)
         {
-            Ensure.ArgumentNotNullOrEmptyString(firstKeyPart, "firstKeyPart");
-            Ensure.ArgumentNotNullOrEmptyString(secondKeyPart, "secondKeyPart");
-            Ensure.ArgumentNotNullOrEmptyString(thirdKeyPart, "thirdKeyPart");
+            Ensure.ArgumentNotNullOrEmptyString(firstKeyPart, nameof(firstKeyPart));
+            Ensure.ArgumentNotNullOrEmptyString(secondKeyPart, nameof(secondKeyPart));
+            Ensure.ArgumentNotNullOrEmptyString(thirdKeyPart, nameof(thirdKeyPart));
 
             return Get<T>(new[] { firstKeyPart, secondKeyPart, thirdKeyPart });
         }
@@ -374,7 +374,7 @@ namespace LibGit2Sharp
         /// <returns>The <see cref="ConfigurationEntry{T}"/>, or null if not set</returns>
         public virtual ConfigurationEntry<T> Get<T>(string key)
         {
-            Ensure.ArgumentNotNullOrEmptyString(key, "key");
+            Ensure.ArgumentNotNullOrEmptyString(key, nameof(key));
 
             using (ConfigurationHandle snapshot = Snapshot())
             {
@@ -405,7 +405,7 @@ namespace LibGit2Sharp
         /// <returns>The <see cref="ConfigurationEntry{T}"/>, or null if not set</returns>
         public virtual ConfigurationEntry<T> Get<T>(string key, ConfigurationLevel level)
         {
-            Ensure.ArgumentNotNullOrEmptyString(key, "key");
+            Ensure.ArgumentNotNullOrEmptyString(key, nameof(key));
 
             using (ConfigurationHandle snapshot = Snapshot())
             using (ConfigurationHandle handle = RetrieveConfigurationHandle(level, false, snapshot))
@@ -587,7 +587,7 @@ namespace LibGit2Sharp
 
         private static T ValueOrDefault<T>(ConfigurationEntry<T> value, Func<T> defaultValueSelector)
         {
-            Ensure.ArgumentNotNull(defaultValueSelector, "defaultValueSelector");
+            Ensure.ArgumentNotNull(defaultValueSelector, nameof(defaultValueSelector));
 
             return value == null
                        ? defaultValueSelector()
@@ -634,8 +634,8 @@ namespace LibGit2Sharp
         /// <param name="level">The configuration file which should be considered as the target of this operation</param>
         public virtual void Set<T>(string key, T value, ConfigurationLevel level)
         {
-            Ensure.ArgumentNotNull(value, "value");
-            Ensure.ArgumentNotNullOrEmptyString(key, "key");
+            Ensure.ArgumentNotNull(value, nameof(value));
+            Ensure.ArgumentNotNullOrEmptyString(key, nameof(key));
 
             using (ConfigurationHandle h = RetrieveConfigurationHandle(level, true, configHandle))
             {
@@ -686,8 +686,8 @@ namespace LibGit2Sharp
         /// <param name="level">The configuration file which should be considered as the target of this operation</param>
         public virtual void Add(string key, string value, ConfigurationLevel level)
         {
-            Ensure.ArgumentNotNull(value, "value");
-            Ensure.ArgumentNotNullOrEmptyString(key, "key");
+            Ensure.ArgumentNotNull(value, nameof(value));
+            Ensure.ArgumentNotNullOrEmptyString(key, nameof(key));
 
             using (ConfigurationHandle h = RetrieveConfigurationHandle(level, true, configHandle))
             {
@@ -713,7 +713,7 @@ namespace LibGit2Sharp
         /// <returns>Matching entries.</returns>
         public virtual IEnumerable<ConfigurationEntry<string>> Find(string regexp, ConfigurationLevel level)
         {
-            Ensure.ArgumentNotNullOrEmptyString(regexp, "regexp");
+            Ensure.ArgumentNotNullOrEmptyString(regexp, nameof(regexp));
 
             using (ConfigurationHandle snapshot = Snapshot())
             using (ConfigurationHandle h = RetrieveConfigurationHandle(level, true, snapshot))

--- a/LibGit2Sharp/Core/FileHistory.cs
+++ b/LibGit2Sharp/Core/FileHistory.cs
@@ -66,9 +66,9 @@ namespace LibGit2Sharp.Core
         /// <exception cref="ArgumentException">When an unsupported commit sort strategy is specified.</exception>
         internal FileHistory(Repository repo, string path, CommitFilter queryFilter)
         {
-            Ensure.ArgumentNotNull(repo, "repo");
-            Ensure.ArgumentNotNull(path, "path");
-            Ensure.ArgumentNotNull(queryFilter, "queryFilter");
+            Ensure.ArgumentNotNull(repo, nameof(repo));
+            Ensure.ArgumentNotNull(path, nameof(path));
+            Ensure.ArgumentNotNull(queryFilter, nameof(queryFilter));
 
             // Ensure the commit sort strategy makes sense.
             if (!AllowedSortStrategies.Contains(queryFilter.SortBy))

--- a/LibGit2Sharp/Core/ObjectSafeWrapper.cs
+++ b/LibGit2Sharp/Core/ObjectSafeWrapper.cs
@@ -9,7 +9,7 @@ namespace LibGit2Sharp.Core
 
         public unsafe ObjectSafeWrapper(ObjectId id, RepositoryHandle handle, bool allowNullObjectId = false, bool throwIfMissing = false)
         {
-            Ensure.ArgumentNotNull(handle, "handle");
+            Ensure.ArgumentNotNull(handle, nameof(handle));
 
             if (allowNullObjectId && id == null)
             {
@@ -17,7 +17,7 @@ namespace LibGit2Sharp.Core
             }
             else
             {
-                Ensure.ArgumentNotNull(id, "id");
+                Ensure.ArgumentNotNull(id, nameof(id));
                 objectPtr = Proxy.git_object_lookup(handle, id, GitObjectType.Any);
             }
 

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -683,7 +683,7 @@ namespace LibGit2Sharp.Core
             ObjectId committishId,
             DescribeOptions options)
         {
-            Ensure.ArgumentPositiveInt32(options.MinimumCommitIdAbbreviatedSize, "options.MinimumCommitIdAbbreviatedSize");
+            Ensure.ArgumentPositiveInt32(options.MinimumCommitIdAbbreviatedSize, $"{nameof(options)}.{nameof(options.MinimumCommitIdAbbreviatedSize)}");
 
             using (var osw = new ObjectSafeWrapper(committishId, repo))
             {
@@ -1808,8 +1808,8 @@ namespace LibGit2Sharp.Core
             Identity author,
             Identity committer)
         {
-            Ensure.ArgumentNotNull(rebase, "rebase");
-            Ensure.ArgumentNotNull(committer, "committer");
+            Ensure.ArgumentNotNull(rebase, nameof(rebase));
+            Ensure.ArgumentNotNull(committer, nameof(committer));
 
             using (SignatureHandle committerHandle = committer.BuildNowSignatureHandle())
             using (SignatureHandle authorHandle = author.SafeBuildNowSignatureHandle())
@@ -1852,7 +1852,7 @@ namespace LibGit2Sharp.Core
         public static unsafe void git_rebase_abort(
             RebaseHandle rebase)
         {
-            Ensure.ArgumentNotNull(rebase, "rebase");
+            Ensure.ArgumentNotNull(rebase, nameof(rebase));
 
             int result = NativeMethods.git_rebase_abort(rebase);
             Ensure.ZeroResult(result);
@@ -1862,8 +1862,8 @@ namespace LibGit2Sharp.Core
             RebaseHandle rebase,
             Identity committer)
         {
-            Ensure.ArgumentNotNull(rebase, "rebase");
-            Ensure.ArgumentNotNull(committer, "committer");
+            Ensure.ArgumentNotNull(rebase, nameof(rebase));
+            Ensure.ArgumentNotNull(committer, nameof(committer));
 
             using (var signatureHandle = committer.BuildNowSignatureHandle())
             {

--- a/LibGit2Sharp/Filter.cs
+++ b/LibGit2Sharp/Filter.cs
@@ -30,8 +30,8 @@ namespace LibGit2Sharp
         /// </summary>
         protected Filter(string name, IEnumerable<FilterAttributeEntry> attributes)
         {
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");
-            Ensure.ArgumentNotNull(attributes, "attributes");
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
+            Ensure.ArgumentNotNull(attributes, nameof(attributes));
 
             this.name = name;
             this.attributes = attributes;
@@ -249,8 +249,8 @@ namespace LibGit2Sharp
 
             try
             {
-                Ensure.ArgumentNotZeroIntPtr(filterSourcePtr, "filterSourcePtr");
-                Ensure.ArgumentNotZeroIntPtr(git_writestream_next, "git_writestream_next");
+                Ensure.ArgumentNotZeroIntPtr(filterSourcePtr, nameof(filterSourcePtr));
+                Ensure.ArgumentNotZeroIntPtr(git_writestream_next, nameof(git_writestream_next));
 
                 state.thisStream = new GitWriteStream();
                 state.thisStream.close = StreamCloseCallback;
@@ -302,14 +302,14 @@ namespace LibGit2Sharp
 
             try
             {
-                Ensure.ArgumentNotZeroIntPtr(stream, "stream");
+                Ensure.ArgumentNotZeroIntPtr(stream, nameof(stream));
 
                 if(!activeStreams.TryGetValue(stream, out state))
                 {
-                    throw new ArgumentException("Unknown stream pointer", "stream");
+                    throw new ArgumentException("Unknown stream pointer", nameof(stream));
                 }
 
-                Ensure.ArgumentIsExpectedIntPtr(stream, state.thisPtr, "stream");
+                Ensure.ArgumentIsExpectedIntPtr(stream, state.thisPtr, nameof(stream));
 
                 using (BufferedStream outputBuffer = new BufferedStream(state.output, BufferSize))
                 {
@@ -335,14 +335,14 @@ namespace LibGit2Sharp
 
             try
             {
-                Ensure.ArgumentNotZeroIntPtr(stream, "stream");
+                Ensure.ArgumentNotZeroIntPtr(stream, nameof(stream));
 
                 if (!activeStreams.TryRemove(stream, out state))
                 {
-                    throw new ArgumentException("Double free or invalid stream pointer", "stream");
+                    throw new ArgumentException("Double free or invalid stream pointer", nameof(stream));
                 }
 
-                Ensure.ArgumentIsExpectedIntPtr(stream, state.thisPtr, "stream");
+                Ensure.ArgumentIsExpectedIntPtr(stream, state.thisPtr, nameof(stream));
 
                 Marshal.FreeHGlobal(state.thisPtr);
             }
@@ -360,15 +360,15 @@ namespace LibGit2Sharp
 
             try
             {
-                Ensure.ArgumentNotZeroIntPtr(stream, "stream");
-                Ensure.ArgumentNotZeroIntPtr(buffer, "buffer");
+                Ensure.ArgumentNotZeroIntPtr(stream, nameof(stream));
+                Ensure.ArgumentNotZeroIntPtr(buffer, nameof(buffer));
 
                 if (!activeStreams.TryGetValue(stream, out state))
                 {
-                    throw new ArgumentException("Invalid or already freed stream pointer", "stream");
+                    throw new ArgumentException("Invalid or already freed stream pointer", nameof(stream));
                 }
 
-                Ensure.ArgumentIsExpectedIntPtr(stream, state.thisPtr, "stream");
+                Ensure.ArgumentIsExpectedIntPtr(stream, state.thisPtr, nameof(stream));
 
                 using (UnmanagedMemoryStream input = new UnmanagedMemoryStream((byte*)buffer.ToPointer(), (long)len))
                 using (BufferedStream outputBuffer = new BufferedStream(state.output, BufferSize))

--- a/LibGit2Sharp/FilteringOptions.cs
+++ b/LibGit2Sharp/FilteringOptions.cs
@@ -13,7 +13,7 @@ namespace LibGit2Sharp
         /// <param name="hintPath">The path that a file would be checked out as</param>
         public FilteringOptions(string hintPath)
         {
-            Ensure.ArgumentNotNull(hintPath, "hintPath");
+            Ensure.ArgumentNotNull(hintPath, nameof(hintPath));
 
             this.HintPath = hintPath;
         }

--- a/LibGit2Sharp/GlobalSettings.cs
+++ b/LibGit2Sharp/GlobalSettings.cs
@@ -89,7 +89,7 @@ namespace LibGit2Sharp
         public static SmartSubtransportRegistration<T> RegisterSmartSubtransport<T>(string scheme)
             where T : SmartSubtransport, new()
         {
-            Ensure.ArgumentNotNull(scheme, "scheme");
+            Ensure.ArgumentNotNull(scheme, nameof(scheme));
 
             var registration = new SmartSubtransportRegistration<T>(scheme);
 
@@ -117,7 +117,7 @@ namespace LibGit2Sharp
         public static void UnregisterSmartSubtransport<T>(SmartSubtransportRegistration<T> registration)
             where T : SmartSubtransport, new()
         {
-            Ensure.ArgumentNotNull(registration, "registration");
+            Ensure.ArgumentNotNull(registration, nameof(registration));
 
             Proxy.git_transport_unregister(registration.Scheme);
             registration.Free();
@@ -134,7 +134,7 @@ namespace LibGit2Sharp
         {
             set
             {
-                Ensure.ArgumentNotNull(value, "value");
+                Ensure.ArgumentNotNull(value, nameof(value));
 
                 logConfiguration = value;
 
@@ -244,10 +244,10 @@ namespace LibGit2Sharp
         /// <returns>A <see cref="FilterRegistration"/> object used to manage the lifetime of the registration.</returns>
         public static FilterRegistration RegisterFilter(Filter filter, int priority)
         {
-            Ensure.ArgumentNotNull(filter, "filter");
+            Ensure.ArgumentNotNull(filter, nameof(filter));
             if (priority < FilterRegistration.FilterPriorityMin || priority > FilterRegistration.FilterPriorityMax)
             {
-                throw new ArgumentOutOfRangeException("priority",
+                throw new ArgumentOutOfRangeException(nameof(priority),
                                                       priority,
                                                       String.Format(System.Globalization.CultureInfo.InvariantCulture,
                                                                     "Filter priorities must be within the inclusive range of [{0}, {1}].",
@@ -280,7 +280,7 @@ namespace LibGit2Sharp
         /// <param name="registration">Registration object with an associated filter.</param>
         public static void DeregisterFilter(FilterRegistration registration)
         {
-            Ensure.ArgumentNotNull(registration, "registration");
+            Ensure.ArgumentNotNull(registration, nameof(registration));
 
             lock (registeredFilters)
             {

--- a/LibGit2Sharp/Identity.cs
+++ b/LibGit2Sharp/Identity.cs
@@ -18,10 +18,10 @@ namespace LibGit2Sharp
         /// <param name="email">The email.</param>
         public Identity(string name, string email)
         {
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");
-            Ensure.ArgumentNotNullOrEmptyString(email, "email");
-            Ensure.ArgumentDoesNotContainZeroByte(name, "name");
-            Ensure.ArgumentDoesNotContainZeroByte(email, "email");
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
+            Ensure.ArgumentNotNullOrEmptyString(email, nameof(email));
+            Ensure.ArgumentDoesNotContainZeroByte(name, nameof(name));
+            Ensure.ArgumentDoesNotContainZeroByte(email, nameof(email));
 
             _name = name;
             _email = email;

--- a/LibGit2Sharp/Ignore.cs
+++ b/LibGit2Sharp/Ignore.cs
@@ -31,7 +31,7 @@ namespace LibGit2Sharp
         /// <param name="rules">The content of a .gitignore file that will be applied.</param>
         public virtual void AddTemporaryRules(IEnumerable<string> rules)
         {
-            Ensure.ArgumentNotNull(rules, "rules");
+            Ensure.ArgumentNotNull(rules, nameof(rules));
 
             var allRules = rules.Aggregate(new StringBuilder(), (acc, x) =>
             {
@@ -61,7 +61,7 @@ namespace LibGit2Sharp
         /// <returns>true if the path should be ignored.</returns>
         public virtual bool IsPathIgnored(string relativePath)
         {
-            Ensure.ArgumentNotNullOrEmptyString(relativePath, "relativePath");
+            Ensure.ArgumentNotNullOrEmptyString(relativePath, nameof(relativePath));
 
             return Proxy.git_ignore_path_is_ignored(repo.Handle, relativePath);
         }

--- a/LibGit2Sharp/Index.cs
+++ b/LibGit2Sharp/Index.cs
@@ -78,7 +78,7 @@ namespace LibGit2Sharp
         {
             get
             {
-                Ensure.ArgumentNotNullOrEmptyString(path, "path");
+                Ensure.ArgumentNotNullOrEmptyString(path, nameof(path));
 
                 git_index_entry* entry = Proxy.git_index_get_bypath(handle, path, 0);
                 return IndexEntry.BuildFromPtr(entry);
@@ -167,7 +167,7 @@ namespace LibGit2Sharp
         /// <param name="indexEntryPath">The path of the <see cref="Index"/> entry to be removed.</param>
         public virtual void Remove(string indexEntryPath)
         {
-            Ensure.ArgumentNotNull(indexEntryPath, "indexEntryPath");
+            Ensure.ArgumentNotNull(indexEntryPath, nameof(indexEntryPath));
             RemoveFromIndex(indexEntryPath);
         }
 
@@ -181,7 +181,7 @@ namespace LibGit2Sharp
         /// <param name="pathInTheWorkdir">The path, in the working directory, of the file to be added.</param>
         public virtual void Add(string pathInTheWorkdir)
         {
-            Ensure.ArgumentNotNull(pathInTheWorkdir, "pathInTheWorkdir");
+            Ensure.ArgumentNotNull(pathInTheWorkdir, nameof(pathInTheWorkdir));
             Proxy.git_index_add_bypath(handle, pathInTheWorkdir);
         }
 
@@ -198,9 +198,9 @@ namespace LibGit2Sharp
         /// or <see cref="Mode.SymbolicLink"/>.</param>
         public virtual void Add(Blob blob, string indexEntryPath, Mode indexEntryMode)
         {
-            Ensure.ArgumentConformsTo(indexEntryMode, m => m.HasAny(TreeEntryDefinition.BlobModes), "indexEntryMode");
-            Ensure.ArgumentNotNull(blob, "blob");
-            Ensure.ArgumentNotNull(indexEntryPath, "indexEntryPath");
+            Ensure.ArgumentConformsTo(indexEntryMode, m => m.HasAny(TreeEntryDefinition.BlobModes), nameof(indexEntryMode));
+            Ensure.ArgumentNotNull(blob, nameof(blob));
+            Ensure.ArgumentNotNull(indexEntryPath, nameof(indexEntryPath));
             AddEntryToTheIndex(indexEntryPath, blob.Id, indexEntryMode);
         }
 
@@ -293,7 +293,7 @@ namespace LibGit2Sharp
         /// </param>
         public virtual void Replace(Commit commit, IEnumerable<string> paths, ExplicitPathsOptions explicitPathsOptions)
         {
-            Ensure.ArgumentNotNull(commit, "commit");
+            Ensure.ArgumentNotNull(commit, nameof(commit));
 
             using (var changes = repo.Diff.Compare<TreeChanges>(commit.Tree, DiffTargets.Index, paths, explicitPathsOptions, new CompareOptions { Similarity = SimilarityOptions.None }))
             {

--- a/LibGit2Sharp/LogConfiguration.cs
+++ b/LibGit2Sharp/LogConfiguration.cs
@@ -23,7 +23,7 @@ namespace LibGit2Sharp
         public LogConfiguration(LogLevel level, LogHandler handler)
         {
             Ensure.ArgumentConformsTo<LogLevel>(level, (t) => { return (level != LogLevel.None); }, "level");
-            Ensure.ArgumentNotNull(handler, "handler");
+            Ensure.ArgumentNotNull(handler, nameof(handler));
 
             Level = level;
             Handler = handler;

--- a/LibGit2Sharp/ObjectDatabase.cs
+++ b/LibGit2Sharp/ObjectDatabase.cs
@@ -66,7 +66,7 @@ namespace LibGit2Sharp
         /// <returns>True if the object has been found; false otherwise.</returns>
         public virtual bool Contains(ObjectId objectId)
         {
-            Ensure.ArgumentNotNull(objectId, "objectId");
+            Ensure.ArgumentNotNull(objectId, nameof(objectId));
 
             return Proxy.git_odb_exists(handle, objectId);
         }
@@ -80,7 +80,7 @@ namespace LibGit2Sharp
         /// <returns>GitObjectMetadata object instance containg object header information</returns>
         public virtual GitObjectMetadata RetrieveObjectMetadata(ObjectId objectId)
         {
-            Ensure.ArgumentNotNull(objectId, "objectId");
+            Ensure.ArgumentNotNull(objectId, nameof(objectId));
 
             return Proxy.git_odb_read_header(handle, objectId);
         }
@@ -94,7 +94,7 @@ namespace LibGit2Sharp
         /// <returns>The created <see cref="Blob"/>.</returns>
         public virtual Blob CreateBlob(string path)
         {
-            Ensure.ArgumentNotNullOrEmptyString(path, "path");
+            Ensure.ArgumentNotNullOrEmptyString(path, nameof(path));
 
             if (repo.Info.IsBare && !Path.IsPathRooted(path))
             {
@@ -121,8 +121,8 @@ namespace LibGit2Sharp
         /// <param name="priority">The priority at which libgit2 should consult this backend (higher values are consulted first)</param>
         public virtual void AddBackend(OdbBackend backend, int priority)
         {
-            Ensure.ArgumentNotNull(backend, "backend");
-            Ensure.ArgumentConformsTo(priority, s => s > 0, "priority");
+            Ensure.ArgumentNotNull(backend, nameof(backend));
+            Ensure.ArgumentConformsTo(priority, s => s > 0, nameof(priority));
 
             Proxy.git_odb_add_backend(handle, backend.GitOdbBackendPointer, priority);
         }
@@ -195,7 +195,7 @@ namespace LibGit2Sharp
         /// <typeparam name="T">The type of object to write</typeparam>
         public virtual ObjectId Write<T>(Stream stream, long numberOfBytesToConsume) where T : GitObject
         {
-            Ensure.ArgumentNotNull(stream, "stream");
+            Ensure.ArgumentNotNull(stream, nameof(stream));
 
             if (!stream.CanRead)
             {
@@ -264,7 +264,7 @@ namespace LibGit2Sharp
 
         private unsafe Blob CreateBlob(Stream stream, string hintpath, long? numberOfBytesToConsume)
         {
-            Ensure.ArgumentNotNull(stream, "stream");
+            Ensure.ArgumentNotNull(stream, nameof(stream));
 
             // there's no need to buffer the file for filtering, so simply use a stream
             if (hintpath == null && numberOfBytesToConsume.HasValue)
@@ -344,7 +344,7 @@ namespace LibGit2Sharp
         /// <returns>The created <see cref="Tree"/>.</returns>
         public virtual Tree CreateTree(TreeDefinition treeDefinition)
         {
-            Ensure.ArgumentNotNull(treeDefinition, "treeDefinition");
+            Ensure.ArgumentNotNull(treeDefinition, nameof(treeDefinition));
 
             return treeDefinition.Build(repo);
         }
@@ -362,7 +362,7 @@ namespace LibGit2Sharp
         /// <returns>The created <see cref="Tree"/>. This can be used e.g. to create a <see cref="Commit"/>.</returns>
         public virtual Tree CreateTree(Index index)
         {
-            Ensure.ArgumentNotNull(index, "index");
+            Ensure.ArgumentNotNull(index, nameof(index));
 
             var treeId = Proxy.git_index_write_tree(index.Handle);
             return this.repo.Lookup<Tree>(treeId);
@@ -412,12 +412,12 @@ namespace LibGit2Sharp
         /// <returns>The created <see cref="Commit"/>.</returns>
         public virtual Commit CreateCommit(Signature author, Signature committer, string message, Tree tree, IEnumerable<Commit> parents, bool prettifyMessage, char? commentChar)
         {
-            Ensure.ArgumentNotNull(message, "message");
-            Ensure.ArgumentDoesNotContainZeroByte(message, "message");
-            Ensure.ArgumentNotNull(author, "author");
-            Ensure.ArgumentNotNull(committer, "committer");
-            Ensure.ArgumentNotNull(tree, "tree");
-            Ensure.ArgumentNotNull(parents, "parents");
+            Ensure.ArgumentNotNull(message, nameof(message));
+            Ensure.ArgumentDoesNotContainZeroByte(message, nameof(message));
+            Ensure.ArgumentNotNull(author, nameof(author));
+            Ensure.ArgumentNotNull(committer, nameof(committer));
+            Ensure.ArgumentNotNull(tree, nameof(tree));
+            Ensure.ArgumentNotNull(parents, nameof(parents));
 
             if (prettifyMessage)
             {
@@ -468,12 +468,12 @@ namespace LibGit2Sharp
         /// <returns>The created <see cref="TagAnnotation"/>.</returns>
         public virtual TagAnnotation CreateTagAnnotation(string name, GitObject target, Signature tagger, string message)
         {
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");
-            Ensure.ArgumentNotNull(message, "message");
-            Ensure.ArgumentNotNull(target, "target");
-            Ensure.ArgumentNotNull(tagger, "tagger");
-            Ensure.ArgumentDoesNotContainZeroByte(name, "name");
-            Ensure.ArgumentDoesNotContainZeroByte(message, "message");
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
+            Ensure.ArgumentNotNull(message, nameof(message));
+            Ensure.ArgumentNotNull(target, nameof(target));
+            Ensure.ArgumentNotNull(tagger, nameof(tagger));
+            Ensure.ArgumentDoesNotContainZeroByte(name, nameof(name));
+            Ensure.ArgumentDoesNotContainZeroByte(message, nameof(message));
 
             string prettifiedMessage = Proxy.git_message_prettify(message, null);
 
@@ -517,8 +517,8 @@ namespace LibGit2Sharp
         /// <param name="archiver">The archiver to use.</param>
         public virtual void Archive(Commit commit, ArchiverBase archiver)
         {
-            Ensure.ArgumentNotNull(commit, "commit");
-            Ensure.ArgumentNotNull(archiver, "archiver");
+            Ensure.ArgumentNotNull(commit, nameof(commit));
+            Ensure.ArgumentNotNull(archiver, nameof(archiver));
 
             archiver.OrchestrateArchiving(commit.Tree, commit.Id, commit.Committer.When);
         }
@@ -530,8 +530,8 @@ namespace LibGit2Sharp
         /// <param name="archiver">The archiver to use.</param>
         public virtual void Archive(Tree tree, ArchiverBase archiver)
         {
-            Ensure.ArgumentNotNull(tree, "tree");
-            Ensure.ArgumentNotNull(archiver, "archiver");
+            Ensure.ArgumentNotNull(tree, nameof(tree));
+            Ensure.ArgumentNotNull(archiver, nameof(archiver));
 
             archiver.OrchestrateArchiving(tree, null, DateTimeOffset.UtcNow);
         }
@@ -545,8 +545,8 @@ namespace LibGit2Sharp
         /// <returns>A instance of <see cref="HistoryDivergence"/>.</returns>
         public virtual HistoryDivergence CalculateHistoryDivergence(Commit one, Commit another)
         {
-            Ensure.ArgumentNotNull(one, "one");
-            Ensure.ArgumentNotNull(another, "another");
+            Ensure.ArgumentNotNull(one, nameof(one));
+            Ensure.ArgumentNotNull(another, nameof(another));
 
             return new HistoryDivergence(repo, one, another);
         }
@@ -561,8 +561,8 @@ namespace LibGit2Sharp
         /// <returns>A result containing a <see cref="Tree"/> if the cherry-pick was successful and a list of <see cref="Conflict"/>s if it is not.</returns>
         public virtual MergeTreeResult CherryPickCommit(Commit cherryPickCommit, Commit cherryPickOnto, int mainline, MergeTreeOptions options)
         {
-            Ensure.ArgumentNotNull(cherryPickCommit, "cherryPickCommit");
-            Ensure.ArgumentNotNull(cherryPickOnto, "cherryPickOnto");
+            Ensure.ArgumentNotNull(cherryPickCommit, nameof(cherryPickCommit));
+            Ensure.ArgumentNotNull(cherryPickOnto, nameof(cherryPickOnto));
 
             var modifiedOptions = new MergeTreeOptions();
 
@@ -635,11 +635,11 @@ namespace LibGit2Sharp
         /// <returns>A short string representation of the <see cref="ObjectId"/>.</returns>
         public virtual string ShortenObjectId(GitObject gitObject, int minLength)
         {
-            Ensure.ArgumentNotNull(gitObject, "gitObject");
+            Ensure.ArgumentNotNull(gitObject, nameof(gitObject));
 
             if (minLength <= 0 || minLength > ObjectId.HexSize)
             {
-                throw new ArgumentOutOfRangeException("minLength",
+                throw new ArgumentOutOfRangeException(nameof(minLength),
                                                       minLength,
                                                       string.Format("Expected value should be greater than zero and less than or equal to {0}.",
                                                                     ObjectId.HexSize));
@@ -669,8 +669,8 @@ namespace LibGit2Sharp
         /// <returns>True if the merge does not result in a conflict, false otherwise.</returns>
         public virtual bool CanMergeWithoutConflict(Commit one, Commit another)
         {
-            Ensure.ArgumentNotNull(one, "one");
-            Ensure.ArgumentNotNull(another, "another");
+            Ensure.ArgumentNotNull(one, nameof(one));
+            Ensure.ArgumentNotNull(another, nameof(another));
 
             var opts = new MergeTreeOptions()
             {
@@ -690,8 +690,8 @@ namespace LibGit2Sharp
         /// <returns>The merge base or null if none found.</returns>
         public virtual Commit FindMergeBase(Commit first, Commit second)
         {
-            Ensure.ArgumentNotNull(first, "first");
-            Ensure.ArgumentNotNull(second, "second");
+            Ensure.ArgumentNotNull(first, nameof(first));
+            Ensure.ArgumentNotNull(second, nameof(second));
 
             return FindMergeBase(new[] { first, second }, MergeBaseFindingStrategy.Standard);
         }
@@ -704,7 +704,7 @@ namespace LibGit2Sharp
         /// <returns>The merge base or null if none found.</returns>
         public virtual Commit FindMergeBase(IEnumerable<Commit> commits, MergeBaseFindingStrategy strategy)
         {
-            Ensure.ArgumentNotNull(commits, "commits");
+            Ensure.ArgumentNotNull(commits, nameof(commits));
 
             ObjectId id;
             List<GitOid> ids = new List<GitOid>(8);
@@ -714,7 +714,7 @@ namespace LibGit2Sharp
             {
                 if (commit == null)
                 {
-                    throw new ArgumentException("Enumerable contains null at position: " + count.ToString(CultureInfo.InvariantCulture), "commits");
+                    throw new ArgumentException("Enumerable contains null at position: " + count.ToString(CultureInfo.InvariantCulture), nameof(commits));
                 }
                 ids.Add(commit.Id.Oid);
                 count++;
@@ -722,7 +722,7 @@ namespace LibGit2Sharp
 
             if (count < 2)
             {
-                throw new ArgumentException("The enumerable must contains at least two commits.", "commits");
+                throw new ArgumentException("The enumerable must contains at least two commits.", nameof(commits));
             }
 
             switch (strategy)
@@ -736,7 +736,7 @@ namespace LibGit2Sharp
                     break;
 
                 default:
-                    throw new ArgumentException("", "strategy");
+                    throw new ArgumentException("", nameof(strategy));
             }
 
             return id == null ? null : repo.Lookup<Commit>(id);
@@ -753,8 +753,8 @@ namespace LibGit2Sharp
         /// <returns>The <see cref="MergeTreeResult"/> containing the merged trees and any conflicts</returns>
         public virtual MergeTreeResult MergeCommits(Commit ours, Commit theirs, MergeTreeOptions options)
         {
-            Ensure.ArgumentNotNull(ours, "ours");
-            Ensure.ArgumentNotNull(theirs, "theirs");
+            Ensure.ArgumentNotNull(ours, nameof(ours));
+            Ensure.ArgumentNotNull(theirs, nameof(theirs));
 
             var modifiedOptions = new MergeTreeOptions();
 
@@ -849,8 +849,8 @@ namespace LibGit2Sharp
         /// The index must be disposed by the caller.</returns>
         public virtual TransientIndex MergeCommitsIntoIndex(Commit ours, Commit theirs, MergeTreeOptions options)
         {
-            Ensure.ArgumentNotNull(ours, "ours");
-            Ensure.ArgumentNotNull(theirs, "theirs");
+            Ensure.ArgumentNotNull(ours, nameof(ours));
+            Ensure.ArgumentNotNull(theirs, nameof(theirs));
 
             options = options ?? new MergeTreeOptions();
 
@@ -879,8 +879,8 @@ namespace LibGit2Sharp
         /// The index must be disposed by the caller. </returns>
         public virtual TransientIndex CherryPickCommitIntoIndex(Commit cherryPickCommit, Commit cherryPickOnto, int mainline, MergeTreeOptions options)
         {
-            Ensure.ArgumentNotNull(cherryPickCommit, "cherryPickCommit");
-            Ensure.ArgumentNotNull(cherryPickOnto, "cherryPickOnto");
+            Ensure.ArgumentNotNull(cherryPickCommit, nameof(cherryPickCommit));
+            Ensure.ArgumentNotNull(cherryPickOnto, nameof(cherryPickOnto));
 
             options = options ?? new MergeTreeOptions();
 
@@ -992,8 +992,8 @@ namespace LibGit2Sharp
         /// <returns>Packing results</returns>
         private PackBuilderResults InternalPack(PackBuilderOptions options, Action<PackBuilder> packDelegate)
         {
-            Ensure.ArgumentNotNull(options, "options");
-            Ensure.ArgumentNotNull(packDelegate, "packDelegate");
+            Ensure.ArgumentNotNull(options, nameof(options));
+            Ensure.ArgumentNotNull(packDelegate, nameof(packDelegate));
 
             PackBuilderResults results = new PackBuilderResults();
 
@@ -1025,8 +1025,8 @@ namespace LibGit2Sharp
         /// <returns>A result containing a <see cref="Tree"/> if the revert was successful and a list of <see cref="Conflict"/>s if it is not.</returns>
         public virtual MergeTreeResult RevertCommit(Commit revertCommit, Commit revertOnto, int mainline, MergeTreeOptions options)
         {
-            Ensure.ArgumentNotNull(revertCommit, "revertCommit");
-            Ensure.ArgumentNotNull(revertOnto, "revertOnto");
+            Ensure.ArgumentNotNull(revertCommit, nameof(revertCommit));
+            Ensure.ArgumentNotNull(revertOnto, nameof(revertOnto));
 
             options = options ?? new MergeTreeOptions();
 

--- a/LibGit2Sharp/Signature.cs
+++ b/LibGit2Sharp/Signature.cs
@@ -32,10 +32,10 @@ namespace LibGit2Sharp
         /// <param name="when">The when.</param>
         public Signature(string name, string email, DateTimeOffset when)
         {
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");
-            Ensure.ArgumentNotNullOrEmptyString(email, "email");
-            Ensure.ArgumentDoesNotContainZeroByte(name, "name");
-            Ensure.ArgumentDoesNotContainZeroByte(email, "email");
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
+            Ensure.ArgumentNotNullOrEmptyString(email, nameof(email));
+            Ensure.ArgumentDoesNotContainZeroByte(name, nameof(name));
+            Ensure.ArgumentDoesNotContainZeroByte(email, nameof(email));
 
             this.name = name;
             this.email = email;
@@ -49,7 +49,7 @@ namespace LibGit2Sharp
         /// <param name="when">The when.</param>
         public Signature(Identity identity, DateTimeOffset when)
         {
-            Ensure.ArgumentNotNull(identity, "identity");
+            Ensure.ArgumentNotNull(identity, nameof(identity));
 
             this.name = identity.Name;
             this.email = identity.Email;


### PR DESCRIPTION
There are many other such checks that remain to be converted, but I figured they would perhaps be too many to review, so I'm doing splitting it in bite-sized pull requests. If this one is merged I want to do more of them in the future.