### PR TITLE
Make owner validation configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ Thumbs.db
 *.ncb
 *.suo
 .vs/
+.idea/
 *.sln.ide/
 *.tlb
 *.tlh

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ Thumbs.db
 *.ncb
 *.suo
 .vs/
-.idea/
 *.sln.ide/
 *.tlb
 *.tlh

--- a/LibGit2Sharp.Tests/GlobalSettingsFixture.cs
+++ b/LibGit2Sharp.Tests/GlobalSettingsFixture.cs
@@ -107,15 +107,15 @@ namespace LibGit2Sharp.Tests
         public void OwnerValidation()
         {
             // Assert that owner validation is enabled by default
-            Assert.True(GlobalSettings.OwnerValidation);
+            Assert.True(GlobalSettings.GetOwnerValidation());
 
             // Disable owner validation
-            GlobalSettings.OwnerValidation = false;
-            Assert.False(GlobalSettings.OwnerValidation);
+            GlobalSettings.SetOwnerValidation(false);
+            Assert.False(GlobalSettings.GetOwnerValidation());
 
             // Enable it again
-            GlobalSettings.OwnerValidation = true;
-            Assert.True(GlobalSettings.OwnerValidation);
+            GlobalSettings.SetOwnerValidation(true);
+            Assert.True(GlobalSettings.GetOwnerValidation());
         }
     }
 }

--- a/LibGit2Sharp.Tests/GlobalSettingsFixture.cs
+++ b/LibGit2Sharp.Tests/GlobalSettingsFixture.cs
@@ -102,5 +102,20 @@ namespace LibGit2Sharp.Tests
             extensions = GlobalSettings.GetExtensions();
             Assert.Equal(new[] { "newext", "noop", "objectformat", "partialclone", "worktreeconfig" }, extensions);
         }
+
+        [Fact]
+        public void OwnerValidation()
+        {
+            // Assert that owner validation is enabled by default
+            Assert.True(GlobalSettings.OwnerValidation);
+
+            // Disable owner validation
+            GlobalSettings.OwnerValidation = false;
+            Assert.False(GlobalSettings.OwnerValidation);
+
+            // Enable it again
+            GlobalSettings.OwnerValidation = true;
+            Assert.True(GlobalSettings.OwnerValidation);
+        }
     }
 }

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -746,6 +746,10 @@ namespace LibGit2Sharp.Core
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_libgit2_opts(int option, int enabled);
 
+        // git_libgit2_opts(GIT_OPT_GET_*, int *enabled)
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern unsafe int git_libgit2_opts(int option, int* enabled);
+
         // git_libgit2_opts(GIT_OPT_SET_USER_AGENT, const char *path)
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_libgit2_opts(int option,
@@ -781,6 +785,10 @@ namespace LibGit2Sharp.Core
         // git_libgit2_opts(GIT_OPT_ENABLE_*, int enabled)
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl, EntryPoint = "git_libgit2_opts")]
         internal static extern int git_libgit2_opts_osxarm64(int option, IntPtr nop2, IntPtr nop3, IntPtr nop4, IntPtr nop5, IntPtr nop6, IntPtr nop7, IntPtr nop8, int enabled);
+
+        // git_libgit2_opts(GIT_OPT_GET_*, int enabled)
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl, EntryPoint = "git_libgit2_opts")]
+        internal static extern unsafe int git_libgit2_opts_osxarm64(int option, IntPtr nop2, IntPtr nop3, IntPtr nop4, IntPtr nop5, IntPtr nop6, IntPtr nop7, IntPtr nop8, int* enabled);
 
         // git_libgit2_opts(GIT_OPT_SET_USER_AGENT, const char *path)
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl, EntryPoint = "git_libgit2_opts")]

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -1,6 +1,8 @@
 using System;
 using System.IO;
+#if NET
 using System.Reflection;
+#endif
 using System.Runtime.CompilerServices;
 using System.Runtime.ConstrainedExecution;
 using System.Runtime.InteropServices;
@@ -743,12 +745,9 @@ namespace LibGit2Sharp.Core
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string path);
 
         // git_libgit2_opts(GIT_OPT_ENABLE_*, int enabled)
+        // git_libgit2_opts(GIT_OPT_SET_OWNER_VALIDATION, int enabled)
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_libgit2_opts(int option, int enabled);
-
-        // git_libgit2_opts(GIT_OPT_GET_*, int *enabled)
-        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern unsafe int git_libgit2_opts(int option, int* enabled);
 
         // git_libgit2_opts(GIT_OPT_SET_USER_AGENT, const char *path)
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
@@ -766,6 +765,10 @@ namespace LibGit2Sharp.Core
         // git_libgit2_opts(GIT_OPT_GET_EXTENSIONS, git_strarray *out)
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_libgit2_opts(int option, out GitStrArray extensions);
+
+        // git_libgit2_opts(GIT_OPT_GET_OWNER_VALIDATION, int *enabled)
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern unsafe int git_libgit2_opts(int option, int* enabled);
         #endregion
 
         #region git_libgit2_opts_osxarm64
