### PR TITLE
Add proxy options

### DIFF
--- a/LibGit2Sharp.Tests/CloneFixture.cs
+++ b/LibGit2Sharp.Tests/CloneFixture.cs
@@ -567,10 +567,8 @@ namespace LibGit2Sharp.Tests
             const string url = "https://github.com/libgit2/TestGitRepository";
 
             const string knownHeader = "User-Agent: mygit-201";
-            var cloneOptions = new CloneOptions()
-            {
-                FetchOptions = new FetchOptions { CustomHeaders = new String[] { knownHeader } }
-            };
+            var cloneOptions = new CloneOptions();
+            cloneOptions.FetchOptions.CustomHeaders = new string[] { knownHeader };
 
             Assert.Throws<LibGit2SharpException>(() => Repository.Clone(url, scd.DirectoryPath, cloneOptions));
         }
@@ -583,10 +581,8 @@ namespace LibGit2Sharp.Tests
             const string url = "https://github.com/libgit2/TestGitRepository";
 
             const string knownHeader = "hello world";
-            var cloneOptions = new CloneOptions()
-            {
-                FetchOptions = new FetchOptions { CustomHeaders = new String[] { knownHeader } }
-            };
+            var cloneOptions = new CloneOptions();
+            cloneOptions.FetchOptions.CustomHeaders = new string[] { knownHeader };
 
             Assert.Throws<LibGit2SharpException>(() => Repository.Clone(url, scd.DirectoryPath, cloneOptions));
         }
@@ -599,10 +595,8 @@ namespace LibGit2Sharp.Tests
             const string url = "https://github.com/libgit2/TestGitRepository";
 
             const string knownHeader = "X-Hello: world";
-            var cloneOptions = new CloneOptions()
-            {
-                FetchOptions = new FetchOptions { CustomHeaders = new String[] { knownHeader } }
-            };
+            var cloneOptions = new CloneOptions();
+            cloneOptions.FetchOptions.CustomHeaders = new string[] { knownHeader };
 
             var clonedRepoPath = Repository.Clone(url, scd.DirectoryPath, cloneOptions);
             Assert.True(Directory.Exists(clonedRepoPath));

--- a/LibGit2Sharp.Tests/SubmoduleFixture.cs
+++ b/LibGit2Sharp.Tests/SubmoduleFixture.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Linq;
 using LibGit2Sharp.Tests.TestHelpers;
 using Xunit;
-using Xunit.Extensions;
 
 namespace LibGit2Sharp.Tests
 {
@@ -240,8 +239,9 @@ namespace LibGit2Sharp.Tests
                     OnCheckoutProgress = (x, y, z) => checkoutProgressCalled = true,
                     OnCheckoutNotify = (x, y) => { checkoutNotifyCalled = true; return true; },
                     CheckoutNotifyFlags = CheckoutNotifyFlags.Updated,
-                    OnUpdateTips = (x, y, z) => { updateTipsCalled = true; return true; },
                 };
+
+                options.FetchOptions.OnUpdateTips = (x, y, z) => { updateTipsCalled = true; return true; };
 
                 repo.Submodules.Init(submodule.Name, false);
                 repo.Submodules.Update(submodule.Name, options);

--- a/LibGit2Sharp/CloneOptions.cs
+++ b/LibGit2Sharp/CloneOptions.cs
@@ -46,7 +46,7 @@ namespace LibGit2Sharp
         /// <summary>
         /// Gets or sets the fetch options.
         /// </summary>
-        public FetchOptions FetchOptions { get; set; }
+        public FetchOptions FetchOptions { get; set; } = new();
 
         #region IConvertableToGitCheckoutOpts
 

--- a/LibGit2Sharp/CloneOptions.cs
+++ b/LibGit2Sharp/CloneOptions.cs
@@ -6,7 +6,7 @@ namespace LibGit2Sharp
     /// <summary>
     /// Options to define clone behaviour
     /// </summary>
-    public sealed class CloneOptions : FetchOptionsBase, IConvertableToGitCheckoutOpts
+    public sealed class CloneOptions : IConvertableToGitCheckoutOpts
     {
         /// <summary>
         /// Creates default <see cref="CloneOptions"/> for a non-bare clone

--- a/LibGit2Sharp/CloneOptions.cs
+++ b/LibGit2Sharp/CloneOptions.cs
@@ -46,7 +46,7 @@ namespace LibGit2Sharp
         /// <summary>
         /// Gets or sets the fetch options.
         /// </summary>
-        public FetchOptions FetchOptions { get; set; } = new();
+        public FetchOptions FetchOptions { get; } = new();
 
         #region IConvertableToGitCheckoutOpts
 

--- a/LibGit2Sharp/Commands/Fetch.cs
+++ b/LibGit2Sharp/Commands/Fetch.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using LibGit2Sharp;
 using LibGit2Sharp.Core;
 using LibGit2Sharp.Core.Handles;
 
@@ -75,7 +74,7 @@ namespace LibGit2Sharp
                     fetchOptions.CustomHeaders = GitStrArrayManaged.BuildFrom(options.CustomHeaders);
                 }
 
-                fetchOptions.ProxyOptions = new GitProxyOptions { Version = 1 };
+                fetchOptions.ProxyOptions = options.ProxyOptions.CreateGitProxyOptions();
 
                 Proxy.git_remote_fetch(remoteHandle, refspecs, fetchOptions, logMessage);
             }

