### PR TITLE
Adds Depth to FetchOptions allowing for shallow cloning

### DIFF
--- a/LibGit2Sharp.Tests/CloneFixture.cs
+++ b/LibGit2Sharp.Tests/CloneFixture.cs
@@ -36,6 +36,34 @@ namespace LibGit2Sharp.Tests
         }
 
         [Theory]
+        [InlineData("https://github.com/libgit2/TestGitRepository",1)]
+        [InlineData("https://github.com/libgit2/TestGitRepository",5)]
+        [InlineData("https://github.com/libgit2/TestGitRepository",7)]
+        public void CanCloneShallow(string url, int depth)
+        {
+            var scd = BuildSelfCleaningDirectory();
+
+            var clonedRepoPath = Repository.Clone(url, scd.DirectoryPath, new CloneOptions
+            {
+                FetchOptions =
+                {
+                    Depth = depth,
+                },
+            });
+
+            using (var repo = new Repository(clonedRepoPath))
+            {
+                var commitsFirstParentOnly = repo.Commits.QueryBy(new CommitFilter
+                {
+                    FirstParentOnly = true,
+                });
+
+                Assert.Equal(depth, commitsFirstParentOnly.Count());
+                Assert.Equal("49322bb17d3acc9146f98c97d078513228bbf3c0", repo.Head.Tip.Id.ToString());
+            }
+        }
+
+        [Theory]
         [InlineData("br2", "a4a7dce85cf63874e984719f4fdd239f5145052f")]
         [InlineData("packed", "41bc8c69075bbdb46c5c6f0566cc8cc5b46e8bd9")]
         [InlineData("test", "e90810b8df3e80c413d903f631643c716887138d")]

--- a/LibGit2Sharp/FetchOptions.cs
+++ b/LibGit2Sharp/FetchOptions.cs
@@ -27,6 +27,14 @@
         public bool? Prune { get; set; }
 
         /// <summary>
+        /// Specifies the depth of the fetch to perform.
+        /// <para>
+        /// Default value is 0 (full) fetch.
+        /// </para>
+        /// </summary>
+        public int Depth { get; set; } = 0;
+
+        /// <summary>
         /// Get/Set the custom headers.
         ///
         /// <para>

--- a/LibGit2Sharp/Repository.cs
+++ b/LibGit2Sharp/Repository.cs
@@ -780,6 +780,13 @@ namespace LibGit2Sharp
 
             options ??= new CloneOptions();
 
+            // As default behaviour for GitFetchOptionsWrapper ctor is to create
+            // a new instance of GitFetchOptions we only populate the Depth field.
+            var fetchOptions = new GitFetchOptions
+            {
+                Depth =  options.FetchOptions.Depth,
+            };
+
             // context variable that contains information on the repository that
             // we are cloning.
             var context = new RepositoryOperationContext(Path.GetFullPath(workdirPath), sourceUrl);
@@ -794,7 +801,7 @@ namespace LibGit2Sharp
             }
 
             using (var checkoutOptionsWrapper = new GitCheckoutOptsWrapper(options))
-            using (var fetchOptionsWrapper = new GitFetchOptionsWrapper())
+            using (var fetchOptionsWrapper = new GitFetchOptionsWrapper(fetchOptions))
             {
                 var gitCheckoutOptions = checkoutOptionsWrapper.Options;
 


### PR DESCRIPTION
This PR adds `Depth` to `FetchOptions` allowing for shallow cloning. 

Since I'm new to this repo and it's complexity it's possible i've missed some key information to why this have not been implemented, and if so I'm sorry for not reading up on it prior to submitting this PR.

Resolves #229 