### PR TITLE
Target netstandard2.0 rather than net472

### DIFF
--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -66,7 +66,7 @@ namespace LibGit2Sharp.Core
             return Path.Combine(nativeLibraryDir, libgit2 + Platform.GetNativeLibraryExtension());
         }
 
-#if NETFRAMEWORK
+#if NETSTANDARD
         private static bool TryUseNativeLibrary() => false;
 #else
         private static bool TryUseNativeLibrary()

--- a/LibGit2Sharp/GlobalSettings.cs
+++ b/LibGit2Sharp/GlobalSettings.cs
@@ -29,7 +29,7 @@ namespace LibGit2Sharp
 
             nativeLibraryPathAllowed = netFX || netCore;
 
-#if NETFRAMEWORK
+#if NETSTANDARD
             if (netFX)
             {
                 // For .NET Framework apps the dependencies are deployed to lib/win32/{architecture} directory
@@ -40,7 +40,7 @@ namespace LibGit2Sharp
             registeredFilters = new Dictionary<Filter, FilterRegistration>();
         }
 
-#if NETFRAMEWORK
+#if NETSTANDARD
         private static string GetExecutingAssemblyDirectory()
         {
             // Assembly.CodeBase is not actually a correctly formatted

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>LibGit2Sharp brings all the might and speed of libgit2, a native Git implementation, to the managed world of .NET</Description>


### PR DESCRIPTION
Targeting `netstandard2.0` will make the library more versatile.

According to [Microsoft's Cross-platform targeting recommendations](https://learn.microsoft.com/en-us/dotnet/standard/library-guidance/cross-platform-targeting):

> Most general-purpose libraries don't need APIs outside of .NET Standard 2.0. .NET Standard 2.0 is supported by all modern platforms and is the recommended way to support multiple platforms with one target.

Closes #2035 