--- a/LibGit2Sharp/Core/GitFetchOptionsWrapper.cs
+++ b/LibGit2Sharp/Core/GitFetchOptionsWrapper.cs
@@ -2,8 +2,8 @@
 
 namespace LibGit2Sharp.Core
 {
-    /// <summary> 
-    /// Git fetch options wrapper. Disposable wrapper for GitFetchOptions 
+    /// <summary>
+    /// Git fetch options wrapper. Disposable wrapper for GitFetchOptions
     /// </summary>
     internal class GitFetchOptionsWrapper : IDisposable
     {
@@ -11,7 +11,7 @@ namespace LibGit2Sharp.Core
 
         public GitFetchOptionsWrapper(GitFetchOptions fetchOptions)
         {
-            this.Options = fetchOptions;
+            Options = fetchOptions;
         }
 
         public GitFetchOptions Options { get; private set; }
@@ -23,7 +23,8 @@ namespace LibGit2Sharp.Core
             if (disposedValue)
                 return;
 
-            this.Options.CustomHeaders.Dispose();
+            Options.CustomHeaders.Dispose();
+            EncodingMarshaler.Cleanup(Options.ProxyOptions.Url);
             disposedValue = true;
         }
 

--- a/LibGit2Sharp/Core/GitProxyOptions.cs
+++ b/LibGit2Sharp/Core/GitProxyOptions.cs
@@ -16,8 +16,8 @@ namespace LibGit2Sharp.Core
         public uint Version;
         public GitProxyType Type;
         public IntPtr Url;
-        public IntPtr CredentialsCb;
-        public IntPtr CertificateCheck;
-        public IntPtr CbPayload;
+        public NativeMethods.git_cred_acquire_cb Credentials;
+        public NativeMethods.git_transport_certificate_check_cb CertificateCheck;
+        public IntPtr Payload;
     }
 }

--- a/LibGit2Sharp/Core/GitProxyOptionsWrapper.cs
+++ b/LibGit2Sharp/Core/GitProxyOptionsWrapper.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace LibGit2Sharp.Core
+{
+    internal class GitProxyOptionsWrapper : IDisposable
+    {
+        public GitProxyOptionsWrapper() : this(new GitProxyOptions()) { }
+
+        public GitProxyOptionsWrapper(GitProxyOptions fetchOptions)
+        {
+            Options = fetchOptions;
+        }
+
+        public GitProxyOptions Options { get; private set; }
+
+        private bool disposedValue = false;
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposedValue)
+                return;
+
+            EncodingMarshaler.Cleanup(Options.Url);
+            disposedValue = true;
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+    }
+}

--- a/LibGit2Sharp/Core/GitPushOptionsWrapper.cs
+++ b/LibGit2Sharp/Core/GitPushOptionsWrapper.cs
@@ -24,6 +24,7 @@ namespace LibGit2Sharp.Core
                 return;
 
             this.Options.CustomHeaders.Dispose();
+            EncodingMarshaler.Cleanup(Options.ProxyOptions.Url);
             disposedValue = true;
         }
 

--- a/LibGit2Sharp/Core/GitSubmoduleOptions.cs
+++ b/LibGit2Sharp/Core/GitSubmoduleOptions.cs
@@ -11,8 +11,6 @@ namespace LibGit2Sharp.Core
 
         public GitFetchOptions FetchOptions;
 
-        public CheckoutStrategy CloneCheckoutStrategy;
-
         public int AllowFetch;
     }
 }

--- a/LibGit2Sharp/FetchOptions.cs
+++ b/LibGit2Sharp/FetchOptions.cs
@@ -28,14 +28,14 @@
 
         /// <summary>
         /// Get/Set the custom headers.
-        /// 
-        /// <para> 
-        /// This allows you to set custom headers (e.g. X-Forwarded-For, 
+        ///
+        /// <para>
+        /// This allows you to set custom headers (e.g. X-Forwarded-For,
         /// X-Request-Id, etc),
         /// </para>
         /// </summary>
         /// <remarks>
-        /// Libgit2 sets some headers for HTTP requests (User-Agent, Host, 
+        /// Libgit2 sets some headers for HTTP requests (User-Agent, Host,
         /// Accept, Content-Type, Transfer-Encoding, Content-Length, Accept) that
         /// cannot be overriden.
         /// </remarks>

--- a/LibGit2Sharp/FetchOptionsBase.cs
+++ b/LibGit2Sharp/FetchOptionsBase.cs
@@ -49,6 +49,6 @@ namespace LibGit2Sharp
         /// </summary>
         public RepositoryOperationCompleted RepositoryOperationCompleted { get; set; }
 
-        public ProxyOptions ProxyOptions { get; set; }
+        public ProxyOptions ProxyOptions { get; set; } = new();
     }
 }

--- a/LibGit2Sharp/FetchOptionsBase.cs
+++ b/LibGit2Sharp/FetchOptionsBase.cs
@@ -35,7 +35,7 @@ namespace LibGit2Sharp
 
         /// <summary>
         /// This handler will be called to let the user make a decision on whether to allow
-        /// the connection to preoceed based on the certificate presented by the server.
+        /// the connection to proceed based on the certificate presented by the server.
         /// </summary>
         public CertificateCheckHandler CertificateCheck { get; set; }
 
@@ -49,6 +49,9 @@ namespace LibGit2Sharp
         /// </summary>
         public RepositoryOperationCompleted RepositoryOperationCompleted { get; set; }
 
+        /// <summary>
+        /// Options for connecting through a proxy.
+        /// </summary>
         public ProxyOptions ProxyOptions { get; } = new();
     }
 }

--- a/LibGit2Sharp/FetchOptionsBase.cs
+++ b/LibGit2Sharp/FetchOptionsBase.cs
@@ -48,5 +48,7 @@ namespace LibGit2Sharp
         /// Completed operating on the current repository.
         /// </summary>
         public RepositoryOperationCompleted RepositoryOperationCompleted { get; set; }
+
+        public ProxyOptions ProxyOptions { get; set; }
     }
 }

