### PR TITLE
Fix empty folder issue in Repositoy.Worktrees.Add

### DIFF
--- a/LibGit2Sharp.Tests/WorktreeFixture.cs
+++ b/LibGit2Sharp.Tests/WorktreeFixture.cs
@@ -3,8 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace LibGit2Sharp.Tests
@@ -238,7 +236,7 @@ namespace LibGit2Sharp.Tests
         }
 
         [Fact]
-        public void CanAddWorktree()
+        public void CanAddWorktree_WithUncommitedChanges()
         {
             var repoPath = SandboxWorktreeTestRepo();
             using (var repo = new Repository(repoPath))
@@ -252,11 +250,55 @@ namespace LibGit2Sharp.Tests
                 Assert.False(worktree.IsLocked);
 
                 Assert.Equal(3, repo.Worktrees.Count());
+
+                // Check that branch contains same number of files and folders
+                // NOTE: There is an open bug - [Repository.Worktrees.Add leaves now worktree empty](https://github.com/libgit2/libgit2sharp/issues/2037)
+                Assert.True(repo.RetrieveStatus().IsDirty);
+                var filesInMain = GetFilesOfRepo(repoPath);
+                var filesInBranch = GetFilesOfRepo(path);
+                Assert.NotEqual(filesInMain, filesInBranch);
+
+                repo.Reset(ResetMode.Hard);
+                repo.RemoveUntrackedFiles();
+
+                Assert.False(repo.RetrieveStatus().IsDirty);
+                filesInMain = GetFilesOfRepo(repoPath);
+                filesInBranch = GetFilesOfRepo(path);
+                Assert.Equal(filesInMain, filesInBranch);
             }
         }
 
         [Fact]
-        public void CanAddLockedWorktree()
+        public void CanAddWorktree_WithCommitedChanges()
+        {
+            var repoPath = SandboxWorktreeTestRepo();
+            using (var repo = new Repository(repoPath))
+            {
+                // stage all changes
+                Commands.Stage(repo, "*");
+                repo.Commit("Apply all changes", Constants.Signature, Constants.Signature);
+
+                Assert.Equal(2, repo.Worktrees.Count());
+
+                var name = "blah";
+                var path = Path.Combine(repo.Info.WorkingDirectory, "..", "worktrees", name);
+                var worktree = repo.Worktrees.Add(name, path, false);
+                Assert.Equal(name, worktree.Name);
+                Assert.False(worktree.IsLocked);
+
+                Assert.Equal(3, repo.Worktrees.Count());
+
+                // Check that branch contains same number of files and folders
+                // NOTE: There is an open bug - [Repository.Worktrees.Add leaves now worktree empty](https://github.com/libgit2/libgit2sharp/issues/2037)
+                Assert.False(repo.RetrieveStatus().IsDirty);
+                var filesInMain = GetFilesOfRepo(repoPath);
+                var filesInBranch = GetFilesOfRepo(path);
+                Assert.Equal(filesInMain, filesInBranch);
+            }
+        }
+
+        [Fact]
+        public void CanAddLockedWorktree_WithUncommitedChanges()
         {
             var repoPath = SandboxWorktreeTestRepo();
             using (var repo = new Repository(repoPath))
@@ -270,6 +312,50 @@ namespace LibGit2Sharp.Tests
                 Assert.True(worktree.IsLocked);
 
                 Assert.Equal(3, repo.Worktrees.Count());
+
+                // Check that branch contains same number of files and folders
+                // NOTE: There is an open bug - [Repository.Worktrees.Add leaves now worktree empty](https://github.com/libgit2/libgit2sharp/issues/2037)
+                Assert.True(repo.RetrieveStatus().IsDirty);
+                var filesInMain = GetFilesOfRepo(repoPath);
+                var filesInBranch = GetFilesOfRepo(path);
+                Assert.NotEqual(filesInMain, filesInBranch);
+
+                repo.Reset(ResetMode.Hard);
+                repo.RemoveUntrackedFiles();
+
+                Assert.False(repo.RetrieveStatus().IsDirty);
+                filesInMain = GetFilesOfRepo(repoPath);
+                filesInBranch = GetFilesOfRepo(path);
+                Assert.Equal(filesInMain, filesInBranch);
+            }
+        }
+
+        [Fact]
+        public void CanAddLockedWorktree_WithCommitedChanges()
+        {
+            var repoPath = SandboxWorktreeTestRepo();
+            using (var repo = new Repository(repoPath))
+            {
+                // stage all changes
+                Commands.Stage(repo, "*");
+                repo.Commit("Apply all changes", Constants.Signature, Constants.Signature);
+
+                Assert.Equal(2, repo.Worktrees.Count());
+
+                var name = "blah";
+                var path = Path.Combine(repo.Info.WorkingDirectory, "..", "worktrees", name);
+                var worktree = repo.Worktrees.Add(name, path, true);
+                Assert.Equal(name, worktree.Name);
+                Assert.True(worktree.IsLocked);
+
+                Assert.Equal(3, repo.Worktrees.Count());
+
+                // Check that branch contains same number of files and folders
+                // NOTE: There is an open bug - [Repository.Worktrees.Add leaves now worktree empty](https://github.com/libgit2/libgit2sharp/issues/2037)
+                Assert.False(repo.RetrieveStatus().IsDirty);
+                var filesInMain = GetFilesOfRepo(repoPath);
+                var filesInBranch = GetFilesOfRepo(path);
+                Assert.Equal(filesInMain, filesInBranch);
             }
         }
 
