### PR TITLE
Add support for long file paths in CheckoutOptions

### DIFF
--- a/LibGit2Sharp.Tests/CloneFixture.cs
+++ b/LibGit2Sharp.Tests/CloneFixture.cs
@@ -629,5 +629,30 @@ namespace LibGit2Sharp.Tests
             var clonedRepoPath = Repository.Clone(url, scd.DirectoryPath, cloneOptions);
             Assert.True(Directory.Exists(clonedRepoPath));
         }
+
+        [Fact]
+        public void CanCloneWithLongPaths()
+        {
+            var scd = BuildSelfCleaningDirectory();
+
+            var cloneOptions = new CloneOptions
+            {
+                LongPaths = true
+            };
+
+            string clonedRepoPath = Repository.Clone("https://github.com/luiswolff/test-long-file-path.git", scd.DirectoryPath, cloneOptions);
+
+            using (var repo = new Repository(clonedRepoPath))
+            {
+                string dir = repo.Info.Path;
+                Assert.True(Path.IsPathRooted(dir));
+                Assert.True(Directory.Exists(dir));
+                Assert.NotNull(repo.Info.WorkingDirectory);
+                Assert.Equal(Path.Combine(scd.RootedDirectoryPath, ".git" + Path.DirectorySeparatorChar), repo.Info.Path);
+                Assert.False(repo.Info.IsBare);
+
+                // Add additional assertions if necessary to verify long path support
+            }
+        }
     }
 }

--- a/LibGit2Sharp/CheckoutOptions.cs
+++ b/LibGit2Sharp/CheckoutOptions.cs
@@ -30,6 +30,9 @@ namespace LibGit2Sharp
         /// controlled with the CheckoutNotifyFlags property.
         public CheckoutProgressHandler OnCheckoutProgress { get; set; }
 
+        /// <inheritdoc />
+        public bool LongPaths { get; set; }
+
         CheckoutStrategy IConvertableToGitCheckoutOpts.CheckoutStrategy
         {
             get

--- a/LibGit2Sharp/CloneOptions.cs
+++ b/LibGit2Sharp/CloneOptions.cs
@@ -21,6 +21,9 @@ namespace LibGit2Sharp
         /// </summary>
         public bool IsBare { get; set; }
 
+        /// <inheritdoc />
+        public bool LongPaths { get; set; }
+
         /// <summary>
         /// If true, the origin's HEAD will be checked out. This only applies
         /// to non-bare repositories.

--- a/LibGit2Sharp/Core/GitCheckoutOpts.cs
+++ b/LibGit2Sharp/Core/GitCheckoutOpts.cs
@@ -105,6 +105,11 @@ namespace LibGit2Sharp.Core
         /// </summary>
         GIT_CHECKOUT_DONT_WRITE_INDEX = (1 << 23),
 
+        /// <summary>
+        /// Support for long file paths.
+        /// </summary>
+        GIT_CHECKOUT_LONGPATHS = (1 << 24),
+
         // THE FOLLOWING OPTIONS ARE NOT YET IMPLEMENTED
 
         /// <summary>
@@ -183,6 +188,11 @@ namespace LibGit2Sharp.Core
         CheckoutStrategy CheckoutStrategy { get; }
 
         CheckoutNotifyFlags CheckoutNotifyFlags { get; }
+
+        /// <summary>
+        /// True will enable support for long paths, allowing the repository to handle paths longer than 260 characters.
+        /// </summary>
+        bool LongPaths { get; }
     }
 
     /// <summary>
@@ -229,5 +239,8 @@ namespace LibGit2Sharp.Core
         {
             get { return internalOptions.CheckoutNotifyFlags; }
         }
+
+        /// <inheritdoc />
+        public bool LongPaths { get; set; }
     }
 }

--- a/LibGit2Sharp/Core/GitCheckoutOptsWrapper.cs
+++ b/LibGit2Sharp/Core/GitCheckoutOptsWrapper.cs
@@ -22,10 +22,17 @@ namespace LibGit2Sharp.Core
                 PathArray = GitStrArrayManaged.BuildFrom(paths);
             }
 
+            var checkout_strategy = options.CheckoutStrategy;
+
+            if (options.LongPaths)
+            {
+                checkout_strategy |= CheckoutStrategy.GIT_CHECKOUT_LONGPATHS;
+            }
+
             Options = new GitCheckoutOpts
             {
                 version = 1,
-                checkout_strategy = options.CheckoutStrategy,
+                checkout_strategy = checkout_strategy,
                 progress_cb = Callbacks.CheckoutProgressCallback,
                 notify_cb = Callbacks.CheckoutNotifyCallback,
                 notify_flags = options.CheckoutNotifyFlags,

--- a/LibGit2Sharp/MergeAndCheckoutOptionsBase.cs
+++ b/LibGit2Sharp/MergeAndCheckoutOptionsBase.cs
@@ -46,6 +46,9 @@ namespace LibGit2Sharp
         /// </summary>
         public CheckoutProgressHandler OnCheckoutProgress { get; set; }
 
+        /// <inheritdoc />
+        public bool LongPaths { get; set; }
+
         /// <summary>
         /// Delegate that checkout will notify callers of
         /// certain conditions. The conditions that are reported is
@@ -68,6 +71,8 @@ namespace LibGit2Sharp
                        GitCheckoutOptsWrapper.CheckoutStrategyFromFileConflictStrategy(FileConflictStrategy);
             }
         }
+
+
 
         #endregion
     }

--- a/LibGit2Sharp/RebaseOptions.cs
+++ b/LibGit2Sharp/RebaseOptions.cs
@@ -54,5 +54,8 @@ namespace LibGit2Sharp
                        GitCheckoutOptsWrapper.CheckoutStrategyFromFileConflictStrategy(FileConflictStrategy);
             }
         }
+
+        /// <inheritdoc />
+        public bool LongPaths { get; set; }
     }
 }

--- a/LibGit2Sharp/SubmoduleUpdateOptions.cs
+++ b/LibGit2Sharp/SubmoduleUpdateOptions.cs
@@ -49,5 +49,8 @@ namespace LibGit2Sharp
         {
             get { return CheckoutNotifyFlags; }
         }
+
+        /// <inheritdoc />
+        public bool LongPaths { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
Adds support for long file paths in `CheckoutOptions` by introducing the `LongPaths` property and updating `CheckoutStrategy` with the `GIT_CHECKOUT_LONGPATHS` flag.

## Changes
- New property `LongPaths` in `CheckoutOptions`.
- Added `GIT_CHECKOUT_LONGPATHS` to `CheckoutStrategy`.

## Motivation
Enhances compatibility with projects that have deeply nested directories or long file names, especially on Windows.