@@ -783,12 +786,9 @@ namespace LibGit2Sharp.Core
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string path);
 
         // git_libgit2_opts(GIT_OPT_ENABLE_*, int enabled)
+        // git_libgit2_opts(GIT_OPT_SET_OWNER_VALIDATION, int enabled)
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl, EntryPoint = "git_libgit2_opts")]
         internal static extern int git_libgit2_opts_osxarm64(int option, IntPtr nop2, IntPtr nop3, IntPtr nop4, IntPtr nop5, IntPtr nop6, IntPtr nop7, IntPtr nop8, int enabled);
-
-        // git_libgit2_opts(GIT_OPT_GET_*, int enabled)
-        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl, EntryPoint = "git_libgit2_opts")]
-        internal static extern unsafe int git_libgit2_opts_osxarm64(int option, IntPtr nop2, IntPtr nop3, IntPtr nop4, IntPtr nop5, IntPtr nop6, IntPtr nop7, IntPtr nop8, int* enabled);
 
         // git_libgit2_opts(GIT_OPT_SET_USER_AGENT, const char *path)
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl, EntryPoint = "git_libgit2_opts")]
@@ -806,6 +806,10 @@ namespace LibGit2Sharp.Core
         // git_libgit2_opts(GIT_OPT_GET_EXTENSIONS, git_strarray *out)
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl, EntryPoint = "git_libgit2_opts")]
         internal static extern int git_libgit2_opts_osxarm64(int option, IntPtr nop2, IntPtr nop3, IntPtr nop4, IntPtr nop5, IntPtr nop6, IntPtr nop7, IntPtr nop8, out GitStrArray extensions);
+
+        // git_libgit2_opts(GIT_OPT_GET_OWNER_VALIDATION, int *enabled)
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl, EntryPoint = "git_libgit2_opts")]
+        internal static extern unsafe int git_libgit2_opts_osxarm64(int option, IntPtr nop2, IntPtr nop3, IntPtr nop4, IntPtr nop5, IntPtr nop6, IntPtr nop7, IntPtr nop8, int* enabled);
         #endregion
 
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -3397,6 +3397,8 @@ namespace LibGit2Sharp.Core
             SetOdbLoosePriority,             // GIT_OPT_SET_ODB_LOOSE_PRIORITY,
             GetExtensions,                   // GIT_OPT_GET_EXTENSIONS,
             SetExtensions,                   // GIT_OPT_SET_EXTENSIONS
+            GetOwnerValidation,              // GIT_OPT_GET_OWNER_VALIDATION
+            SetOwnerValidation,              // GIT_OPT_SET_OWNER_VALIDATION
         }
 
         /// <summary>
@@ -3568,6 +3570,36 @@ namespace LibGit2Sharp.Core
             {
                 array.Dispose();
             }
+        }
+
+        /// <summary>
+        /// Gets the value of owner validation
+        /// </summary>
+        public static unsafe bool git_libgit2_opts_get_owner_validation()
+        {
+            // libgit2 expects non-zero value for true
+            int res, enabled;
+            if (isOSXArm64)
+                res = NativeMethods.git_libgit2_opts_osxarm64((int)LibGit2Option.GetOwnerValidation, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, &enabled);
+            else
+                res = NativeMethods.git_libgit2_opts((int)LibGit2Option.GetOwnerValidation, &enabled);
+            Ensure.ZeroResult(res);
+            return enabled != 0;
+        }
+
+        /// <summary>
+        /// Enable or disable owner validation
+        /// </summary>
+        /// <param name="enabled">true to enable owner validation, false otherwise</param>
+        public static void git_libgit2_opts_set_owner_validation(bool enabled)
+        {
+            // libgit2 expects non-zero value for true
+            int res;
+            if (isOSXArm64)
+                res = NativeMethods.git_libgit2_opts_osxarm64((int)LibGit2Option.SetOwnerValidation, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, enabled ? 1 : 0);
+            else
+                res = NativeMethods.git_libgit2_opts((int)LibGit2Option.SetOwnerValidation, enabled ? 1 : 0);
+            Ensure.ZeroResult(res);
         }
 
         #endregion

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -3577,13 +3577,20 @@ namespace LibGit2Sharp.Core
         /// </summary>
         public static unsafe bool git_libgit2_opts_get_owner_validation()
         {
-            // libgit2 expects non-zero value for true
-            int res, enabled;
+            int res;
+            int enabled;
+
             if (isOSXArm64)
+            {
                 res = NativeMethods.git_libgit2_opts_osxarm64((int)LibGit2Option.GetOwnerValidation, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, &enabled);
+            }
             else
+            {
                 res = NativeMethods.git_libgit2_opts((int)LibGit2Option.GetOwnerValidation, &enabled);
+            }
+
             Ensure.ZeroResult(res);
+
             return enabled != 0;
         }
 