@@ -292,7 +378,22 @@ namespace LibGit2Sharp.Tests
                     Assert.Equal(committish, repository.Head.FriendlyName);
                 }
                 Assert.Equal(3, repo.Worktrees.Count());
+
+                // Check that branch contains same number of files and folders
+                // NOTE: There is an open bug - [Repository.Worktrees.Add leaves now worktree empty](https://github.com/libgit2/libgit2sharp/issues/2037)
+                var filesInCommittish = new string[] { "numbers.txt", "super-file.txt" };
+                var filesInBranch = GetFilesOfRepo(path);
+                Assert.Equal(filesInCommittish, filesInBranch);
             }
+        }
+
+        private static IEnumerable<string> GetFilesOfRepo(string repoPath)
+        {
+            return Directory.GetFiles(repoPath, "*", SearchOption.AllDirectories)
+                .Where(fileName => !fileName.StartsWith($"{repoPath}\\.git", StringComparison.InvariantCultureIgnoreCase))
+                .Select(fileName => fileName.Replace($"{repoPath}\\", "", StringComparison.InvariantCultureIgnoreCase))
+                .OrderBy(fileName => fileName, StringComparer.InvariantCultureIgnoreCase)
+                .ToList();
         }
     }
 }

--- a/LibGit2Sharp.Tests/WorktreeFixture.cs
+++ b/LibGit2Sharp.Tests/WorktreeFixture.cs
@@ -1,8 +1,8 @@
-﻿using LibGit2Sharp.Tests.TestHelpers;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using LibGit2Sharp.Tests.TestHelpers;
 using Xunit;
 
 namespace LibGit2Sharp.Tests
@@ -252,7 +252,6 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(3, repo.Worktrees.Count());
 
                 // Check that branch contains same number of files and folders
-                // NOTE: There is an open bug - [Repository.Worktrees.Add leaves now worktree empty](https://github.com/libgit2/libgit2sharp/issues/2037)
                 Assert.True(repo.RetrieveStatus().IsDirty);
                 var filesInMain = GetFilesOfRepo(repoPath);
                 var filesInBranch = GetFilesOfRepo(path);
@@ -289,10 +288,10 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(3, repo.Worktrees.Count());
 
                 // Check that branch contains same number of files and folders
-                // NOTE: There is an open bug - [Repository.Worktrees.Add leaves now worktree empty](https://github.com/libgit2/libgit2sharp/issues/2037)
                 Assert.False(repo.RetrieveStatus().IsDirty);
                 var filesInMain = GetFilesOfRepo(repoPath);
                 var filesInBranch = GetFilesOfRepo(path);
+
                 Assert.Equal(filesInMain, filesInBranch);
             }
         }
@@ -314,7 +313,6 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(3, repo.Worktrees.Count());
 
                 // Check that branch contains same number of files and folders
-                // NOTE: There is an open bug - [Repository.Worktrees.Add leaves now worktree empty](https://github.com/libgit2/libgit2sharp/issues/2037)
                 Assert.True(repo.RetrieveStatus().IsDirty);
                 var filesInMain = GetFilesOfRepo(repoPath);
                 var filesInBranch = GetFilesOfRepo(path);
@@ -351,7 +349,6 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(3, repo.Worktrees.Count());
 
                 // Check that branch contains same number of files and folders
-                // NOTE: There is an open bug - [Repository.Worktrees.Add leaves now worktree empty](https://github.com/libgit2/libgit2sharp/issues/2037)
                 Assert.False(repo.RetrieveStatus().IsDirty);
                 var filesInMain = GetFilesOfRepo(repoPath);
                 var filesInBranch = GetFilesOfRepo(path);
@@ -380,7 +377,6 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(3, repo.Worktrees.Count());
 
                 // Check that branch contains same number of files and folders
-                // NOTE: There is an open bug - [Repository.Worktrees.Add leaves now worktree empty](https://github.com/libgit2/libgit2sharp/issues/2037)
                 var filesInCommittish = new string[] { "numbers.txt", "super-file.txt" };
                 var filesInBranch = GetFilesOfRepo(path);
                 Assert.Equal(filesInCommittish, filesInBranch);
