### PR TITLE
Update LibGit2Sharp.NativeBinaries to 2.0.321

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       matrix:
         arch: [ amd64 ]
         # arch: [ amd64, arm64 ]
-        distro: [ alpine.3.13, alpine.3.14, alpine.3.15, alpine.3.16, alpine.3.17, centos.7, centos.stream.8, debian.10, debian.11, fedora.36, ubuntu.18.04, ubuntu.20.04, ubuntu.22.04 ]
+        distro: [ alpine.3.13, alpine.3.14, alpine.3.15, alpine.3.16, alpine.3.17, centos.stream.8, debian.10, debian.11, fedora.36, ubuntu.18.04, ubuntu.20.04, ubuntu.22.04 ]
         sdk:  [ '6.0', '7.0' ]
         exclude:
           - distro: alpine.3.13

--- a/LibGit2Sharp.Tests/GlobalSettingsFixture.cs
+++ b/LibGit2Sharp.Tests/GlobalSettingsFixture.cs
@@ -100,7 +100,7 @@ namespace LibGit2Sharp.Tests
             // Enable two new extensions (it will reset the configuration and "noop" will be enabled)
             GlobalSettings.SetExtensions("partialclone", "newext");
             extensions = GlobalSettings.GetExtensions();
-            Assert.Equal(new[] { "noop", "objectformat", "partialclone", "newext" }, extensions);
+            Assert.Equal(new[] { "newext", "noop", "objectformat", "partialclone" }, extensions);
         }
     }
 }

--- a/LibGit2Sharp/Core/GitFetchOptions.cs
+++ b/LibGit2Sharp/Core/GitFetchOptions.cs
@@ -11,6 +11,7 @@ namespace LibGit2Sharp.Core
         public bool UpdateFetchHead = true;
         public TagFetchMode download_tags;
         public GitProxyOptions ProxyOptions;
+        public int Depth = 0; // GIT_FETCH_DEPTH_FULL
         public RemoteRedirectMode FollowRedirects = RemoteRedirectMode.Initial;
         public GitStrArrayManaged CustomHeaders;
     }

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="[2.0.320]" PrivateAssets="none" />
+    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="[2.0.321]" PrivateAssets="none" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
     <PackageReference Include="MinVer" Version="5.0.0-beta.1" PrivateAssets="all" />
   </ItemGroup>


### PR DESCRIPTION
LibGit2Sharp.NativeBinaries 2.0.321 is [libgit2 v1.7.1](https://github.com/libgit2/libgit2/releases/tag/v1.7.1).

Due to CI changes in the NativeBinaries repo, the build images used to build the linux binaries had to be updated. This resulted in a newer glibc version being used, and it's too new for CentOS 7 to work properly.

This means that going forward, CentOS 7 and related distros will no longer be supported LibGit2Sharp despite them still being supported by .NET 6 and 7.