### PR TITLE
Updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install .NET SDK
         uses: actions/setup-dotnet@v4.0.0
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
       - name: Build
         run: dotnet build LibGit2Sharp.sln --configuration Release
       - name: Upload packages
@@ -39,7 +39,7 @@ jobs:
       matrix:
         arch: [ x64 ]
         os: [ windows-2019, windows-2022, macos-12, macos-13 ]
-        tfm: [ net472, net8.0 ]
+        tfm: [ net472, net8.0, net9.0 ]
         exclude:
           - os: macos-12
             tfm: net472
@@ -49,6 +49,9 @@ jobs:
           - arch: arm64
             os: macos-14
             tfm: net8.0
+          - arch: arm64
+            os: macos-14
+            tfm: net9.0
       fail-fast: false
     steps:
       - name: Checkout
@@ -59,6 +62,7 @@ jobs:
         uses: actions/setup-dotnet@v4.0.0
         with:
           dotnet-version: |
+            9.0.x
             8.0.x
       - name: Run ${{ matrix.tfm }} tests
         run: dotnet test LibGit2Sharp.sln --configuration Release --framework ${{ matrix.tfm }} --logger "GitHubActions" /p:ExtraDefine=LEAKS_IDENTIFYING
@@ -69,26 +73,13 @@ jobs:
       matrix:
         arch: [ amd64 ]
         # arch: [ amd64, arm64 ]
-        distro: [ alpine.3.13, alpine.3.14, alpine.3.15, alpine.3.16, alpine.3.17, alpine.3.18, centos.stream.8, debian.10, debian.11, fedora.36, fedora.37, ubuntu.18.04, ubuntu.20.04, ubuntu.22.04 ]
-        sdk:  [ '8.0' ]
-        exclude:
-          - distro: alpine.3.13
-            sdk: '8.0'
-          - distro: alpine.3.14
-            sdk: '8.0'
-          - distro: alpine.3.15
-            sdk: '8.0'
-          - distro: alpine.3.16
-            sdk: '8.0'
-          - distro: debian.10
-            sdk: '8.0'
-          - distro: fedora.36
-            sdk: '8.0'
-          - distro: ubuntu.18.04
-            sdk: '8.0'
+        distro: [ alpine.3.17, alpine.3.18, centos.stream.8, debian.11, fedora.37, ubuntu.18.04, ubuntu.20.04, ubuntu.22.04 ]
+        sdk:  [ '8.0', '9.0' ]
         include:
           - sdk: '8.0'
             tfm: net8.0
+          - sdk: '9.0'
+            tfm: net9.0
       fail-fast: false
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,16 +39,13 @@ jobs:
       matrix:
         arch: [ x64 ]
         os: [ windows-2019, windows-2022, macos-12, macos-13 ]
-        tfm: [ net472, net6.0, net8.0 ]
+        tfm: [ net472, net8.0 ]
         exclude:
           - os: macos-12
             tfm: net472
           - os: macos-13
             tfm: net472
         include:
-          - arch: arm64
-            os: macos-14
-            tfm: net6.0
           - arch: arm64
             os: macos-14
             tfm: net8.0
@@ -63,7 +60,6 @@ jobs:
         with:
           dotnet-version: |
             8.0.x
-            6.0.x
       - name: Run ${{ matrix.tfm }} tests
         run: dotnet test LibGit2Sharp.sln --configuration Release --framework ${{ matrix.tfm }} --logger "GitHubActions" /p:ExtraDefine=LEAKS_IDENTIFYING
   test-linux:
@@ -74,7 +70,7 @@ jobs:
         arch: [ amd64 ]
         # arch: [ amd64, arm64 ]
         distro: [ alpine.3.13, alpine.3.14, alpine.3.15, alpine.3.16, alpine.3.17, alpine.3.18, centos.stream.8, debian.10, debian.11, fedora.36, fedora.37, ubuntu.18.04, ubuntu.20.04, ubuntu.22.04 ]
-        sdk:  [ '6.0', '8.0' ]
+        sdk:  [ '8.0' ]
         exclude:
           - distro: alpine.3.13
             sdk: '8.0'
@@ -91,8 +87,6 @@ jobs:
           - distro: ubuntu.18.04
             sdk: '8.0'
         include:
-          - sdk: '6.0'
-            tfm: net6.0
           - sdk: '8.0'
             tfm: net8.0
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,8 +73,15 @@ jobs:
       matrix:
         arch: [ amd64 ]
         # arch: [ amd64, arm64 ]
-        distro: [ alpine.3.17, alpine.3.18, centos.stream.8, debian.11, fedora.37, ubuntu.18.04, ubuntu.20.04, ubuntu.22.04 ]
+        distro: [ alpine.3.17, alpine.3.18, alpine.3.19, alpine.3.20, centos.stream.9, debian.12, fedora.39, fedora.40, ubuntu.20.04, ubuntu.22.04, ubuntu.24.04 ]
         sdk:  [ '8.0', '9.0' ]