@@ -3593,15 +3600,19 @@ namespace LibGit2Sharp.Core
         /// <param name="enabled">true to enable owner validation, false otherwise</param>
         public static void git_libgit2_opts_set_owner_validation(bool enabled)
         {
-            // libgit2 expects non-zero value for true
             int res;
+
             if (isOSXArm64)
+            {
                 res = NativeMethods.git_libgit2_opts_osxarm64((int)LibGit2Option.SetOwnerValidation, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, enabled ? 1 : 0);
+            }
             else
+            {
                 res = NativeMethods.git_libgit2_opts((int)LibGit2Option.SetOwnerValidation, enabled ? 1 : 0);
+            }
+
             Ensure.ZeroResult(res);
         }
-
         #endregion
 
         #region git_worktree_

--- a/LibGit2Sharp/GlobalSettings.cs
+++ b/LibGit2Sharp/GlobalSettings.cs
@@ -204,19 +204,6 @@ namespace LibGit2Sharp
             }
         }
 
-        /// <summary>
-        /// Controls the status of repository directory owner validation.
-        /// </summary>
-        /// <remarks>
-        /// By default, repository directories must be owned by the current user to be opened. This can be disabled by setting this property to false.
-        /// Note that disabling this can lead to security vulnerabilities (see CVE-2022-24765).
-        /// </remarks>
-        public static bool OwnerValidation
-        {
-            get => Proxy.git_libgit2_opts_get_owner_validation();
-            set => Proxy.git_libgit2_opts_set_owner_validation(value);
-        }
-
         internal static string GetAndLockNativeLibraryPath()
         {
             nativeLibraryPathLocked = true;
@@ -429,6 +416,27 @@ namespace LibGit2Sharp
         public static string GetUserAgent()
         {
             return Proxy.git_libgit2_opts_get_user_agent();
+        }
+
+        /// <summary>
+        /// Gets the owner validation setting for repository directories.
+        /// </summary>
+        /// <returns></returns>
+        public static bool GetOwnerValidation()
+        {
+            return Proxy.git_libgit2_opts_get_owner_validation();
+        }
+
+        /// <summary>
+        ///  Sets whether repository directories should be owned by the current user. The default is to validate ownership.
+        /// </summary>
+        /// <remarks>
+        ///  Disabling owner validation can lead to security vulnerabilities (see CVE-2022-24765).
+        /// </remarks>
+        /// <param name="enabled">true to enable owner validation; otherwise, false.</param>
+        public static void SetOwnerValidation(bool enabled)
+        {
+            Proxy.git_libgit2_opts_set_owner_validation(enabled);
         }
     }
 }

--- a/LibGit2Sharp/GlobalSettings.cs
+++ b/LibGit2Sharp/GlobalSettings.cs
@@ -204,6 +204,19 @@ namespace LibGit2Sharp
             }
         }
 
+        /// <summary>
+        /// Controls the status of repository directory owner validation.
+        /// </summary>
+        /// <remarks>
+        /// By default, repository directories must be owned by the current user to be opened. This can be disabled by setting this property to false.
+        /// Note that disabling this can lead to security vulnerabilities (see CVE-2022-24765).
+        /// </remarks>
+        public static bool OwnerValidation
+        {
+            get => Proxy.git_libgit2_opts_get_owner_validation();
+            set => Proxy.git_libgit2_opts_set_owner_validation(value);
+        }
+
         internal static string GetAndLockNativeLibraryPath()
         {
             nativeLibraryPathLocked = true;


### PR DESCRIPTION
This adds a `GlobalSettings.OwnerValidation` property which wraps `git_libgit2_opts(GIT_OPT_[GET/SET]_OWNER_VALIDATION)`.

I needed to disable this (I'm using a safe environment), and I had to do this through reflection, but I suppose other people may have the same problem so exposing the feature in the library would be better. 🙂 

Closes #2036

**Edit:** I'm an idiot, I forgot to check whether someone else submitted a PR for this, so this duplicates #2042, sorry 🤦  
I'm leaving this open so you can choose the implementation, and this one also lets you retrieve the current option value.