--- a/LibGit2Sharp/FetchOptionsBase.cs
+++ b/LibGit2Sharp/FetchOptionsBase.cs
@@ -49,6 +49,6 @@ namespace LibGit2Sharp
         /// </summary>
         public RepositoryOperationCompleted RepositoryOperationCompleted { get; set; }
 
-        public ProxyOptions ProxyOptions { get; set; } = new();
+        public ProxyOptions ProxyOptions { get; } = new();
     }
 }

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;net6.0</TargetFrameworks>
+    <LangVersion>10.0</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>LibGit2Sharp brings all the might and speed of libgit2, a native Git implementation, to the managed world of .NET</Description>
     <Company>LibGit2Sharp contributors</Company>

--- a/LibGit2Sharp/Network.cs
+++ b/LibGit2Sharp/Network.cs
@@ -52,7 +52,14 @@ namespace LibGit2Sharp
         {
             Ensure.ArgumentNotNull(remote, "remote");
 
-            return ListReferencesInternal(remote.Url, null);
+            return ListReferencesInternal(remote.Url, null, new ProxyOptions());
+        }
+
+        public virtual IEnumerable<Reference> ListReferences(Remote remote, ProxyOptions proxyOptions)
+        {
+            Ensure.ArgumentNotNull(remote, "remote");
+
+            return ListReferencesInternal(remote.Url, null, proxyOptions);
         }
 
         /// <summary>
@@ -72,7 +79,15 @@ namespace LibGit2Sharp
             Ensure.ArgumentNotNull(remote, "remote");
             Ensure.ArgumentNotNull(credentialsProvider, "credentialsProvider");
 
-            return ListReferencesInternal(remote.Url, credentialsProvider);
+            return ListReferencesInternal(remote.Url, credentialsProvider, new ProxyOptions());
+        }
+
+        public virtual IEnumerable<Reference> ListReferences(Remote remote, CredentialsHandler credentialsProvider, ProxyOptions proxyOptions)
+        {
+            Ensure.ArgumentNotNull(remote, "remote");
+            Ensure.ArgumentNotNull(credentialsProvider, "credentialsProvider");
+
+            return ListReferencesInternal(remote.Url, credentialsProvider, proxyOptions);
         }
 
         /// <summary>
@@ -90,7 +105,14 @@ namespace LibGit2Sharp
         {
             Ensure.ArgumentNotNull(url, "url");
 
-            return ListReferencesInternal(url, null);
+            return ListReferencesInternal(url, null, new ProxyOptions());
+        }
+
+        public virtual IEnumerable<Reference> ListReferences(string url, ProxyOptions proxyOptions)
+        {
+            Ensure.ArgumentNotNull(url, "url");
+
+            return ListReferencesInternal(url, null, proxyOptions);
         }
 
         /// <summary>
@@ -110,25 +132,36 @@ namespace LibGit2Sharp
             Ensure.ArgumentNotNull(url, "url");
             Ensure.ArgumentNotNull(credentialsProvider, "credentialsProvider");
 
-            return ListReferencesInternal(url, credentialsProvider);
+            return ListReferencesInternal(url, credentialsProvider, new ProxyOptions());
         }
 
-        private IEnumerable<Reference> ListReferencesInternal(string url, CredentialsHandler credentialsProvider)
+        public virtual IEnumerable<Reference> ListReferences(string url, CredentialsHandler credentialsProvider, ProxyOptions proxyOptions)
         {
-            using (RemoteHandle remoteHandle = BuildRemoteHandle(repository.Handle, url))
+            Ensure.ArgumentNotNull(url, "url");
+            Ensure.ArgumentNotNull(credentialsProvider, "credentialsProvider");
+
+            return ListReferencesInternal(url, credentialsProvider, new ProxyOptions());
+        }
+
+        private IEnumerable<Reference> ListReferencesInternal(string url, CredentialsHandler credentialsProvider, ProxyOptions proxyOptions)
+        {
+            proxyOptions ??= new();
+
+            using RemoteHandle remoteHandle = BuildRemoteHandle(repository.Handle, url);
+            using var proxyOptionsWrapper = new GitProxyOptionsWrapper(proxyOptions.CreateGitProxyOptions());
+
+            GitRemoteCallbacks gitCallbacks = new GitRemoteCallbacks { version = 1 };
+
+            if (credentialsProvider != null)
             {
-                GitRemoteCallbacks gitCallbacks = new GitRemoteCallbacks { version = 1 };
-                GitProxyOptions proxyOptions = new GitProxyOptions { Version = 1 };
-
-                if (credentialsProvider != null)
-                {
-                    var callbacks = new RemoteCallbacks(credentialsProvider);
-                    gitCallbacks = callbacks.GenerateCallbacks();
-                }
-
-                Proxy.git_remote_connect(remoteHandle, GitDirection.Fetch, ref gitCallbacks, ref proxyOptions);
-                return Proxy.git_remote_ls(repository, remoteHandle);
+                var callbacks = new RemoteCallbacks(credentialsProvider);
+                gitCallbacks = callbacks.GenerateCallbacks();
             }
+
+            var gitProxyOptions = proxyOptionsWrapper.Options;
+
+            Proxy.git_remote_connect(remoteHandle, GitDirection.Fetch, ref gitCallbacks, ref gitProxyOptions);
+            return Proxy.git_remote_ls(repository, remoteHandle);
         }
 
         static RemoteHandle BuildRemoteHandle(RepositoryHandle repoHandle, string url)
@@ -375,7 +408,7 @@ namespace LibGit2Sharp
                 var gitPushOptions = pushOptionsWrapper.Options;
                 gitPushOptions.PackbuilderDegreeOfParallelism = pushOptions.PackbuilderDegreeOfParallelism;
                 gitPushOptions.RemoteCallbacks = gitCallbacks;