@@ -390,9 +386,9 @@ namespace LibGit2Sharp.Tests
         private static IEnumerable<string> GetFilesOfRepo(string repoPath)
         {
             return Directory.GetFiles(repoPath, "*", SearchOption.AllDirectories)
-                .Where(fileName => !fileName.StartsWith($"{repoPath}\\.git", StringComparison.InvariantCultureIgnoreCase))
-                .Select(fileName => fileName.Replace($"{repoPath}\\", "", StringComparison.InvariantCultureIgnoreCase))
-                .OrderBy(fileName => fileName, StringComparer.InvariantCultureIgnoreCase)
+                .Where(fileName => !fileName.StartsWith(Path.Combine(repoPath, ".git")))
+                .Select(fileName => fileName.Replace($"{repoPath}{Path.DirectorySeparatorChar}", ""))
+                .OrderBy(fileName => fileName)
                 .ToList();
         }
     }

--- a/LibGit2Sharp/Core/GitWorktree.cs
+++ b/LibGit2Sharp/Core/GitWorktree.cs
@@ -38,7 +38,11 @@ namespace LibGit2Sharp.Core
 
         public IntPtr @ref = IntPtr.Zero;
 
-        public GitCheckoutOpts checkoutOpts = new GitCheckoutOpts { version = 1 };
+        public GitCheckoutOpts checkoutOpts = new GitCheckoutOpts
+        {
+            version = 1,
+            checkout_strategy = CheckoutStrategy.GIT_CHECKOUT_FORCE
+        };
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/LibGit2Sharp/Core/GitWorktree.cs
+++ b/LibGit2Sharp/Core/GitWorktree.cs
@@ -41,7 +41,7 @@ namespace LibGit2Sharp.Core
         public GitCheckoutOpts checkoutOpts = new GitCheckoutOpts
         {
             version = 1,
-            checkout_strategy = CheckoutStrategy.GIT_CHECKOUT_FORCE
+            checkout_strategy = CheckoutStrategy.GIT_CHECKOUT_SAFE
         };
     }
 

--- a/LibGit2Sharp/WorktreeCollection.cs
+++ b/LibGit2Sharp/WorktreeCollection.cs
@@ -48,11 +48,10 @@ namespace LibGit2Sharp
         /// <summary>
         ///
         /// </summary>
-        /// <param name="committishOrBranchSpec"></param>
-        /// <param name="name"></param>
-        /// <param name="path"></param>
+        /// <param name="committishOrBranchSpec">A committish or branch name./param>
+        /// <param name="name">Name of the worktree.</param>
+        /// <param name="path">Location of the worktree.</param>
         /// <param name="isLocked"></param>
-        /// <returns></returns>
         public virtual Worktree Add(string committishOrBranchSpec, string name, string path, bool isLocked)
         {
             if (string.Equals(committishOrBranchSpec, name))
@@ -61,7 +60,7 @@ namespace LibGit2Sharp
                 return null;
             }
 
-            git_worktree_add_options options = new git_worktree_add_options
+            var options = new git_worktree_add_options
             {
                 version = 1,
                 locked = Convert.ToInt32(isLocked)
@@ -81,20 +80,18 @@ namespace LibGit2Sharp
                 }
             }
 
-
-
             return this[name];
         }
 
         /// <summary>
         ///
         /// </summary>
-        /// <param name="name"></param>
-        /// <param name="path"></param>
-        /// <param name="isLocked"></param>
+        /// <param name="committishOrBranchSpec">A committish or branch name./param>
+        /// <param name="name">Name of the worktree.</param>
+        /// <param name="path">Location of the worktree.</param>
         public virtual Worktree Add(string name, string path, bool isLocked)
         {
-            git_worktree_add_options options = new git_worktree_add_options
+            var options = new git_worktree_add_options
             {
                 version = 1,
                 locked = Convert.ToInt32(isLocked)

--- a/LibGit2Sharp/WorktreeCollection.cs
+++ b/LibGit2Sharp/WorktreeCollection.cs
@@ -46,9 +46,9 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
-        ///
+        /// Creates a worktree.
         /// </summary>
-        /// <param name="committishOrBranchSpec">A committish or branch name./param>
+        /// <param name="committishOrBranchSpec">The committish to checkout into the new worktree.</param>
         /// <param name="name">Name of the worktree.</param>
         /// <param name="path">Location of the worktree.</param>
         /// <param name="isLocked"></param>
@@ -84,11 +84,11 @@ namespace LibGit2Sharp
         }
 
         /// <summary>
-        ///
+        /// Creates a worktree.
         /// </summary>
-        /// <param name="committishOrBranchSpec">A committish or branch name./param>
         /// <param name="name">Name of the worktree.</param>
         /// <param name="path">Location of the worktree.</param>
+        /// <param name="isLocked"></param>
         public virtual Worktree Add(string name, string path, bool isLocked)
         {
             var options = new git_worktree_add_options


### PR DESCRIPTION
This PR is fixing an issue when creating a worktree. It creates an empty folder with .git file only. 0.26.2 was the Latest version that creating a worktree works well and it was using the GIT_CHECKOUT_FORCE as checkout strategy.

* Set GIT_CHECKOUT_FORCE as checkout strategy when creating a worktree.
* Update current and add unit tests in WorktreeFixture.