+        exclude:
+          - distro: alpine.3.17
+            sdk: '9.0'
+          - distro: alpine.3.18
+            sdk: '9.0'
+          - distro: fedora.39
+            sdk: '9.0'
         include:
           - sdk: '8.0'
             tfm: net8.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,14 +71,14 @@ jobs:
       matrix:
         arch: [ amd64 ]
         # arch: [ amd64, arm64 ]
-        distro: [ alpine.3.17, alpine.3.18, alpine.3.19, alpine.3.20, centos.stream.9, debian.12, fedora.39, fedora.40, ubuntu.20.04, ubuntu.22.04, ubuntu.24.04 ]
+        distro: [ alpine.3.17, alpine.3.18, alpine.3.19, alpine.3.20, centos.stream.9, debian.12, fedora.40, ubuntu.20.04, ubuntu.22.04, ubuntu.24.04 ]
         sdk:  [ '8.0', '9.0' ]
         exclude:
           - distro: alpine.3.17
             sdk: '9.0'
           - distro: alpine.3.18
             sdk: '9.0'
-          - distro: fedora.39
+          - distro: alpine.3.19
             sdk: '9.0'
         include:
           - sdk: '8.0'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,9 @@ jobs:
     strategy:
       matrix:
         arch: [ x64 ]
-        os: [ windows-2019, windows-2022, macos-12, macos-13 ]
+        os: [ windows-2019, windows-2022, macos-13 ]
         tfm: [ net472, net8.0, net9.0 ]
         exclude:
-          - os: macos-12
-            tfm: net472
           - os: macos-13
             tfm: net472
         include:
@@ -100,5 +98,5 @@ jobs:
         run: |
             git_command="git config --global --add safe.directory /app"
             test_command="dotnet test LibGit2Sharp.sln --configuration Release -p:TargetFrameworks=${{ matrix.tfm }} --logger "GitHubActions" -p:ExtraDefine=LEAKS_IDENTIFYING"
-            docker run -t --rm --platform linux/${{ matrix.arch }} -v "$PWD:/app" gittools/build-images:${{ matrix.distro }}-sdk-${{ matrix.sdk }} sh -c "$git_command && $test_command"
+            docker run -t --rm --platform linux/${{ matrix.arch }} -v "$PWD:/app" -e OPENSSL_ENABLE_SHA1_SIGNATURES=1 gittools/build-images:${{ matrix.distro }}-sdk-${{ matrix.sdk }} sh -c "$git_command && $test_command"
 

--- a/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
+++ b/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(TargetFrameworks)'==''">net472;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)'==''">net472;net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
+++ b/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(TargetFrameworks)'==''">net472;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)'==''">net472;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
+++ b/LibGit2Sharp.Tests/LibGit2Sharp.Tests.csproj
@@ -11,12 +11,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.console" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.console" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageReference Include="xunit.skippablefact" Version="1.4.13" />
   </ItemGroup>
 

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -40,8 +40,7 @@
 
   <ItemGroup>
     <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="[2.0.322]" PrivateAssets="none" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
-    <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="all" />
+    <PackageReference Include="MinVer" Version="6.0.0" PrivateAssets="all" />
   </ItemGroup>
 
   <Import Project="..\Targets\CodeGenerator.targets" />

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <TargetFrameworks>net472;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>LibGit2Sharp brings all the might and speed of libgit2, a native Git implementation, to the managed world of .NET</Description>
     <Company>LibGit2Sharp contributors</Company>
@@ -24,7 +24,7 @@
     <MinVerBuildMetadata Condition="'$(libgit2_hash)' != ''">libgit2-$(libgit2_hash.Substring(0,7))</MinVerBuildMetadata>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -29,6 +29,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="[2.0.322]" PrivateAssets="none" />
+    <PackageReference Include="MinVer" Version="6.0.0" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="..\square-logo.png" Pack="true" PackagePath="" Visible="false" />
     <None Include="..\README.md" Pack="true" PackagePath="App_Readme/" Visible="false" />
     <None Include="..\LICENSE.md" Pack="true" PackagePath="App_Readme/" Visible="false" />
@@ -36,11 +41,6 @@
     <None Update="Core\Handles\Objects.tt" Generator="TextTemplatingFileGenerator" LastGenOutput="Objects.cs" />
     <Compile Update="Core\Handles\Objects.cs" DependentUpon="Objects.tt" DesignTime="True" AutoGen="True" />
     <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" /> <!-- Needed for T4 generation -->
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="[2.0.322]" PrivateAssets="none" />
-    <PackageReference Include="MinVer" Version="6.0.0" PrivateAssets="all" />
   </ItemGroup>
 
   <Import Project="..\Targets\CodeGenerator.targets" />

--- a/TrimmingTestApp/TrimmingTestApp.csproj
+++ b/TrimmingTestApp/TrimmingTestApp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
This PR makes the following changes:

- .NET 6 is out of support, so the `net6.0` TFM has been changed to `net8.0`
- .NET 9 has been added as a testing target
- CI has been updated for new combinations of OS and .NET versions
- NuGet packages have been updated to latest versions