-                gitPushOptions.ProxyOptions = new GitProxyOptions { Version = 1 };
+                gitPushOptions.ProxyOptions = pushOptions.ProxyOptions.CreateGitProxyOptions();
 
                 // If there are custom headers, create a managed string array.
                 if (pushOptions.CustomHeaders != null && pushOptions.CustomHeaders.Length > 0)

--- a/LibGit2Sharp/Network.cs
+++ b/LibGit2Sharp/Network.cs
@@ -55,6 +55,18 @@ namespace LibGit2Sharp
             return ListReferencesInternal(remote.Url, null, new ProxyOptions());
         }
 
+        /// <summary>
+        /// List references in a <see cref="Remote"/> repository.
+        /// <para>
+        /// When the remote tips are ahead of the local ones, the retrieved
+        /// <see cref="DirectReference"/>s may point to non existing
+        /// <see cref="GitObject"/>s in the local repository. In that
+        /// case, <see cref="DirectReference.Target"/> will return <c>null</c>.
+        /// </para>
+        /// </summary>
+        /// <param name="remote">The <see cref="Remote"/> to list from.</param>
+        /// <param name="proxyOptions">Options for connecting through a proxy.</param>
+        /// <returns>The references in the <see cref="Remote"/> repository.</returns>
         public virtual IEnumerable<Reference> ListReferences(Remote remote, ProxyOptions proxyOptions)
         {
             Ensure.ArgumentNotNull(remote, "remote");
@@ -82,6 +94,19 @@ namespace LibGit2Sharp
             return ListReferencesInternal(remote.Url, credentialsProvider, new ProxyOptions());
         }
 
+        /// <summary>
+        /// List references in a <see cref="Remote"/> repository.
+        /// <para>
+        /// When the remote tips are ahead of the local ones, the retrieved
+        /// <see cref="DirectReference"/>s may point to non existing
+        /// <see cref="GitObject"/>s in the local repository. In that
+        /// case, <see cref="DirectReference.Target"/> will return <c>null</c>.
+        /// </para>
+        /// </summary>
+        /// <param name="remote">The <see cref="Remote"/> to list from.</param>
+        /// <param name="credentialsProvider">The <see cref="Func{Credentials}"/> used to connect to remote repository.</param>
+        /// <param name="proxyOptions">Options for connecting through a proxy.</param>
+        /// <returns>The references in the <see cref="Remote"/> repository.</returns>
         public virtual IEnumerable<Reference> ListReferences(Remote remote, CredentialsHandler credentialsProvider, ProxyOptions proxyOptions)
         {
             Ensure.ArgumentNotNull(remote, "remote");
@@ -108,6 +133,18 @@ namespace LibGit2Sharp
             return ListReferencesInternal(url, null, new ProxyOptions());
         }
 
+        /// <summary>
+        /// List references in a remote repository.
+        /// <para>
+        /// When the remote tips are ahead of the local ones, the retrieved
+        /// <see cref="DirectReference"/>s may point to non existing
+        /// <see cref="GitObject"/>s in the local repository. In that
+        /// case, <see cref="DirectReference.Target"/> will return <c>null</c>.
+        /// </para>
+        /// </summary>
+        /// <param name="url">The url to list from.</param>
+        /// <param name="proxyOptions">Options for connecting through a proxy.</param>
+        /// <returns>The references in the remote repository.</returns>
         public virtual IEnumerable<Reference> ListReferences(string url, ProxyOptions proxyOptions)
         {
             Ensure.ArgumentNotNull(url, "url");
@@ -135,6 +172,19 @@ namespace LibGit2Sharp
             return ListReferencesInternal(url, credentialsProvider, new ProxyOptions());
         }
 
+        /// <summary>
+        /// List references in a remote repository.
+        /// <para>
+        /// When the remote tips are ahead of the local ones, the retrieved
+        /// <see cref="DirectReference"/>s may point to non existing
+        /// <see cref="GitObject"/>s in the local repository. In that
+        /// case, <see cref="DirectReference.Target"/> will return <c>null</c>.
+        /// </para>
+        /// </summary>
+        /// <param name="url">The url to list from.</param>
+        /// <param name="credentialsProvider">The <see cref="Func{Credentials}"/> used to connect to remote repository.</param>
+        /// <param name="proxyOptions">Options for connecting through a proxy.</param>
+        /// <returns>The references in the remote repository.</returns>
         public virtual IEnumerable<Reference> ListReferences(string url, CredentialsHandler credentialsProvider, ProxyOptions proxyOptions)
         {
             Ensure.ArgumentNotNull(url, "url");

--- a/LibGit2Sharp/ProxyOptions.cs
+++ b/LibGit2Sharp/ProxyOptions.cs
@@ -4,14 +4,30 @@ using LibGit2Sharp.Handlers;
 
 namespace LibGit2Sharp
 {
+    /// <summary>
+    /// Options for connecting through a proxy.
+    /// </summary>
     public sealed class ProxyOptions
     {
+        /// <summary>
+        /// The type of proxy to use. Set to Auto by default.
+        /// </summary>
         public ProxyType ProxyType { get; set; } = ProxyType.Auto;
 
+        /// <summary>
+        /// The URL of the proxy when <see cref="LibGit2Sharp.ProxyType"/> is set to Specified.
+        /// </summary>
         public string Url { get; set; }
 
+        /// <summary>
+        /// Handler to generate <see cref="LibGit2Sharp.Credentials"/> for authentication.
+        /// </summary>
         public CredentialsHandler CredentialsProvider { get; set; }
 
+        /// <summary>
+        /// This handler will be called to let the user make a decision on whether to allow
+        /// the connection to proceed based on the certificate presented by the server.
+        /// </summary>
         public CertificateCheckHandler CertificateCheck { get; set; }
 
         internal unsafe GitProxyOptions CreateGitProxyOptions()

--- a/LibGit2Sharp/ProxyOptions.cs
+++ b/LibGit2Sharp/ProxyOptions.cs
@@ -1,15 +1,103 @@
-﻿using LibGit2Sharp.Handlers;
+﻿using System;
+using LibGit2Sharp.Core;
+using LibGit2Sharp.Handlers;
 
 namespace LibGit2Sharp
 {
     public class ProxyOptions
     {
-        public ProxyType ProxyType { get; set; }
+        public ProxyType ProxyType { get; set; } = ProxyType.Auto;
 
         public string Url { get; set; }
 
         public CredentialsHandler CredentialsProvider { get; set; }
 
         public CertificateCheckHandler CertificateCheck { get; set; }
+
+        internal unsafe GitProxyOptions CreateGitProxyOptions()
+        {
+            var gitProxyOptions = new GitProxyOptions
+            {
+                Version = 1,
+                Type = (GitProxyType)ProxyType
+            };
+
+            if (Url is not null)
+            {
+                gitProxyOptions.Url = StrictUtf8Marshaler.FromManaged(Url);
+            }
+
+            if (CredentialsProvider is not null)
+            {
+                gitProxyOptions.Credentials = GitCredentialHandler;
+            }
+
+            if (CertificateCheck is not null)
+            {
+                gitProxyOptions.CertificateCheck = GitCertificateCheck;
+            }
+
+            return gitProxyOptions;
+        }
+
+        private int GitCredentialHandler(out IntPtr ptr, IntPtr cUrl, IntPtr usernameFromUrl, GitCredentialType credTypes, IntPtr payload)
+        {
+            string url = LaxUtf8Marshaler.FromNative(cUrl);
+            string username = LaxUtf8Marshaler.FromNative(usernameFromUrl);
+
+            SupportedCredentialTypes types = default(SupportedCredentialTypes);
+            if (credTypes.HasFlag(GitCredentialType.UserPassPlaintext))
+            {
+                types |= SupportedCredentialTypes.UsernamePassword;
+            }
+            if (credTypes.HasFlag(GitCredentialType.Default))
+            {
+                types |= SupportedCredentialTypes.Default;
+            }
+
+            ptr = IntPtr.Zero;
+            try
+            {
+                var cred = CredentialsProvider(url, username, types);
+                if (cred == null)
+                {
+                    return (int)GitErrorCode.PassThrough;
+                }
+                return cred.GitCredentialHandler(out ptr);
+            }
+            catch (Exception exception)
+            {
+                Proxy.git_error_set_str(GitErrorCategory.Callback, exception);
+                return (int)GitErrorCode.Error;
+            }
+        }
+
+        private unsafe int GitCertificateCheck(git_certificate* certPtr, int valid, IntPtr cHostname, IntPtr payload)
+        {
+            string hostname = LaxUtf8Marshaler.FromNative(cHostname);
+            Certificate cert = null;
+
+            switch (certPtr->type)
+            {
+                case GitCertificateType.X509:
+                    cert = new CertificateX509((git_certificate_x509*)certPtr);
+                    break;
+                case GitCertificateType.Hostkey:
+                    cert = new CertificateSsh((git_certificate_ssh*)certPtr);
+                    break;
+            }
+
+            bool result = false;
+            try
+            {
+                result = CertificateCheck(cert, valid != 0, hostname);
+            }
+            catch (Exception exception)
+            {
+                Proxy.git_error_set_str(GitErrorCategory.Callback, exception);
+            }
+
+            return Proxy.ConvertResultToCancelFlag(result);
+        }
     }
 }

--- a/LibGit2Sharp/ProxyOptions.cs
+++ b/LibGit2Sharp/ProxyOptions.cs
@@ -4,7 +4,7 @@ using LibGit2Sharp.Handlers;
 
 namespace LibGit2Sharp
 {
-    public class ProxyOptions
+    public sealed class ProxyOptions
     {
         public ProxyType ProxyType { get; set; } = ProxyType.Auto;
 

--- a/LibGit2Sharp/ProxyOptions.cs
+++ b/LibGit2Sharp/ProxyOptions.cs
@@ -1,0 +1,15 @@
+﻿using LibGit2Sharp.Handlers;
+
+namespace LibGit2Sharp
+{
+    public class ProxyOptions
+    {
+        public ProxyType ProxyType { get; set; }
+
+        public string Url { get; set; }
+
+        public CredentialsHandler CredentialsProvider { get; set; }
+
+        public CertificateCheckHandler CertificateCheck { get; set; }
+    }
+}

--- a/LibGit2Sharp/ProxyType.cs
+++ b/LibGit2Sharp/ProxyType.cs
@@ -1,0 +1,9 @@
+﻿namespace LibGit2Sharp
+{
+    public enum ProxyType
+    {
+        None,
+        Auto,
+        Specified
+    }
+}

--- a/LibGit2Sharp/ProxyType.cs
+++ b/LibGit2Sharp/ProxyType.cs
@@ -1,9 +1,23 @@
 ﻿namespace LibGit2Sharp
 {
+    /// <summary>
+    /// The type of proxy to use.
+    /// </summary>
     public enum ProxyType
     {
+        /// <summary>
+        /// Do not attempt to connect through a proxy.
+        /// </summary>
         None,
+
+        /// <summary>
+        /// Try to auto-detect the proxy from the git configuration.
+        /// </summary>
         Auto,
+
+        /// <summary>
+        /// Connect via the URL given in the options.
+        /// </summary>
         Specified
     }
 }

--- a/LibGit2Sharp/PushOptions.cs
+++ b/LibGit2Sharp/PushOptions.cs
@@ -72,6 +72,9 @@ namespace LibGit2Sharp
         /// <value>The custom headers string array</value>
         public string[] CustomHeaders { get; set; }
 
+        /// <summary>
+        /// Options for connecting through a proxy.
+        /// </summary>
         public ProxyOptions ProxyOptions { get; set; } = new();
     }
 }

--- a/LibGit2Sharp/PushOptions.cs
+++ b/LibGit2Sharp/PushOptions.cs
@@ -71,5 +71,7 @@ namespace LibGit2Sharp
         /// </example>
         /// <value>The custom headers string array</value>
         public string[] CustomHeaders { get; set; }
+
+        public ProxyOptions ProxyOptions { get; set; } = new();
     }
 }

--- a/LibGit2Sharp/Repository.cs
+++ b/LibGit2Sharp/Repository.cs
@@ -865,14 +865,11 @@ namespace LibGit2Sharp
 
                 using (Repository repo = new Repository(repoPath))
                 {
-                    SubmoduleUpdateOptions updateOptions = new SubmoduleUpdateOptions()
+                    var updateOptions = new SubmoduleUpdateOptions()
                     {
                         Init = true,
-                        CredentialsProvider = options.FetchOptions.CredentialsProvider,
                         OnCheckoutProgress = options.OnCheckoutProgress,
-                        OnProgress = options.FetchOptions.OnProgress,
-                        OnTransferProgress = options.FetchOptions.OnTransferProgress,
-                        OnUpdateTips = options.FetchOptions.OnUpdateTips,
+                        FetchOptions = options.FetchOptions
                     };
 
                     string parentRepoWorkDir = repo.Info.WorkingDirectory;

--- a/LibGit2Sharp/Repository.cs
+++ b/LibGit2Sharp/Repository.cs
@@ -656,7 +656,12 @@ namespace LibGit2Sharp
         /// <returns>The references in the remote repository.</returns>
         public static IEnumerable<Reference> ListRemoteReferences(string url)
         {
-            return ListRemoteReferences(url, null);
+            return ListRemoteReferences(url, null, new ProxyOptions());
+        }
+
+        public static IEnumerable<Reference> ListRemoteReferences(string url, ProxyOptions proxyOptions)
+        {
+            return ListRemoteReferences(url, null, proxyOptions);
         }
 
         /// <summary>
@@ -672,23 +677,31 @@ namespace LibGit2Sharp
         /// <returns>The references in the remote repository.</returns>
         public static IEnumerable<Reference> ListRemoteReferences(string url, CredentialsHandler credentialsProvider)
         {
+            return ListRemoteReferences(url, credentialsProvider, new ProxyOptions());
+        }
+
+        public static IEnumerable<Reference> ListRemoteReferences(string url, CredentialsHandler credentialsProvider, ProxyOptions proxyOptions)
+        {
             Ensure.ArgumentNotNull(url, "url");
 
-            using (RepositoryHandle repositoryHandle = Proxy.git_repository_new())
-            using (RemoteHandle remoteHandle = Proxy.git_remote_create_anonymous(repositoryHandle, url))
+            proxyOptions ??= new();
+
+            using RepositoryHandle repositoryHandle = Proxy.git_repository_new();
+            using RemoteHandle remoteHandle = Proxy.git_remote_create_anonymous(repositoryHandle, url);
+            using var proxyOptionsWrapper = new GitProxyOptionsWrapper(proxyOptions.CreateGitProxyOptions());
+
+            var gitCallbacks = new GitRemoteCallbacks { version = 1 };
+
+            if (credentialsProvider != null)
             {
-                var gitCallbacks = new GitRemoteCallbacks { version = 1 };
-                var proxyOptions = new GitProxyOptions { Version = 1 };
-
-                if (credentialsProvider != null)
-                {
-                    var callbacks = new RemoteCallbacks(credentialsProvider);
-                    gitCallbacks = callbacks.GenerateCallbacks();
-                }
-
-                Proxy.git_remote_connect(remoteHandle, GitDirection.Fetch, ref gitCallbacks, ref proxyOptions);
-                return Proxy.git_remote_ls(null, remoteHandle);
+                var callbacks = new RemoteCallbacks(credentialsProvider);
+                gitCallbacks = callbacks.GenerateCallbacks();
             }
+
+            var gitProxyOptions = proxyOptionsWrapper.Options;
+
+            Proxy.git_remote_connect(remoteHandle, GitDirection.Fetch, ref gitCallbacks, ref gitProxyOptions);
+            return Proxy.git_remote_ls(null, remoteHandle);
         }
 
         /// <summary>
@@ -754,7 +767,7 @@ namespace LibGit2Sharp
             var context = new RepositoryOperationContext(Path.GetFullPath(workdirPath), sourceUrl);
 
             // Notify caller that we are starting to work with the current repository.
-            bool continueOperation = OnRepositoryOperationStarting(options.RepositoryOperationStarting,
+            bool continueOperation = OnRepositoryOperationStarting(options.FetchOptions.RepositoryOperationStarting,
                                                                    context);
 
             if (!continueOperation)
@@ -768,8 +781,8 @@ namespace LibGit2Sharp
                 var gitCheckoutOptions = checkoutOptionsWrapper.Options;
 
                 var gitFetchOptions = fetchOptionsWrapper.Options;
-                gitFetchOptions.ProxyOptions = new GitProxyOptions { Version = 1 };
-                gitFetchOptions.RemoteCallbacks = new RemoteCallbacks(options).GenerateCallbacks();
+                gitFetchOptions.ProxyOptions = options.FetchOptions.ProxyOptions.CreateGitProxyOptions();
+                gitFetchOptions.RemoteCallbacks = new RemoteCallbacks(options.FetchOptions).GenerateCallbacks();
                 if (options.FetchOptions != null && options.FetchOptions.CustomHeaders != null)
                 {
                     gitFetchOptions.CustomHeaders =
@@ -801,7 +814,7 @@ namespace LibGit2Sharp
                 }
 
                 // Notify caller that we are done with the current repository.
-                OnRepositoryOperationCompleted(options.RepositoryOperationCompleted,
+                OnRepositoryOperationCompleted(options.FetchOptions.RepositoryOperationCompleted,
                                                context);
 
                 // Recursively clone submodules if requested.
@@ -837,11 +850,11 @@ namespace LibGit2Sharp
                     SubmoduleUpdateOptions updateOptions = new SubmoduleUpdateOptions()
                     {
                         Init = true,
-                        CredentialsProvider = options.CredentialsProvider,
+                        CredentialsProvider = options.FetchOptions.CredentialsProvider,
                         OnCheckoutProgress = options.OnCheckoutProgress,
-                        OnProgress = options.OnProgress,
-                        OnTransferProgress = options.OnTransferProgress,
-                        OnUpdateTips = options.OnUpdateTips,
+                        OnProgress = options.FetchOptions.OnProgress,
+                        OnTransferProgress = options.FetchOptions.OnTransferProgress,
+                        OnUpdateTips = options.FetchOptions.OnUpdateTips,
                     };
 
                     string parentRepoWorkDir = repo.Info.WorkingDirectory;
@@ -862,7 +875,7 @@ namespace LibGit2Sharp
                                                                      sm.Name,
                                                                      recursionDepth);
 
-                        bool continueOperation = OnRepositoryOperationStarting(options.RepositoryOperationStarting,
+                        bool continueOperation = OnRepositoryOperationStarting(options.FetchOptions.RepositoryOperationStarting,
                                                                                context);
 
                         if (!continueOperation)
@@ -872,7 +885,7 @@ namespace LibGit2Sharp
 
                         repo.Submodules.Update(sm.Name, updateOptions);
 
-                        OnRepositoryOperationCompleted(options.RepositoryOperationCompleted,
+                        OnRepositoryOperationCompleted(options.FetchOptions.RepositoryOperationCompleted,
                                                        context);
 
                         submodules.Add(Path.Combine(repo.Info.WorkingDirectory, sm.Path));
@@ -1050,7 +1063,7 @@ namespace LibGit2Sharp
 
                 if (treesame && !amendMergeCommit)
                 {
-                    throw (options.AmendPreviousCommit ? 
+                    throw (options.AmendPreviousCommit ?
                         new EmptyCommitException("Amending this commit would produce a commit that is identical to its parent (id = {0})", parents[0].Id) :
                         new EmptyCommitException("No changes; nothing to commit."));
                 }
@@ -1241,7 +1254,7 @@ namespace LibGit2Sharp
             if (fetchHeads.Length == 0)
             {
                 var expectedRef = this.Head.UpstreamBranchCanonicalName;
-                throw new MergeFetchHeadNotFoundException("The current branch is configured to merge with the reference '{0}' from the remote, but this reference was not fetched.", 
+                throw new MergeFetchHeadNotFoundException("The current branch is configured to merge with the reference '{0}' from the remote, but this reference was not fetched.",
                     expectedRef);
             }
 

--- a/LibGit2Sharp/Repository.cs
+++ b/LibGit2Sharp/Repository.cs
@@ -659,6 +659,12 @@ namespace LibGit2Sharp
             return ListRemoteReferences(url, null, new ProxyOptions());
         }
 
+        /// <summary>
+        /// Lists the Remote Repository References.
+        /// </summary>
+        /// <param name="url">The url to list from.</param>
+        /// <param name="proxyOptions">Options for connecting through a proxy.</param>
+        /// <returns>The references in the remote repository.</returns>
         public static IEnumerable<Reference> ListRemoteReferences(string url, ProxyOptions proxyOptions)
         {
             return ListRemoteReferences(url, null, proxyOptions);
@@ -680,6 +686,18 @@ namespace LibGit2Sharp
             return ListRemoteReferences(url, credentialsProvider, new ProxyOptions());
         }
 
+        /// <summary>
+        /// Lists the Remote Repository References.
+        /// </summary>
+        /// <para>
+        /// Does not require a local Repository. The retrieved
+        /// <see cref="IBelongToARepository.Repository"/>
+        /// throws <see cref="InvalidOperationException"/> in this case.
+        /// </para>
+        /// <param name="url">The url to list from.</param>
+        /// <param name="credentialsProvider">The <see cref="Func{Credentials}"/> used to connect to remote repository.</param>
+        /// <param name="proxyOptions">Options for connecting through a proxy.</param>
+        /// <returns>The references in the remote repository.</returns>
         public static IEnumerable<Reference> ListRemoteReferences(string url, CredentialsHandler credentialsProvider, ProxyOptions proxyOptions)
         {
             Ensure.ArgumentNotNull(url, "url");

--- a/LibGit2Sharp/Repository.cs
+++ b/LibGit2Sharp/Repository.cs
@@ -760,7 +760,7 @@ namespace LibGit2Sharp
             Ensure.ArgumentNotNull(sourceUrl, "sourceUrl");
             Ensure.ArgumentNotNull(workdirPath, "workdirPath");
 
-            options = options ?? new CloneOptions();
+            options ??= new CloneOptions();
 
             // context variable that contains information on the repository that
             // we are cloning.

--- a/LibGit2Sharp/SubmoduleCollection.cs
+++ b/LibGit2Sharp/SubmoduleCollection.cs
@@ -74,43 +74,41 @@ namespace LibGit2Sharp
         /// Update specified submodule.
         /// <para>
         ///   This will:
-        ///   1) Optionally initialize the if it not already initialzed,
+        ///   1) Optionally initialize the if it not already initialized,
         ///   2) clone the sub repository if it has not already been cloned, and
         ///   3) checkout the commit ID for the submodule in the sub repository.
         /// </para>
         /// </summary>
         /// <param name="name">The name of the submodule to update.</param>
-        /// <param name="options">Options controlling submodule udpate behavior and callbacks.</param>
+        /// <param name="options">Options controlling submodule update behavior and callbacks.</param>
         public virtual void Update(string name, SubmoduleUpdateOptions options)
         {
-            options = options ?? new SubmoduleUpdateOptions();
+            options ??= new SubmoduleUpdateOptions();
 
-            using (var handle = Proxy.git_submodule_lookup(repo.Handle, name))
+            using var handle = Proxy.git_submodule_lookup(repo.Handle, name) ?? throw new NotFoundException("Submodule lookup failed for '{0}'.", name);
+            using var checkoutOptionsWrapper = new GitCheckoutOptsWrapper(options);
+            using var fetchOptionsWrapper = new GitFetchOptionsWrapper();
+
+            var gitCheckoutOptions = checkoutOptionsWrapper.Options;
+
+            var gitFetchOptions = fetchOptionsWrapper.Options;
+            gitFetchOptions.ProxyOptions = options.FetchOptions.ProxyOptions.CreateGitProxyOptions();
+            gitFetchOptions.RemoteCallbacks = new RemoteCallbacks(options.FetchOptions).GenerateCallbacks();
+
+            if (options.FetchOptions != null && options.FetchOptions.CustomHeaders != null)
             {
-                if (handle == null)
-                {
-                    throw new NotFoundException("Submodule lookup failed for '{0}'.",
-                                                              name);
-                }
-
-                using (GitCheckoutOptsWrapper checkoutOptionsWrapper = new GitCheckoutOptsWrapper(options))
-                {
-                    var gitCheckoutOptions = checkoutOptionsWrapper.Options;
-
-                    var remoteCallbacks = new RemoteCallbacks(options);
-                    var gitRemoteCallbacks = remoteCallbacks.GenerateCallbacks();
-
-                    var gitSubmoduleUpdateOpts = new GitSubmoduleUpdateOptions
-                    {
-                        Version = 1,
-                        CheckoutOptions = gitCheckoutOptions,
-                        FetchOptions = new GitFetchOptions { ProxyOptions = options.ProxyOptions.CreateGitProxyOptions(), RemoteCallbacks = gitRemoteCallbacks },
-                        CloneCheckoutStrategy = CheckoutStrategy.GIT_CHECKOUT_SAFE
-                    };
-
-                    Proxy.git_submodule_update(handle, options.Init, ref gitSubmoduleUpdateOpts);
-                }
+                gitFetchOptions.CustomHeaders =
+                    GitStrArrayManaged.BuildFrom(options.FetchOptions.CustomHeaders);
             }
+
+            var gitSubmoduleUpdateOpts = new GitSubmoduleUpdateOptions
+            {
+                Version = 1,
+                CheckoutOptions = gitCheckoutOptions,
+                FetchOptions = gitFetchOptions
+            };
+
+            Proxy.git_submodule_update(handle, options.Init, ref gitSubmoduleUpdateOpts);
         }
 
         /// <summary>

--- a/LibGit2Sharp/SubmoduleCollection.cs
+++ b/LibGit2Sharp/SubmoduleCollection.cs
@@ -104,7 +104,7 @@ namespace LibGit2Sharp
                     {
                         Version = 1,
                         CheckoutOptions = gitCheckoutOptions,
-                        FetchOptions = new GitFetchOptions { ProxyOptions = new GitProxyOptions { Version = 1 }, RemoteCallbacks = gitRemoteCallbacks },
+                        FetchOptions = new GitFetchOptions { ProxyOptions = options.ProxyOptions.CreateGitProxyOptions(), RemoteCallbacks = gitRemoteCallbacks },
                         CloneCheckoutStrategy = CheckoutStrategy.GIT_CHECKOUT_SAFE
                     };
 

--- a/LibGit2Sharp/SubmoduleUpdateOptions.cs
+++ b/LibGit2Sharp/SubmoduleUpdateOptions.cs
@@ -6,7 +6,7 @@ namespace LibGit2Sharp
     /// <summary>
     /// Options controlling Submodule Update behavior and callbacks.
     /// </summary>
-    public sealed class SubmoduleUpdateOptions : FetchOptionsBase, IConvertableToGitCheckoutOpts
+    public sealed class SubmoduleUpdateOptions : IConvertableToGitCheckoutOpts
     {
         /// <summary>
         /// Initialize the submodule if it is not already initialized.
@@ -29,6 +29,11 @@ namespace LibGit2Sharp
         /// reported through the OnCheckoutNotify delegate.
         /// </summary>
         public CheckoutNotifyFlags CheckoutNotifyFlags { get; set; }
+
+        /// <summary>
+        /// Collection of parameters controlling Fetch behavior.
+        /// </summary>
+        public FetchOptions FetchOptions { get; internal set; } = new();
 
         CheckoutCallbacks IConvertableToGitCheckoutOpts.GenerateCallbacks()
         {


### PR DESCRIPTION
This PR adds a `ProxyOptions` class that can be used to specify proxy options to all of the relevant places where a proxy could be needed.

`ProxyType` is set to `Auto` by default, so LibGit2Sharp will now respect any proxy settings configured in git. `ProxyType` can be set to `None` to disable using the repo's proxy settings. `Specified` let's you specify a a proxy URL. There are also callbacks to deal with credentials and certificate verification.

As part of these changes, `CloneOptions` and `SubmoduleUpdateOptions` have been updated to have all fetch-related options be exposed via a `FetchOptions` property and not a confusing mix of some being directly on the class and others being only in an existing `FetchOptions` property.

I haven't added any proxy-specific automated tests here primarily because I don't currently know of a good way to have a proxy server spun up in GitHub Actions that I can reliably use on all platforms that need to be tested on.

For now, the manual testing I've done will have to be enough!