### PR TITLE
Use `nameof` on arguments for Ensure

### DIFF
--- a/LibGit2Sharp/Blob.cs
+++ b/LibGit2Sharp/Blob.cs
@@ -62,7 +62,7 @@ namespace LibGit2Sharp
         /// <exception cref="NotFoundException">Throws if blob is missing</exception>
         public virtual Stream GetContentStream(FilteringOptions filteringOptions)
         {
-            Ensure.ArgumentNotNull(filteringOptions, "filteringOptions");
+            Ensure.ArgumentNotNull(filteringOptions, nameof(filteringOptions));
 
             return Proxy.git_blob_filtered_content_stream(repo.Handle, Id, filteringOptions.HintPath, false);
         }
@@ -86,7 +86,7 @@ namespace LibGit2Sharp
         /// <exception cref="NotFoundException">Throws if blob is missing</exception>
         public virtual string GetContentText(Encoding encoding)
         {
-            Ensure.ArgumentNotNull(encoding, "encoding");
+            Ensure.ArgumentNotNull(encoding, nameof(encoding));
 
             return ReadToEnd(GetContentStream(), encoding);
         }
@@ -114,7 +114,7 @@ namespace LibGit2Sharp
         /// <exception cref="NotFoundException">Throws if blob is missing</exception>
         public virtual string GetContentText(FilteringOptions filteringOptions, Encoding encoding)
         {
-            Ensure.ArgumentNotNull(filteringOptions, "filteringOptions");
+            Ensure.ArgumentNotNull(filteringOptions, nameof(filteringOptions));
 
             return ReadToEnd(GetContentStream(filteringOptions), encoding);
         }

--- a/LibGit2Sharp/BranchCollection.cs
+++ b/LibGit2Sharp/BranchCollection.cs
@@ -39,7 +39,7 @@ namespace LibGit2Sharp
         {
             get
             {
-                Ensure.ArgumentNotNullOrEmptyString(name, "name");
+                Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
                 if (LooksLikeABranchName(name))
                 {
@@ -138,7 +138,7 @@ namespace LibGit2Sharp
         /// <returns>A new <see cref="Branch"/>.</returns>
         public virtual Branch Add(string name, Commit commit, bool allowOverwrite)
         {
-            Ensure.ArgumentNotNull(commit, "commit");
+            Ensure.ArgumentNotNull(commit, nameof(commit));
 
             return Add(name, commit.Sha, allowOverwrite);
         }
@@ -152,8 +152,8 @@ namespace LibGit2Sharp
         /// <returns>A new <see cref="Branch"/>.</returns>
         public virtual Branch Add(string name, string committish, bool allowOverwrite)
         {
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");
-            Ensure.ArgumentNotNullOrEmptyString(committish, "committish");
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
+            Ensure.ArgumentNotNullOrEmptyString(committish, nameof(committish));
 
             using (Proxy.git_branch_create_from_annotated(repo.Handle, name, committish, allowOverwrite))
             { }
@@ -178,7 +178,7 @@ namespace LibGit2Sharp
         /// <param name="isRemote">True if the provided <paramref name="name"/> is the name of a remote branch, false otherwise.</param>
         public virtual void Remove(string name, bool isRemote)
         {
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
             string branchName = isRemote ? Reference.RemoteTrackingBranchPrefix + name : name;
 
@@ -197,7 +197,7 @@ namespace LibGit2Sharp
         /// <param name="branch">The branch to delete.</param>
         public virtual void Remove(Branch branch)
         {
-            Ensure.ArgumentNotNull(branch, "branch");
+            Ensure.ArgumentNotNull(branch, nameof(branch));
 
             using (ReferenceHandle referencePtr = repo.Refs.RetrieveReferencePtr(branch.CanonicalName))
             {
@@ -225,8 +225,8 @@ namespace LibGit2Sharp
         /// <returns>A new <see cref="Branch"/>.</returns>
         public virtual Branch Rename(string currentName, string newName, bool allowOverwrite)
         {
-            Ensure.ArgumentNotNullOrEmptyString(currentName, "currentName");
-            Ensure.ArgumentNotNullOrEmptyString(newName, "newName");
+            Ensure.ArgumentNotNullOrEmptyString(currentName, nameof(currentName));
+            Ensure.ArgumentNotNullOrEmptyString(newName, nameof(newName));
 
             Branch branch = this[currentName];
 
@@ -258,8 +258,8 @@ namespace LibGit2Sharp
         /// <returns>A new <see cref="Branch"/>.</returns>
         public virtual Branch Rename(Branch branch, string newName, bool allowOverwrite)
         {
-            Ensure.ArgumentNotNull(branch, "branch");
-            Ensure.ArgumentNotNullOrEmptyString(newName, "newName");
+            Ensure.ArgumentNotNull(branch, nameof(branch));
+            Ensure.ArgumentNotNullOrEmptyString(newName, nameof(newName));
 
             if (branch.IsRemote)
             {

--- a/LibGit2Sharp/BranchUpdater.cs
+++ b/LibGit2Sharp/BranchUpdater.cs
@@ -20,8 +20,8 @@ namespace LibGit2Sharp
 
         internal BranchUpdater(Repository repo, Branch branch)
         {
-            Ensure.ArgumentNotNull(repo, "repo");
-            Ensure.ArgumentNotNull(branch, "branch");
+            Ensure.ArgumentNotNull(repo, nameof(repo));
+            Ensure.ArgumentNotNull(branch, nameof(branch));
 
             this.repo = repo;
             this.branch = branch;

--- a/LibGit2Sharp/CloneOptions.cs
+++ b/LibGit2Sharp/CloneOptions.cs
@@ -14,7 +14,7 @@ namespace LibGit2Sharp
         /// <param name="fetchOptions">The fetch options to use.</param>
         public CloneOptions(FetchOptions fetchOptions) : this()
         {
-            Ensure.ArgumentNotNull(fetchOptions, "fetchOptions");
+            Ensure.ArgumentNotNull(fetchOptions, nameof(fetchOptions));
 
             FetchOptions = fetchOptions;
         }

--- a/LibGit2Sharp/Commands/Checkout.cs
+++ b/LibGit2Sharp/Commands/Checkout.cs
@@ -34,9 +34,9 @@ namespace LibGit2Sharp
         /// <returns>The <see cref="Branch"/> that was checked out.</returns>
         public static Branch Checkout(IRepository repository, string committishOrBranchSpec, CheckoutOptions options)
         {
-            Ensure.ArgumentNotNull(repository, "repository");
-            Ensure.ArgumentNotNullOrEmptyString(committishOrBranchSpec, "committishOrBranchSpec");
-            Ensure.ArgumentNotNull(options, "options");
+            Ensure.ArgumentNotNull(repository, nameof(repository));
+            Ensure.ArgumentNotNullOrEmptyString(committishOrBranchSpec, nameof(committishOrBranchSpec));
+            Ensure.ArgumentNotNull(options, nameof(options));
 
             Reference reference = null;
             GitObject obj = null;
@@ -109,9 +109,9 @@ namespace LibGit2Sharp
         /// <returns>The <see cref="Branch"/> that was checked out.</returns>
         public static Branch Checkout(IRepository repository, Branch branch, CheckoutOptions options)
         {
-            Ensure.ArgumentNotNull(repository, "repository");
-            Ensure.ArgumentNotNull(branch, "branch");
-            Ensure.ArgumentNotNull(options, "options");
+            Ensure.ArgumentNotNull(repository, nameof(repository));
+            Ensure.ArgumentNotNull(branch, nameof(branch));
+            Ensure.ArgumentNotNull(options, nameof(options));
 
             // Make sure this is not an unborn branch.
             if (branch.Tip == null)
@@ -160,9 +160,9 @@ namespace LibGit2Sharp
         /// <returns>The <see cref="Branch"/> that was checked out.</returns>
         public static Branch Checkout(IRepository repository, Commit commit, CheckoutOptions options)
         {
-            Ensure.ArgumentNotNull(repository, "repository");
-            Ensure.ArgumentNotNull(commit, "commit");
-            Ensure.ArgumentNotNull(options, "options");
+            Ensure.ArgumentNotNull(repository, nameof(repository));
+            Ensure.ArgumentNotNull(commit, nameof(commit));
+            Ensure.ArgumentNotNull(options, nameof(options));
 
             Checkout(repository, commit.Tree, options, commit.Id.Sha);
 

--- a/LibGit2Sharp/Commands/Fetch.cs
+++ b/LibGit2Sharp/Commands/Fetch.cs
@@ -33,7 +33,7 @@ namespace LibGit2Sharp
         /// <param name="refspecs">List of refspecs to apply as active.</param>
         public static void Fetch(Repository repository, string remote, IEnumerable<string> refspecs, FetchOptions options, string logMessage)
         {
-            Ensure.ArgumentNotNull(remote, "remote");
+            Ensure.ArgumentNotNull(remote, nameof(remote));
 
             options = options ?? new FetchOptions();
             using (var remoteHandle = RemoteFromNameOrUrl(repository.Handle, remote))

--- a/LibGit2Sharp/Commands/Pull.cs
+++ b/LibGit2Sharp/Commands/Pull.cs
@@ -16,8 +16,8 @@ namespace LibGit2Sharp
         /// <param name="options">The options for fetch and merging.</param>
         public static MergeResult Pull(Repository repository, Signature merger, PullOptions options)
         {
-            Ensure.ArgumentNotNull(repository, "repository");
-            Ensure.ArgumentNotNull(merger, "merger");
+            Ensure.ArgumentNotNull(repository, nameof(repository));
+            Ensure.ArgumentNotNull(merger, nameof(merger));
 
 
             options = options ?? new PullOptions();

--- a/LibGit2Sharp/Commands/Remove.cs
+++ b/LibGit2Sharp/Commands/Remove.cs
@@ -68,8 +68,8 @@ namespace LibGit2Sharp
         /// </param>
         public static void Remove(IRepository repository, string path, bool removeFromWorkingDirectory, ExplicitPathsOptions explicitPathsOptions)
         {
-            Ensure.ArgumentNotNull(repository, "repository");
-            Ensure.ArgumentNotNull(path, "path");
+            Ensure.ArgumentNotNull(repository, nameof(repository));
+            Ensure.ArgumentNotNull(path, nameof(path));
 
             Remove(repository, new[] { path }, removeFromWorkingDirectory, explicitPathsOptions);
         }
@@ -115,8 +115,8 @@ namespace LibGit2Sharp
         /// </param>
         public static void Remove(IRepository repository, IEnumerable<string> paths, bool removeFromWorkingDirectory, ExplicitPathsOptions explicitPathsOptions)
         {
-            Ensure.ArgumentNotNull(repository, "repository");
-            Ensure.ArgumentNotNullOrEmptyEnumerable<string>(paths, "paths");
+            Ensure.ArgumentNotNull(repository, nameof(repository));
+            Ensure.ArgumentNotNullOrEmptyEnumerable<string>(paths, nameof(paths));
 
             var pathsToDelete = paths.Where(p => Directory.Exists(Path.Combine(repository.Info.WorkingDirectory, p))).ToList();
             var notConflictedPaths = new List<string>();
@@ -124,7 +124,7 @@ namespace LibGit2Sharp
 
             foreach (var path in paths)
             {
-                Ensure.ArgumentNotNullOrEmptyString(path, "path");
+                Ensure.ArgumentNotNullOrEmptyString(path, nameof(path));
 
                 var conflict = index.Conflicts[path];
 

--- a/LibGit2Sharp/Commands/Stage.cs
+++ b/LibGit2Sharp/Commands/Stage.cs
@@ -19,8 +19,8 @@ namespace LibGit2Sharp
         /// <param name="path">The path of the file within the working directory.</param>
         public static void Stage(IRepository repository, string path)
         {
-            Ensure.ArgumentNotNull(repository, "repository");
-            Ensure.ArgumentNotNull(path, "path");
+            Ensure.ArgumentNotNull(repository, nameof(repository));
+            Ensure.ArgumentNotNull(path, nameof(path));
 
             Stage(repository, new[] { path }, null);
         }
@@ -35,8 +35,8 @@ namespace LibGit2Sharp
         /// <param name="stageOptions">Determines how paths will be staged.</param>
         public static void Stage(IRepository repository, string path, StageOptions stageOptions)
         {
-            Ensure.ArgumentNotNull(repository, "repository");
-            Ensure.ArgumentNotNull(path, "path");
+            Ensure.ArgumentNotNull(repository, nameof(repository));
+            Ensure.ArgumentNotNull(path, nameof(path));
 
             Stage(repository, new[] { path }, stageOptions);
         }
@@ -63,8 +63,8 @@ namespace LibGit2Sharp
         /// <param name="stageOptions">Determines how paths will be staged.</param>
         public static void Stage(IRepository repository, IEnumerable<string> paths, StageOptions stageOptions)
         {
-            Ensure.ArgumentNotNull(repository, "repository");
-            Ensure.ArgumentNotNull(paths, "paths");
+            Ensure.ArgumentNotNull(repository, nameof(repository));
+            Ensure.ArgumentNotNull(paths, nameof(paths));
 
             DiffModifiers diffModifiers = DiffModifiers.IncludeUntracked;
             ExplicitPathsOptions explicitPathsOptions = stageOptions != null ? stageOptions.ExplicitPathsOptions : null;
@@ -160,8 +160,8 @@ namespace LibGit2Sharp
         /// </param>
         public static void Unstage(IRepository repository, string path, ExplicitPathsOptions explicitPathsOptions)
         {
-            Ensure.ArgumentNotNull(repository, "repository");
-            Ensure.ArgumentNotNull(path, "path");
+            Ensure.ArgumentNotNull(repository, nameof(repository));
+            Ensure.ArgumentNotNull(path, nameof(path));
 
             Unstage(repository, new[] { path }, explicitPathsOptions);
         }
@@ -187,8 +187,8 @@ namespace LibGit2Sharp
         /// </param>
         public static void Unstage(IRepository repository, IEnumerable<string> paths, ExplicitPathsOptions explicitPathsOptions)
         {
-            Ensure.ArgumentNotNull(repository, "repository");
-            Ensure.ArgumentNotNull(paths, "paths");
+            Ensure.ArgumentNotNull(repository, nameof(repository));
+            Ensure.ArgumentNotNull(paths, nameof(paths));
 
             if (repository.Info.IsHeadUnborn)
             {
@@ -222,9 +222,9 @@ namespace LibGit2Sharp
         /// <param name="destinationPaths">The target paths of the files within the working directory.</param>
         public static void Move(IRepository repository, IEnumerable<string> sourcePaths, IEnumerable<string> destinationPaths)
         {
-            Ensure.ArgumentNotNull(repository, "repository");
-            Ensure.ArgumentNotNull(sourcePaths, "sourcePaths");
-            Ensure.ArgumentNotNull(destinationPaths, "destinationPaths");
+            Ensure.ArgumentNotNull(repository, nameof(repository));
+            Ensure.ArgumentNotNull(sourcePaths, nameof(sourcePaths));
+            Ensure.ArgumentNotNull(destinationPaths, nameof(destinationPaths));
 
             //TODO: Move() should support following use cases:
             // - Moving a file under a directory ('file' and 'dir' -> 'dir/file')

--- a/LibGit2Sharp/Commit.cs
+++ b/LibGit2Sharp/Commit.cs
@@ -185,12 +185,12 @@ namespace LibGit2Sharp
         /// <returns>The contents of the commit object.</returns>
         public static string CreateBuffer(Signature author, Signature committer, string message, Tree tree, IEnumerable<Commit> parents, bool prettifyMessage, char? commentChar)
         {
-            Ensure.ArgumentNotNull(message, "message");
-            Ensure.ArgumentDoesNotContainZeroByte(message, "message");
-            Ensure.ArgumentNotNull(author, "author");
-            Ensure.ArgumentNotNull(committer, "committer");
-            Ensure.ArgumentNotNull(tree, "tree");
-            Ensure.ArgumentNotNull(parents, "parents");
+            Ensure.ArgumentNotNull(message, nameof(message));
+            Ensure.ArgumentDoesNotContainZeroByte(message, nameof(message));
+            Ensure.ArgumentNotNull(author, nameof(author));
+            Ensure.ArgumentNotNull(committer, nameof(committer));
+            Ensure.ArgumentNotNull(tree, nameof(tree));
+            Ensure.ArgumentNotNull(parents, nameof(parents));
 
             if (prettifyMessage)
             {

--- a/LibGit2Sharp/CommitLog.cs
+++ b/LibGit2Sharp/CommitLog.cs
@@ -72,9 +72,9 @@ namespace LibGit2Sharp
         /// <returns>A list of commits, ready to be enumerated.</returns>
         public ICommitLog QueryBy(CommitFilter filter)
         {
-            Ensure.ArgumentNotNull(filter, "filter");
-            Ensure.ArgumentNotNull(filter.IncludeReachableFrom, "filter.IncludeReachableFrom");
-            Ensure.ArgumentNotNullOrEmptyString(filter.IncludeReachableFrom.ToString(), "filter.IncludeReachableFrom");
+            Ensure.ArgumentNotNull(filter, nameof(filter));
+            Ensure.ArgumentNotNull(filter.IncludeReachableFrom, nameof(filter.IncludeReachableFrom));
+            Ensure.ArgumentNotNullOrEmptyString(filter.IncludeReachableFrom.ToString(), nameof(filter.IncludeReachableFrom.ToString()));
 
             return new CommitLog(repo, filter);
         }
@@ -86,7 +86,7 @@ namespace LibGit2Sharp
         /// <returns>A list of file history entries, ready to be enumerated.</returns>
         public IEnumerable<LogEntry> QueryBy(string path)
         {
-            Ensure.ArgumentNotNull(path, "path");
+            Ensure.ArgumentNotNull(path, nameof(path));
 
             return new FileHistory(repo, path);
         }
@@ -99,8 +99,8 @@ namespace LibGit2Sharp
         /// <returns>A list of file history entries, ready to be enumerated.</returns>
         public IEnumerable<LogEntry> QueryBy(string path, CommitFilter filter)
         {
-            Ensure.ArgumentNotNull(path, "path");
-            Ensure.ArgumentNotNull(filter, "filter");
+            Ensure.ArgumentNotNull(path, nameof(path));
+            Ensure.ArgumentNotNull(filter, nameof(filter));
 
             return new FileHistory(repo, path, filter);
         }

--- a/LibGit2Sharp/Configuration.cs
+++ b/LibGit2Sharp/Configuration.cs
@@ -245,7 +245,7 @@ namespace LibGit2Sharp
         /// <param name="level">The configuration file which should be considered as the target of this operation</param>
         public virtual bool Unset(string key, ConfigurationLevel level)
         {
-            Ensure.ArgumentNotNullOrEmptyString(key, "key");
+            Ensure.ArgumentNotNullOrEmptyString(key, nameof(key));
 
             using (ConfigurationHandle h = RetrieveConfigurationHandle(level, true, configHandle))
             {
@@ -269,7 +269,7 @@ namespace LibGit2Sharp
         /// <param name="level">The configuration file which should be considered as the target of this operation</param>
         public virtual bool UnsetAll(string key, ConfigurationLevel level)
         {
-            Ensure.ArgumentNotNullOrEmptyString(key, "key");
+            Ensure.ArgumentNotNullOrEmptyString(key, nameof(key));
 
             using (ConfigurationHandle h = RetrieveConfigurationHandle(level, true, configHandle))
             {
@@ -307,7 +307,7 @@ namespace LibGit2Sharp
         /// <returns>The <see cref="ConfigurationEntry{T}"/>, or null if not set</returns>
         public virtual ConfigurationEntry<T> Get<T>(string[] keyParts)
         {
-            Ensure.ArgumentNotNull(keyParts, "keyParts");
+            Ensure.ArgumentNotNull(keyParts, nameof(keyParts));
 
             return Get<T>(string.Join(".", keyParts));
         }
@@ -336,9 +336,9 @@ namespace LibGit2Sharp
         /// <returns>The <see cref="ConfigurationEntry{T}"/>, or null if not set</returns>
         public virtual ConfigurationEntry<T> Get<T>(string firstKeyPart, string secondKeyPart, string thirdKeyPart)
         {
-            Ensure.ArgumentNotNullOrEmptyString(firstKeyPart, "firstKeyPart");
-            Ensure.ArgumentNotNullOrEmptyString(secondKeyPart, "secondKeyPart");
-            Ensure.ArgumentNotNullOrEmptyString(thirdKeyPart, "thirdKeyPart");
+            Ensure.ArgumentNotNullOrEmptyString(firstKeyPart, nameof(firstKeyPart));
+            Ensure.ArgumentNotNullOrEmptyString(secondKeyPart, nameof(secondKeyPart));
+            Ensure.ArgumentNotNullOrEmptyString(thirdKeyPart, nameof(thirdKeyPart));
 
             return Get<T>(new[] { firstKeyPart, secondKeyPart, thirdKeyPart });
         }
@@ -374,7 +374,7 @@ namespace LibGit2Sharp
         /// <returns>The <see cref="ConfigurationEntry{T}"/>, or null if not set</returns>
         public virtual ConfigurationEntry<T> Get<T>(string key)
         {
-            Ensure.ArgumentNotNullOrEmptyString(key, "key");
+            Ensure.ArgumentNotNullOrEmptyString(key, nameof(key));
 
             using (ConfigurationHandle snapshot = Snapshot())
             {
@@ -405,7 +405,7 @@ namespace LibGit2Sharp
         /// <returns>The <see cref="ConfigurationEntry{T}"/>, or null if not set</returns>
         public virtual ConfigurationEntry<T> Get<T>(string key, ConfigurationLevel level)
         {
-            Ensure.ArgumentNotNullOrEmptyString(key, "key");
+            Ensure.ArgumentNotNullOrEmptyString(key, nameof(key));
 
             using (ConfigurationHandle snapshot = Snapshot())
             using (ConfigurationHandle handle = RetrieveConfigurationHandle(level, false, snapshot))
@@ -587,7 +587,7 @@ namespace LibGit2Sharp
 
         private static T ValueOrDefault<T>(ConfigurationEntry<T> value, Func<T> defaultValueSelector)
         {
-            Ensure.ArgumentNotNull(defaultValueSelector, "defaultValueSelector");
+            Ensure.ArgumentNotNull(defaultValueSelector, nameof(defaultValueSelector));
 
             return value == null
                        ? defaultValueSelector()
@@ -634,8 +634,8 @@ namespace LibGit2Sharp
         /// <param name="level">The configuration file which should be considered as the target of this operation</param>
         public virtual void Set<T>(string key, T value, ConfigurationLevel level)
         {
-            Ensure.ArgumentNotNull(value, "value");
-            Ensure.ArgumentNotNullOrEmptyString(key, "key");
+            Ensure.ArgumentNotNull(value, nameof(value));
+            Ensure.ArgumentNotNullOrEmptyString(key, nameof(key));
 
             using (ConfigurationHandle h = RetrieveConfigurationHandle(level, true, configHandle))
             {
@@ -686,8 +686,8 @@ namespace LibGit2Sharp
         /// <param name="level">The configuration file which should be considered as the target of this operation</param>
         public virtual void Add(string key, string value, ConfigurationLevel level)
         {
-            Ensure.ArgumentNotNull(value, "value");
-            Ensure.ArgumentNotNullOrEmptyString(key, "key");
+            Ensure.ArgumentNotNull(value, nameof(value));
+            Ensure.ArgumentNotNullOrEmptyString(key, nameof(key));
 
             using (ConfigurationHandle h = RetrieveConfigurationHandle(level, true, configHandle))
             {
@@ -713,7 +713,7 @@ namespace LibGit2Sharp
         /// <returns>Matching entries.</returns>
         public virtual IEnumerable<ConfigurationEntry<string>> Find(string regexp, ConfigurationLevel level)
         {
-            Ensure.ArgumentNotNullOrEmptyString(regexp, "regexp");
+            Ensure.ArgumentNotNullOrEmptyString(regexp, nameof(regexp));
 
             using (ConfigurationHandle snapshot = Snapshot())
             using (ConfigurationHandle h = RetrieveConfigurationHandle(level, true, snapshot))

--- a/LibGit2Sharp/Core/FileHistory.cs
+++ b/LibGit2Sharp/Core/FileHistory.cs
@@ -66,9 +66,9 @@ namespace LibGit2Sharp.Core
         /// <exception cref="ArgumentException">When an unsupported commit sort strategy is specified.</exception>
         internal FileHistory(Repository repo, string path, CommitFilter queryFilter)
         {
-            Ensure.ArgumentNotNull(repo, "repo");
-            Ensure.ArgumentNotNull(path, "path");
-            Ensure.ArgumentNotNull(queryFilter, "queryFilter");
+            Ensure.ArgumentNotNull(repo, nameof(repo));
+            Ensure.ArgumentNotNull(path, nameof(path));
+            Ensure.ArgumentNotNull(queryFilter, nameof(queryFilter));
 
             // Ensure the commit sort strategy makes sense.
             if (!AllowedSortStrategies.Contains(queryFilter.SortBy))

--- a/LibGit2Sharp/Core/ObjectSafeWrapper.cs
+++ b/LibGit2Sharp/Core/ObjectSafeWrapper.cs
@@ -9,7 +9,7 @@ namespace LibGit2Sharp.Core
 
         public unsafe ObjectSafeWrapper(ObjectId id, RepositoryHandle handle, bool allowNullObjectId = false, bool throwIfMissing = false)
         {
-            Ensure.ArgumentNotNull(handle, "handle");
+            Ensure.ArgumentNotNull(handle, nameof(handle));
 
             if (allowNullObjectId && id == null)
             {
@@ -17,7 +17,7 @@ namespace LibGit2Sharp.Core
             }
             else
             {
-                Ensure.ArgumentNotNull(id, "id");
+                Ensure.ArgumentNotNull(id, nameof(id));
                 objectPtr = Proxy.git_object_lookup(handle, id, GitObjectType.Any);
             }
 

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -683,7 +683,7 @@ namespace LibGit2Sharp.Core
             ObjectId committishId,
             DescribeOptions options)
         {
-            Ensure.ArgumentPositiveInt32(options.MinimumCommitIdAbbreviatedSize, "options.MinimumCommitIdAbbreviatedSize");
+            Ensure.ArgumentPositiveInt32(options.MinimumCommitIdAbbreviatedSize, nameof(options.MinimumCommitIdAbbreviatedSize));
 
             using (var osw = new ObjectSafeWrapper(committishId, repo))
             {
@@ -1808,8 +1808,8 @@ namespace LibGit2Sharp.Core
             Identity author,
             Identity committer)
         {
-            Ensure.ArgumentNotNull(rebase, "rebase");
-            Ensure.ArgumentNotNull(committer, "committer");
+            Ensure.ArgumentNotNull(rebase, nameof(rebase));
+            Ensure.ArgumentNotNull(committer, nameof(committer));
 
             using (SignatureHandle committerHandle = committer.BuildNowSignatureHandle())
             using (SignatureHandle authorHandle = author.SafeBuildNowSignatureHandle())
@@ -1852,7 +1852,7 @@ namespace LibGit2Sharp.Core
         public static unsafe void git_rebase_abort(
             RebaseHandle rebase)
         {
-            Ensure.ArgumentNotNull(rebase, "rebase");
+            Ensure.ArgumentNotNull(rebase, nameof(rebase));
 
             int result = NativeMethods.git_rebase_abort(rebase);
             Ensure.ZeroResult(result);
@@ -1862,8 +1862,8 @@ namespace LibGit2Sharp.Core
             RebaseHandle rebase,
             Identity committer)
         {
-            Ensure.ArgumentNotNull(rebase, "rebase");
-            Ensure.ArgumentNotNull(committer, "committer");
+            Ensure.ArgumentNotNull(rebase, nameof(rebase));
+            Ensure.ArgumentNotNull(committer, nameof(committer));
 
             using (var signatureHandle = committer.BuildNowSignatureHandle())
             {

--- a/LibGit2Sharp/Filter.cs
+++ b/LibGit2Sharp/Filter.cs
@@ -30,8 +30,8 @@ namespace LibGit2Sharp
         /// </summary>
         protected Filter(string name, IEnumerable<FilterAttributeEntry> attributes)
         {
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");
-            Ensure.ArgumentNotNull(attributes, "attributes");
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
+            Ensure.ArgumentNotNull(attributes, nameof(attributes));
 
             this.name = name;
             this.attributes = attributes;
@@ -249,8 +249,8 @@ namespace LibGit2Sharp
 
             try
             {
-                Ensure.ArgumentNotZeroIntPtr(filterSourcePtr, "filterSourcePtr");
-                Ensure.ArgumentNotZeroIntPtr(git_writestream_next, "git_writestream_next");
+                Ensure.ArgumentNotZeroIntPtr(filterSourcePtr, nameof(filterSourcePtr));
+                Ensure.ArgumentNotZeroIntPtr(git_writestream_next, nameof(git_writestream_next));
 
                 state.thisStream = new GitWriteStream();
                 state.thisStream.close = StreamCloseCallback;
@@ -302,14 +302,14 @@ namespace LibGit2Sharp
 
             try
             {
-                Ensure.ArgumentNotZeroIntPtr(stream, "stream");
+                Ensure.ArgumentNotZeroIntPtr(stream, nameof(stream));
 
                 if (!activeStreams.TryGetValue(stream, out state))
                 {
                     throw new ArgumentException("Unknown stream pointer", nameof(stream));
                 }
 
-                Ensure.ArgumentIsExpectedIntPtr(stream, state.thisPtr, "stream");
+                Ensure.ArgumentIsExpectedIntPtr(stream, state.thisPtr, nameof(stream));
 
                 using (BufferedStream outputBuffer = new BufferedStream(state.output, BufferSize))
                 {
@@ -335,14 +335,14 @@ namespace LibGit2Sharp
 
             try
             {
-                Ensure.ArgumentNotZeroIntPtr(stream, "stream");
+                Ensure.ArgumentNotZeroIntPtr(stream, nameof(stream));
 
                 if (!activeStreams.TryRemove(stream, out state))
                 {
                     throw new ArgumentException("Double free or invalid stream pointer", nameof(stream));
                 }
 
-                Ensure.ArgumentIsExpectedIntPtr(stream, state.thisPtr, "stream");
+                Ensure.ArgumentIsExpectedIntPtr(stream, state.thisPtr, nameof(stream));
 
                 Marshal.FreeHGlobal(state.thisPtr);
             }
@@ -360,15 +360,15 @@ namespace LibGit2Sharp
 
             try
             {
-                Ensure.ArgumentNotZeroIntPtr(stream, "stream");
-                Ensure.ArgumentNotZeroIntPtr(buffer, "buffer");
+                Ensure.ArgumentNotZeroIntPtr(stream, nameof(stream));
+                Ensure.ArgumentNotZeroIntPtr(buffer, nameof(buffer));
 
                 if (!activeStreams.TryGetValue(stream, out state))
                 {
                     throw new ArgumentException("Invalid or already freed stream pointer", nameof(stream));
                 }
 
-                Ensure.ArgumentIsExpectedIntPtr(stream, state.thisPtr, "stream");
+                Ensure.ArgumentIsExpectedIntPtr(stream, state.thisPtr, nameof(stream));
 
                 using (UnmanagedMemoryStream input = new UnmanagedMemoryStream((byte*)buffer.ToPointer(), (long)len))
                 using (BufferedStream outputBuffer = new BufferedStream(state.output, BufferSize))

--- a/LibGit2Sharp/FilterAttributeEntry.cs
+++ b/LibGit2Sharp/FilterAttributeEntry.cs
@@ -32,7 +32,7 @@ namespace LibGit2Sharp
         /// </remarks>
         public FilterAttributeEntry(string filterName)
         {
-            Ensure.ArgumentNotNullOrEmptyString(filterName, "filterName");
+            Ensure.ArgumentNotNullOrEmptyString(filterName, nameof(filterName));
             if (filterName.StartsWith("filter=", StringComparison.OrdinalIgnoreCase))
             {
                 throw new ArgumentException("The filterName parameter should not begin with \"filter=\"", filterName);

--- a/LibGit2Sharp/FilteringOptions.cs
+++ b/LibGit2Sharp/FilteringOptions.cs
@@ -13,7 +13,7 @@ namespace LibGit2Sharp
         /// <param name="hintPath">The path that a file would be checked out as</param>
         public FilteringOptions(string hintPath)
         {
-            Ensure.ArgumentNotNull(hintPath, "hintPath");
+            Ensure.ArgumentNotNull(hintPath, nameof(hintPath));
 
             this.HintPath = hintPath;
         }

--- a/LibGit2Sharp/GlobalSettings.cs
+++ b/LibGit2Sharp/GlobalSettings.cs
@@ -89,7 +89,7 @@ namespace LibGit2Sharp
         public static SmartSubtransportRegistration<T> RegisterSmartSubtransport<T>(string scheme)
             where T : SmartSubtransport, new()
         {
-            Ensure.ArgumentNotNull(scheme, "scheme");
+            Ensure.ArgumentNotNull(scheme, nameof(scheme));
 
             var registration = new SmartSubtransportRegistration<T>(scheme);
 
@@ -117,7 +117,7 @@ namespace LibGit2Sharp
         public static void UnregisterSmartSubtransport<T>(SmartSubtransportRegistration<T> registration)
             where T : SmartSubtransport, new()
         {
-            Ensure.ArgumentNotNull(registration, "registration");
+            Ensure.ArgumentNotNull(registration, nameof(registration));
 
             Proxy.git_transport_unregister(registration.Scheme);
             registration.Free();
@@ -134,7 +134,7 @@ namespace LibGit2Sharp
         {
             set
             {
-                Ensure.ArgumentNotNull(value, "value");
+                Ensure.ArgumentNotNull(value, nameof(value));
 
                 logConfiguration = value;
 
@@ -244,7 +244,7 @@ namespace LibGit2Sharp
         /// <returns>A <see cref="FilterRegistration"/> object used to manage the lifetime of the registration.</returns>
         public static FilterRegistration RegisterFilter(Filter filter, int priority)
         {
-            Ensure.ArgumentNotNull(filter, "filter");
+            Ensure.ArgumentNotNull(filter, nameof(filter));
             if (priority < FilterRegistration.FilterPriorityMin || priority > FilterRegistration.FilterPriorityMax)
             {
                 throw new ArgumentOutOfRangeException(nameof(priority),
@@ -280,7 +280,7 @@ namespace LibGit2Sharp
         /// <param name="registration">Registration object with an associated filter.</param>
         public static void DeregisterFilter(FilterRegistration registration)
         {
-            Ensure.ArgumentNotNull(registration, "registration");
+            Ensure.ArgumentNotNull(registration, nameof(registration));
 
             lock (registeredFilters)
             {

--- a/LibGit2Sharp/Identity.cs
+++ b/LibGit2Sharp/Identity.cs
@@ -18,10 +18,10 @@ namespace LibGit2Sharp
         /// <param name="email">The email.</param>
         public Identity(string name, string email)
         {
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");
-            Ensure.ArgumentNotNullOrEmptyString(email, "email");
-            Ensure.ArgumentDoesNotContainZeroByte(name, "name");
-            Ensure.ArgumentDoesNotContainZeroByte(email, "email");
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
+            Ensure.ArgumentNotNullOrEmptyString(email, nameof(email));
+            Ensure.ArgumentDoesNotContainZeroByte(name, nameof(name));
+            Ensure.ArgumentDoesNotContainZeroByte(email, nameof(email));
 
             _name = name;
             _email = email;

--- a/LibGit2Sharp/Ignore.cs
+++ b/LibGit2Sharp/Ignore.cs
@@ -31,7 +31,7 @@ namespace LibGit2Sharp
         /// <param name="rules">The content of a .gitignore file that will be applied.</param>
         public virtual void AddTemporaryRules(IEnumerable<string> rules)
         {
-            Ensure.ArgumentNotNull(rules, "rules");
+            Ensure.ArgumentNotNull(rules, nameof(rules));
 
             var allRules = rules.Aggregate(new StringBuilder(), (acc, x) =>
             {
@@ -61,7 +61,7 @@ namespace LibGit2Sharp
         /// <returns>true if the path should be ignored.</returns>
         public virtual bool IsPathIgnored(string relativePath)
         {
-            Ensure.ArgumentNotNullOrEmptyString(relativePath, "relativePath");
+            Ensure.ArgumentNotNullOrEmptyString(relativePath, nameof(relativePath));
 
             return Proxy.git_ignore_path_is_ignored(repo.Handle, relativePath);
         }

--- a/LibGit2Sharp/Index.cs
+++ b/LibGit2Sharp/Index.cs
@@ -78,7 +78,7 @@ namespace LibGit2Sharp
         {
             get
             {
-                Ensure.ArgumentNotNullOrEmptyString(path, "path");
+                Ensure.ArgumentNotNullOrEmptyString(path, nameof(path));
 
                 git_index_entry* entry = Proxy.git_index_get_bypath(handle, path, 0);
                 return IndexEntry.BuildFromPtr(entry);
@@ -167,7 +167,7 @@ namespace LibGit2Sharp
         /// <param name="indexEntryPath">The path of the <see cref="Index"/> entry to be removed.</param>
         public virtual void Remove(string indexEntryPath)
         {
-            Ensure.ArgumentNotNull(indexEntryPath, "indexEntryPath");
+            Ensure.ArgumentNotNull(indexEntryPath, nameof(indexEntryPath));
             RemoveFromIndex(indexEntryPath);
         }
 
@@ -181,7 +181,7 @@ namespace LibGit2Sharp
         /// <param name="pathInTheWorkdir">The path, in the working directory, of the file to be added.</param>
         public virtual void Add(string pathInTheWorkdir)
         {
-            Ensure.ArgumentNotNull(pathInTheWorkdir, "pathInTheWorkdir");
+            Ensure.ArgumentNotNull(pathInTheWorkdir, nameof(pathInTheWorkdir));
             Proxy.git_index_add_bypath(handle, pathInTheWorkdir);
         }
 
@@ -198,9 +198,9 @@ namespace LibGit2Sharp
         /// or <see cref="Mode.SymbolicLink"/>.</param>
         public virtual void Add(Blob blob, string indexEntryPath, Mode indexEntryMode)
         {
-            Ensure.ArgumentConformsTo(indexEntryMode, m => m.HasAny(TreeEntryDefinition.BlobModes), "indexEntryMode");
-            Ensure.ArgumentNotNull(blob, "blob");
-            Ensure.ArgumentNotNull(indexEntryPath, "indexEntryPath");
+            Ensure.ArgumentConformsTo(indexEntryMode, m => m.HasAny(TreeEntryDefinition.BlobModes), nameof(indexEntryMode));
+            Ensure.ArgumentNotNull(blob, nameof(blob));
+            Ensure.ArgumentNotNull(indexEntryPath, nameof(indexEntryPath));
             AddEntryToTheIndex(indexEntryPath, blob.Id, indexEntryMode);
         }
 
@@ -293,7 +293,7 @@ namespace LibGit2Sharp
         /// </param>
         public virtual void Replace(Commit commit, IEnumerable<string> paths, ExplicitPathsOptions explicitPathsOptions)
         {
-            Ensure.ArgumentNotNull(commit, "commit");
+            Ensure.ArgumentNotNull(commit, nameof(commit));
 
             using (var changes = repo.Diff.Compare<TreeChanges>(commit.Tree, DiffTargets.Index, paths, explicitPathsOptions, new CompareOptions { Similarity = SimilarityOptions.None }))
             {

--- a/LibGit2Sharp/IndexReucEntryCollection.cs
+++ b/LibGit2Sharp/IndexReucEntryCollection.cs
@@ -33,7 +33,7 @@ namespace LibGit2Sharp
         {
             get
             {
-                Ensure.ArgumentNotNullOrEmptyString(path, "path");
+                Ensure.ArgumentNotNullOrEmptyString(path, nameof(path));
 
                 git_index_reuc_entry* entryHandle = Proxy.git_index_reuc_get_bypath(index.Handle, path);
                 return IndexReucEntry.BuildFromPtr(entryHandle);

--- a/LibGit2Sharp/LogConfiguration.cs
+++ b/LibGit2Sharp/LogConfiguration.cs
@@ -22,8 +22,8 @@ namespace LibGit2Sharp
         /// <param name="handler">Handler to call when logging occurs</param>
         public LogConfiguration(LogLevel level, LogHandler handler)
         {
-            Ensure.ArgumentConformsTo<LogLevel>(level, (t) => { return (level != LogLevel.None); }, "level");
-            Ensure.ArgumentNotNull(handler, "handler");
+            Ensure.ArgumentConformsTo<LogLevel>(level, (t) => { return (level != LogLevel.None); }, nameof(level));
+            Ensure.ArgumentNotNull(handler, nameof(handler));
 
             Level = level;
             Handler = handler;

--- a/LibGit2Sharp/Network.cs
+++ b/LibGit2Sharp/Network.cs
@@ -50,7 +50,7 @@ namespace LibGit2Sharp
         /// <returns>The references in the <see cref="Remote"/> repository.</returns>
         public virtual IEnumerable<Reference> ListReferences(Remote remote)
         {
-            Ensure.ArgumentNotNull(remote, "remote");
+            Ensure.ArgumentNotNull(remote, nameof(remote));
 
             return ListReferencesInternal(remote.Url, null, new ProxyOptions());
         }
@@ -69,7 +69,7 @@ namespace LibGit2Sharp
         /// <returns>The references in the <see cref="Remote"/> repository.</returns>
         public virtual IEnumerable<Reference> ListReferences(Remote remote, ProxyOptions proxyOptions)
         {
-            Ensure.ArgumentNotNull(remote, "remote");
+            Ensure.ArgumentNotNull(remote, nameof(remote));
 
             return ListReferencesInternal(remote.Url, null, proxyOptions);
         }
@@ -88,8 +88,8 @@ namespace LibGit2Sharp
         /// <returns>The references in the <see cref="Remote"/> repository.</returns>
         public virtual IEnumerable<Reference> ListReferences(Remote remote, CredentialsHandler credentialsProvider)
         {
-            Ensure.ArgumentNotNull(remote, "remote");
-            Ensure.ArgumentNotNull(credentialsProvider, "credentialsProvider");
+            Ensure.ArgumentNotNull(remote, nameof(remote));
+            Ensure.ArgumentNotNull(credentialsProvider, nameof(credentialsProvider));
 
             return ListReferencesInternal(remote.Url, credentialsProvider, new ProxyOptions());
         }
@@ -109,8 +109,8 @@ namespace LibGit2Sharp
         /// <returns>The references in the <see cref="Remote"/> repository.</returns>
         public virtual IEnumerable<Reference> ListReferences(Remote remote, CredentialsHandler credentialsProvider, ProxyOptions proxyOptions)
         {
-            Ensure.ArgumentNotNull(remote, "remote");
-            Ensure.ArgumentNotNull(credentialsProvider, "credentialsProvider");
+            Ensure.ArgumentNotNull(remote, nameof(remote));
+            Ensure.ArgumentNotNull(credentialsProvider, nameof(credentialsProvider));
 
             return ListReferencesInternal(remote.Url, credentialsProvider, proxyOptions);
         }
@@ -128,7 +128,7 @@ namespace LibGit2Sharp
         /// <returns>The references in the remote repository.</returns>
         public virtual IEnumerable<Reference> ListReferences(string url)
         {
-            Ensure.ArgumentNotNull(url, "url");
+            Ensure.ArgumentNotNull(url, nameof(url));
 
             return ListReferencesInternal(url, null, new ProxyOptions());
         }
@@ -147,7 +147,7 @@ namespace LibGit2Sharp
         /// <returns>The references in the remote repository.</returns>
         public virtual IEnumerable<Reference> ListReferences(string url, ProxyOptions proxyOptions)
         {
-            Ensure.ArgumentNotNull(url, "url");
+            Ensure.ArgumentNotNull(url, nameof(url));
 
             return ListReferencesInternal(url, null, proxyOptions);
         }
@@ -166,8 +166,8 @@ namespace LibGit2Sharp
         /// <returns>The references in the remote repository.</returns>
         public virtual IEnumerable<Reference> ListReferences(string url, CredentialsHandler credentialsProvider)
         {
-            Ensure.ArgumentNotNull(url, "url");
-            Ensure.ArgumentNotNull(credentialsProvider, "credentialsProvider");
+            Ensure.ArgumentNotNull(url, nameof(url));
+            Ensure.ArgumentNotNull(credentialsProvider, nameof(credentialsProvider));
 
             return ListReferencesInternal(url, credentialsProvider, new ProxyOptions());
         }
@@ -187,8 +187,8 @@ namespace LibGit2Sharp
         /// <returns>The references in the remote repository.</returns>
         public virtual IEnumerable<Reference> ListReferences(string url, CredentialsHandler credentialsProvider, ProxyOptions proxyOptions)
         {
-            Ensure.ArgumentNotNull(url, "url");
-            Ensure.ArgumentNotNull(credentialsProvider, "credentialsProvider");
+            Ensure.ArgumentNotNull(url, nameof(url));
+            Ensure.ArgumentNotNull(credentialsProvider, nameof(credentialsProvider));
 
             return ListReferencesInternal(url, credentialsProvider, new ProxyOptions());
         }
@@ -270,8 +270,8 @@ namespace LibGit2Sharp
             FetchOptions options,
             string logMessage)
         {
-            Ensure.ArgumentNotNull(url, "url");
-            Ensure.ArgumentNotNull(refspecs, "refspecs");
+            Ensure.ArgumentNotNull(url, nameof(url));
+            Ensure.ArgumentNotNull(refspecs, nameof(refspecs));
 
             Commands.Fetch(repository, url, refspecs, options, logMessage);
         }
@@ -353,8 +353,8 @@ namespace LibGit2Sharp
             string objectish,
             string destinationSpec)
         {
-            Ensure.ArgumentNotNull(objectish, "objectish");
-            Ensure.ArgumentNotNullOrEmptyString(destinationSpec, "destinationSpec");
+            Ensure.ArgumentNotNull(objectish, nameof(objectish));
+            Ensure.ArgumentNotNullOrEmptyString(destinationSpec, nameof(destinationSpec));
 
             Push(remote,
                  string.Format(CultureInfo.InvariantCulture,
@@ -376,8 +376,8 @@ namespace LibGit2Sharp
             string destinationSpec,
             PushOptions pushOptions)
         {
-            Ensure.ArgumentNotNull(objectish, "objectish");
-            Ensure.ArgumentNotNullOrEmptyString(destinationSpec, "destinationSpec");
+            Ensure.ArgumentNotNull(objectish, nameof(objectish));
+            Ensure.ArgumentNotNullOrEmptyString(destinationSpec, nameof(destinationSpec));
 
             Push(remote,
                  string.Format(CultureInfo.InvariantCulture,
@@ -394,7 +394,7 @@ namespace LibGit2Sharp
         /// <param name="pushRefSpec">The pushRefSpec to push.</param>
         public virtual void Push(Remote remote, string pushRefSpec)
         {
-            Ensure.ArgumentNotNullOrEmptyString(pushRefSpec, "pushRefSpec");
+            Ensure.ArgumentNotNullOrEmptyString(pushRefSpec, nameof(pushRefSpec));
 
             Push(remote, new[] { pushRefSpec });
         }
@@ -409,7 +409,7 @@ namespace LibGit2Sharp
             string pushRefSpec,
             PushOptions pushOptions)
         {
-            Ensure.ArgumentNotNullOrEmptyString(pushRefSpec, "pushRefSpec");
+            Ensure.ArgumentNotNullOrEmptyString(pushRefSpec, nameof(pushRefSpec));
 
             Push(remote, new[] { pushRefSpec }, pushOptions);
         }
@@ -432,8 +432,8 @@ namespace LibGit2Sharp
         /// <param name="pushOptions"><see cref="PushOptions"/> controlling push behavior</param>
         public virtual void Push(Remote remote, IEnumerable<string> pushRefSpecs, PushOptions pushOptions)
         {
-            Ensure.ArgumentNotNull(remote, "remote");
-            Ensure.ArgumentNotNull(pushRefSpecs, "pushRefSpecs");
+            Ensure.ArgumentNotNull(remote, nameof(remote));
+            Ensure.ArgumentNotNull(pushRefSpecs, nameof(pushRefSpecs));
 
             // Return early if there is nothing to push.
             if (!pushRefSpecs.Any())

--- a/LibGit2Sharp/NoteCollection.cs
+++ b/LibGit2Sharp/NoteCollection.cs
@@ -85,7 +85,7 @@ namespace LibGit2Sharp
         {
             get
             {
-                Ensure.ArgumentNotNull(id, "id");
+                Ensure.ArgumentNotNull(id, nameof(id));
 
                 return NamespaceRefs
                     .Select(ns => this[ns, id])
@@ -101,7 +101,7 @@ namespace LibGit2Sharp
         {
             get
             {
-                Ensure.ArgumentNotNull(@namespace, "@namespace");
+                Ensure.ArgumentNotNull(@namespace, nameof(@namespace));
 
                 string canonicalNamespace = NormalizeToCanonicalName(@namespace);
 
@@ -118,8 +118,8 @@ namespace LibGit2Sharp
         {
             get
             {
-                Ensure.ArgumentNotNull(id, "id");
-                Ensure.ArgumentNotNull(@namespace, "@namespace");
+                Ensure.ArgumentNotNull(id, nameof(id));
+                Ensure.ArgumentNotNull(@namespace, nameof(@namespace));
 
                 string canonicalNamespace = NormalizeToCanonicalName(@namespace);
 
@@ -141,7 +141,7 @@ namespace LibGit2Sharp
 
         internal static string NormalizeToCanonicalName(string name)
         {
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
             if (name.LooksLikeNote())
             {
@@ -153,7 +153,7 @@ namespace LibGit2Sharp
 
         internal static string UnCanonicalizeName(string name)
         {
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
             if (!name.LooksLikeNote())
             {
@@ -174,11 +174,11 @@ namespace LibGit2Sharp
         /// <returns>The note which was just saved.</returns>
         public virtual Note Add(ObjectId targetId, string message, Signature author, Signature committer, string @namespace)
         {
-            Ensure.ArgumentNotNull(targetId, "targetId");
-            Ensure.ArgumentNotNullOrEmptyString(message, "message");
-            Ensure.ArgumentNotNull(author, "author");
-            Ensure.ArgumentNotNull(committer, "committer");
-            Ensure.ArgumentNotNullOrEmptyString(@namespace, "@namespace");
+            Ensure.ArgumentNotNull(targetId, nameof(targetId));
+            Ensure.ArgumentNotNullOrEmptyString(message, nameof(message));
+            Ensure.ArgumentNotNull(author, nameof(author));
+            Ensure.ArgumentNotNull(committer, nameof(committer));
+            Ensure.ArgumentNotNullOrEmptyString(@namespace, nameof(@namespace));
 
             string canonicalNamespace = NormalizeToCanonicalName(@namespace);
 
@@ -198,10 +198,10 @@ namespace LibGit2Sharp
         /// <param name="namespace">The namespace on which the note will be removed. It can be either a canonical namespace or an abbreviated namespace ('refs/notes/myNamespace' or just 'myNamespace').</param>
         public virtual void Remove(ObjectId targetId, Signature author, Signature committer, string @namespace)
         {
-            Ensure.ArgumentNotNull(targetId, "targetId");
-            Ensure.ArgumentNotNull(author, "author");
-            Ensure.ArgumentNotNull(committer, "committer");
-            Ensure.ArgumentNotNullOrEmptyString(@namespace, "@namespace");
+            Ensure.ArgumentNotNull(targetId, nameof(targetId));
+            Ensure.ArgumentNotNull(author, nameof(author));
+            Ensure.ArgumentNotNull(committer, nameof(committer));
+            Ensure.ArgumentNotNullOrEmptyString(@namespace, nameof(@namespace));
 
             string canonicalNamespace = NormalizeToCanonicalName(@namespace);
 

--- a/LibGit2Sharp/ObjectDatabase.cs
+++ b/LibGit2Sharp/ObjectDatabase.cs
@@ -66,7 +66,7 @@ namespace LibGit2Sharp
         /// <returns>True if the object has been found; false otherwise.</returns>
         public virtual bool Contains(ObjectId objectId)
         {
-            Ensure.ArgumentNotNull(objectId, "objectId");
+            Ensure.ArgumentNotNull(objectId, nameof(objectId));
 
             return Proxy.git_odb_exists(handle, objectId);
         }
@@ -80,7 +80,7 @@ namespace LibGit2Sharp
         /// <returns>GitObjectMetadata object instance containg object header information</returns>
         public virtual GitObjectMetadata RetrieveObjectMetadata(ObjectId objectId)
         {
-            Ensure.ArgumentNotNull(objectId, "objectId");
+            Ensure.ArgumentNotNull(objectId, nameof(objectId));
 
             return Proxy.git_odb_read_header(handle, objectId);
         }
@@ -94,7 +94,7 @@ namespace LibGit2Sharp
         /// <returns>The created <see cref="Blob"/>.</returns>
         public virtual Blob CreateBlob(string path)
         {
-            Ensure.ArgumentNotNullOrEmptyString(path, "path");
+            Ensure.ArgumentNotNullOrEmptyString(path, nameof(path));
 
             if (repo.Info.IsBare && !Path.IsPathRooted(path))
             {
@@ -121,8 +121,8 @@ namespace LibGit2Sharp
         /// <param name="priority">The priority at which libgit2 should consult this backend (higher values are consulted first)</param>
         public virtual void AddBackend(OdbBackend backend, int priority)
         {
-            Ensure.ArgumentNotNull(backend, "backend");
-            Ensure.ArgumentConformsTo(priority, s => s > 0, "priority");
+            Ensure.ArgumentNotNull(backend, nameof(backend));
+            Ensure.ArgumentConformsTo(priority, s => s > 0, nameof(priority));
 
             Proxy.git_odb_add_backend(handle, backend.GitOdbBackendPointer, priority);
         }
@@ -195,7 +195,7 @@ namespace LibGit2Sharp
         /// <typeparam name="T">The type of object to write</typeparam>
         public virtual ObjectId Write<T>(Stream stream, long numberOfBytesToConsume) where T : GitObject
         {
-            Ensure.ArgumentNotNull(stream, "stream");
+            Ensure.ArgumentNotNull(stream, nameof(stream));
 
             if (!stream.CanRead)
             {
@@ -264,7 +264,7 @@ namespace LibGit2Sharp
 
         private unsafe Blob CreateBlob(Stream stream, string hintpath, long? numberOfBytesToConsume)
         {
-            Ensure.ArgumentNotNull(stream, "stream");
+            Ensure.ArgumentNotNull(stream, nameof(stream));
 
             // there's no need to buffer the file for filtering, so simply use a stream
             if (hintpath == null && numberOfBytesToConsume.HasValue)
@@ -344,7 +344,7 @@ namespace LibGit2Sharp
         /// <returns>The created <see cref="Tree"/>.</returns>
         public virtual Tree CreateTree(TreeDefinition treeDefinition)
         {
-            Ensure.ArgumentNotNull(treeDefinition, "treeDefinition");
+            Ensure.ArgumentNotNull(treeDefinition, nameof(treeDefinition));
 
             return treeDefinition.Build(repo);
         }
@@ -362,7 +362,7 @@ namespace LibGit2Sharp
         /// <returns>The created <see cref="Tree"/>. This can be used e.g. to create a <see cref="Commit"/>.</returns>
         public virtual Tree CreateTree(Index index)
         {
-            Ensure.ArgumentNotNull(index, "index");
+            Ensure.ArgumentNotNull(index, nameof(index));
 
             var treeId = Proxy.git_index_write_tree(index.Handle);
             return this.repo.Lookup<Tree>(treeId);
@@ -412,12 +412,12 @@ namespace LibGit2Sharp
         /// <returns>The created <see cref="Commit"/>.</returns>
         public virtual Commit CreateCommit(Signature author, Signature committer, string message, Tree tree, IEnumerable<Commit> parents, bool prettifyMessage, char? commentChar)
         {
-            Ensure.ArgumentNotNull(message, "message");
-            Ensure.ArgumentDoesNotContainZeroByte(message, "message");
-            Ensure.ArgumentNotNull(author, "author");
-            Ensure.ArgumentNotNull(committer, "committer");
-            Ensure.ArgumentNotNull(tree, "tree");
-            Ensure.ArgumentNotNull(parents, "parents");
+            Ensure.ArgumentNotNull(message, nameof(message));
+            Ensure.ArgumentDoesNotContainZeroByte(message, nameof(message));
+            Ensure.ArgumentNotNull(author, nameof(author));
+            Ensure.ArgumentNotNull(committer, nameof(committer));
+            Ensure.ArgumentNotNull(tree, nameof(tree));
+            Ensure.ArgumentNotNull(parents, nameof(parents));
 
             if (prettifyMessage)
             {
@@ -468,12 +468,12 @@ namespace LibGit2Sharp
         /// <returns>The created <see cref="TagAnnotation"/>.</returns>
         public virtual TagAnnotation CreateTagAnnotation(string name, GitObject target, Signature tagger, string message)
         {
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");
-            Ensure.ArgumentNotNull(message, "message");
-            Ensure.ArgumentNotNull(target, "target");
-            Ensure.ArgumentNotNull(tagger, "tagger");
-            Ensure.ArgumentDoesNotContainZeroByte(name, "name");
-            Ensure.ArgumentDoesNotContainZeroByte(message, "message");
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
+            Ensure.ArgumentNotNull(message, nameof(message));
+            Ensure.ArgumentNotNull(target, nameof(target));
+            Ensure.ArgumentNotNull(tagger, nameof(tagger));
+            Ensure.ArgumentDoesNotContainZeroByte(name, nameof(name));
+            Ensure.ArgumentDoesNotContainZeroByte(message, nameof(message));
 
             string prettifiedMessage = Proxy.git_message_prettify(message, null);
 
@@ -517,8 +517,8 @@ namespace LibGit2Sharp
         /// <param name="archiver">The archiver to use.</param>
         public virtual void Archive(Commit commit, ArchiverBase archiver)
         {
-            Ensure.ArgumentNotNull(commit, "commit");
-            Ensure.ArgumentNotNull(archiver, "archiver");
+            Ensure.ArgumentNotNull(commit, nameof(commit));
+            Ensure.ArgumentNotNull(archiver, nameof(archiver));
 
             archiver.OrchestrateArchiving(commit.Tree, commit.Id, commit.Committer.When);
         }
@@ -530,8 +530,8 @@ namespace LibGit2Sharp
         /// <param name="archiver">The archiver to use.</param>
         public virtual void Archive(Tree tree, ArchiverBase archiver)
         {
-            Ensure.ArgumentNotNull(tree, "tree");
-            Ensure.ArgumentNotNull(archiver, "archiver");
+            Ensure.ArgumentNotNull(tree, nameof(tree));
+            Ensure.ArgumentNotNull(archiver, nameof(archiver));
 
             archiver.OrchestrateArchiving(tree, null, DateTimeOffset.UtcNow);
         }
@@ -545,8 +545,8 @@ namespace LibGit2Sharp
         /// <returns>A instance of <see cref="HistoryDivergence"/>.</returns>
         public virtual HistoryDivergence CalculateHistoryDivergence(Commit one, Commit another)
         {
-            Ensure.ArgumentNotNull(one, "one");
-            Ensure.ArgumentNotNull(another, "another");
+            Ensure.ArgumentNotNull(one, nameof(one));
+            Ensure.ArgumentNotNull(another, nameof(another));
 
             return new HistoryDivergence(repo, one, another);
         }
@@ -561,8 +561,8 @@ namespace LibGit2Sharp
         /// <returns>A result containing a <see cref="Tree"/> if the cherry-pick was successful and a list of <see cref="Conflict"/>s if it is not.</returns>
         public virtual MergeTreeResult CherryPickCommit(Commit cherryPickCommit, Commit cherryPickOnto, int mainline, MergeTreeOptions options)
         {
-            Ensure.ArgumentNotNull(cherryPickCommit, "cherryPickCommit");
-            Ensure.ArgumentNotNull(cherryPickOnto, "cherryPickOnto");
+            Ensure.ArgumentNotNull(cherryPickCommit, nameof(cherryPickCommit));
+            Ensure.ArgumentNotNull(cherryPickOnto, nameof(cherryPickOnto));
 
             var modifiedOptions = new MergeTreeOptions();
 
@@ -635,7 +635,7 @@ namespace LibGit2Sharp
         /// <returns>A short string representation of the <see cref="ObjectId"/>.</returns>
         public virtual string ShortenObjectId(GitObject gitObject, int minLength)
         {
-            Ensure.ArgumentNotNull(gitObject, "gitObject");
+            Ensure.ArgumentNotNull(gitObject, nameof(gitObject));
 
             if (minLength <= 0 || minLength > ObjectId.HexSize)
             {
@@ -669,8 +669,8 @@ namespace LibGit2Sharp
         /// <returns>True if the merge does not result in a conflict, false otherwise.</returns>
         public virtual bool CanMergeWithoutConflict(Commit one, Commit another)
         {
-            Ensure.ArgumentNotNull(one, "one");
-            Ensure.ArgumentNotNull(another, "another");
+            Ensure.ArgumentNotNull(one, nameof(one));
+            Ensure.ArgumentNotNull(another, nameof(another));
 
             var opts = new MergeTreeOptions()
             {
@@ -690,8 +690,8 @@ namespace LibGit2Sharp
         /// <returns>The merge base or null if none found.</returns>
         public virtual Commit FindMergeBase(Commit first, Commit second)
         {
-            Ensure.ArgumentNotNull(first, "first");
-            Ensure.ArgumentNotNull(second, "second");
+            Ensure.ArgumentNotNull(first, nameof(first));
+            Ensure.ArgumentNotNull(second, nameof(second));
 
             return FindMergeBase(new[] { first, second }, MergeBaseFindingStrategy.Standard);
         }
@@ -704,7 +704,7 @@ namespace LibGit2Sharp
         /// <returns>The merge base or null if none found.</returns>
         public virtual Commit FindMergeBase(IEnumerable<Commit> commits, MergeBaseFindingStrategy strategy)
         {
-            Ensure.ArgumentNotNull(commits, "commits");
+            Ensure.ArgumentNotNull(commits, nameof(commits));
 
             ObjectId id;
             List<GitOid> ids = new List<GitOid>(8);
@@ -753,8 +753,8 @@ namespace LibGit2Sharp
         /// <returns>The <see cref="MergeTreeResult"/> containing the merged trees and any conflicts</returns>
         public virtual MergeTreeResult MergeCommits(Commit ours, Commit theirs, MergeTreeOptions options)
         {
-            Ensure.ArgumentNotNull(ours, "ours");
-            Ensure.ArgumentNotNull(theirs, "theirs");
+            Ensure.ArgumentNotNull(ours, nameof(ours));
+            Ensure.ArgumentNotNull(theirs, nameof(theirs));
 
             var modifiedOptions = new MergeTreeOptions();
 
@@ -849,8 +849,8 @@ namespace LibGit2Sharp
         /// The index must be disposed by the caller.</returns>
         public virtual TransientIndex MergeCommitsIntoIndex(Commit ours, Commit theirs, MergeTreeOptions options)
         {
-            Ensure.ArgumentNotNull(ours, "ours");
-            Ensure.ArgumentNotNull(theirs, "theirs");
+            Ensure.ArgumentNotNull(ours, nameof(ours));
+            Ensure.ArgumentNotNull(theirs, nameof(theirs));
 
             options = options ?? new MergeTreeOptions();
 
@@ -879,8 +879,8 @@ namespace LibGit2Sharp
         /// The index must be disposed by the caller. </returns>
         public virtual TransientIndex CherryPickCommitIntoIndex(Commit cherryPickCommit, Commit cherryPickOnto, int mainline, MergeTreeOptions options)
         {
-            Ensure.ArgumentNotNull(cherryPickCommit, "cherryPickCommit");
-            Ensure.ArgumentNotNull(cherryPickOnto, "cherryPickOnto");
+            Ensure.ArgumentNotNull(cherryPickCommit, nameof(cherryPickCommit));
+            Ensure.ArgumentNotNull(cherryPickOnto, nameof(cherryPickOnto));
 
             options = options ?? new MergeTreeOptions();
 
@@ -992,8 +992,8 @@ namespace LibGit2Sharp
         /// <returns>Packing results</returns>
         private PackBuilderResults InternalPack(PackBuilderOptions options, Action<PackBuilder> packDelegate)
         {
-            Ensure.ArgumentNotNull(options, "options");
-            Ensure.ArgumentNotNull(packDelegate, "packDelegate");
+            Ensure.ArgumentNotNull(options, nameof(options));
+            Ensure.ArgumentNotNull(packDelegate, nameof(packDelegate));
 
             PackBuilderResults results = new PackBuilderResults();
 
@@ -1025,8 +1025,8 @@ namespace LibGit2Sharp
         /// <returns>A result containing a <see cref="Tree"/> if the revert was successful and a list of <see cref="Conflict"/>s if it is not.</returns>
         public virtual MergeTreeResult RevertCommit(Commit revertCommit, Commit revertOnto, int mainline, MergeTreeOptions options)
         {
-            Ensure.ArgumentNotNull(revertCommit, "revertCommit");
-            Ensure.ArgumentNotNull(revertOnto, "revertOnto");
+            Ensure.ArgumentNotNull(revertCommit, nameof(revertCommit));
+            Ensure.ArgumentNotNull(revertOnto, nameof(revertOnto));
 
             options = options ?? new MergeTreeOptions();
 

--- a/LibGit2Sharp/ObjectId.cs
+++ b/LibGit2Sharp/ObjectId.cs
@@ -53,8 +53,8 @@ namespace LibGit2Sharp
         public ObjectId(byte[] rawId)
             : this(new GitOid { Id = rawId })
         {
-            Ensure.ArgumentNotNull(rawId, "rawId");
-            Ensure.ArgumentConformsTo(rawId, b => b.Length == rawSize, "rawId");
+            Ensure.ArgumentNotNull(rawId, nameof(rawId));
+            Ensure.ArgumentConformsTo(rawId, b => b.Length == rawSize, nameof(rawId));
         }
 
         internal static unsafe ObjectId BuildFromPtr(IntPtr ptr)
@@ -313,7 +313,7 @@ namespace LibGit2Sharp
                     return false;
                 }
 
-                Ensure.ArgumentNotNullOrEmptyString(objectId, "objectId");
+                Ensure.ArgumentNotNullOrEmptyString(objectId, nameof(objectId));
             }
 
             if ((objectId.Length != HexSize))
@@ -344,7 +344,7 @@ namespace LibGit2Sharp
         /// false otherwise.</returns>
         public bool StartsWith(string shortSha)
         {
-            Ensure.ArgumentNotNullOrEmptyString(shortSha, "shortSha");
+            Ensure.ArgumentNotNullOrEmptyString(shortSha, nameof(shortSha));
 
             return Sha.StartsWith(shortSha, StringComparison.OrdinalIgnoreCase);
         }

--- a/LibGit2Sharp/PackBuilder.cs
+++ b/LibGit2Sharp/PackBuilder.cs
@@ -17,7 +17,7 @@ namespace LibGit2Sharp
         /// </summary>
         internal PackBuilder(Repository repository)
         {
-            Ensure.ArgumentNotNull(repository, "repository");
+            Ensure.ArgumentNotNull(repository, nameof(repository));
 
             packBuilderHandle = Proxy.git_packbuilder_new(repository.Handle);
         }
@@ -30,7 +30,7 @@ namespace LibGit2Sharp
         /// <exception cref="ArgumentNullException">if the gitObject is null</exception>
         public void Add<T>(T gitObject) where T : GitObject
         {
-            Ensure.ArgumentNotNull(gitObject, "gitObject");
+            Ensure.ArgumentNotNull(gitObject, nameof(gitObject));
 
             Add(gitObject.Id);
         }
@@ -43,7 +43,7 @@ namespace LibGit2Sharp
         /// <exception cref="ArgumentNullException">if the gitObject is null</exception>
         public void AddRecursively<T>(T gitObject) where T : GitObject
         {
-            Ensure.ArgumentNotNull(gitObject, "gitObject");
+            Ensure.ArgumentNotNull(gitObject, nameof(gitObject));
 
             AddRecursively(gitObject.Id);
         }
@@ -56,7 +56,7 @@ namespace LibGit2Sharp
         /// <exception cref="ArgumentNullException">if the id is null</exception>
         public void Add(ObjectId id)
         {
-            Ensure.ArgumentNotNull(id, "id");
+            Ensure.ArgumentNotNull(id, nameof(id));
 
             Proxy.git_packbuilder_insert(packBuilderHandle, id, null);
         }
@@ -69,7 +69,7 @@ namespace LibGit2Sharp
         /// <exception cref="ArgumentNullException">if the id is null</exception>
         public void AddRecursively(ObjectId id)
         {
-            Ensure.ArgumentNotNull(id, "id");
+            Ensure.ArgumentNotNull(id, nameof(id));
 
             Proxy.git_packbuilder_insert_recur(packBuilderHandle, id, null);
         }
@@ -164,7 +164,7 @@ namespace LibGit2Sharp
         {
             set
             {
-                Ensure.ArgumentNotNullOrEmptyString(value, "packDirectory");
+                Ensure.ArgumentNotNullOrEmptyString(value, nameof(value));
 
                 if (!Directory.Exists(value))
                 {

--- a/LibGit2Sharp/Rebase.cs
+++ b/LibGit2Sharp/Rebase.cs
@@ -80,7 +80,7 @@ namespace LibGit2Sharp
         /// <returns>true if completed successfully, false if conflicts encountered.</returns>
         public virtual RebaseResult Start(Branch branch, Branch upstream, Branch onto, Identity committer, RebaseOptions options)
         {
-            Ensure.ArgumentNotNull(upstream, "upstream");
+            Ensure.ArgumentNotNull(upstream, nameof(upstream));
 
             options = options ?? new RebaseOptions();
 
@@ -135,7 +135,7 @@ namespace LibGit2Sharp
         /// <param name="options">The <see cref="RebaseOptions"/> that specify the rebase behavior.</param>
         public virtual unsafe RebaseResult Continue(Identity committer, RebaseOptions options)
         {
-            Ensure.ArgumentNotNull(committer, "committer");
+            Ensure.ArgumentNotNull(committer, nameof(committer));
 
             options = options ?? new RebaseOptions();
 

--- a/LibGit2Sharp/RebaseOperationImpl.cs
+++ b/LibGit2Sharp/RebaseOperationImpl.cs
@@ -20,10 +20,10 @@ namespace LibGit2Sharp
             Identity committer,
             RebaseOptions options)
         {
-            Ensure.ArgumentNotNull(rebaseOperationHandle, "rebaseOperationHandle");
-            Ensure.ArgumentNotNull(repository, "repository");
-            Ensure.ArgumentNotNull(committer, "committer");
-            Ensure.ArgumentNotNull(options, "options");
+            Ensure.ArgumentNotNull(rebaseOperationHandle, nameof(rebaseOperationHandle));
+            Ensure.ArgumentNotNull(repository, nameof(repository));
+            Ensure.ArgumentNotNull(committer, nameof(committer));
+            Ensure.ArgumentNotNull(options, nameof(options));
 
             RebaseResult rebaseResult = null;
 

--- a/LibGit2Sharp/RefSpecCollection.cs
+++ b/LibGit2Sharp/RefSpecCollection.cs
@@ -30,7 +30,7 @@ namespace LibGit2Sharp
 
         internal RefSpecCollection(Remote remote, RemoteHandle handle)
         {
-            Ensure.ArgumentNotNull(handle, "handle");
+            Ensure.ArgumentNotNull(handle, nameof(handle));
 
             this.remote = remote;
             this.handle = handle;

--- a/LibGit2Sharp/ReferenceCollection.cs
+++ b/LibGit2Sharp/ReferenceCollection.cs
@@ -109,8 +109,8 @@ namespace LibGit2Sharp
         /// <returns>A new <see cref="Reference"/>.</returns>
         public virtual Reference Add(string name, string canonicalRefNameOrObjectish, string logMessage, bool allowOverwrite)
         {
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");
-            Ensure.ArgumentNotNullOrEmptyString(canonicalRefNameOrObjectish, "canonicalRefNameOrObjectish");
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
+            Ensure.ArgumentNotNullOrEmptyString(canonicalRefNameOrObjectish, nameof(canonicalRefNameOrObjectish));
 
             Reference reference;
             RefState refState = TryResolveReference(out reference, this, canonicalRefNameOrObjectish);
@@ -188,8 +188,8 @@ namespace LibGit2Sharp
         /// <returns>A new <see cref="Reference"/>.</returns>
         public virtual DirectReference Add(string name, ObjectId targetId, string logMessage, bool allowOverwrite)
         {
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");
-            Ensure.ArgumentNotNull(targetId, "targetId");
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
+            Ensure.ArgumentNotNull(targetId, nameof(targetId));
 
             using (ReferenceHandle handle = Proxy.git_reference_create(repo.Handle, name, targetId, allowOverwrite, logMessage))
             {
@@ -242,8 +242,8 @@ namespace LibGit2Sharp
         /// <returns>A new <see cref="Reference"/>.</returns>
         public virtual SymbolicReference Add(string name, Reference targetRef, string logMessage, bool allowOverwrite)
         {
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");
-            Ensure.ArgumentNotNull(targetRef, "targetRef");
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
+            Ensure.ArgumentNotNull(targetRef, nameof(targetRef));
 
             using (ReferenceHandle handle = Proxy.git_reference_symbolic_create(repo.Handle,
                                                                                     name,
@@ -284,7 +284,7 @@ namespace LibGit2Sharp
         /// <param name="name">The canonical name of the reference to delete.</param>
         public virtual void Remove(string name)
         {
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
             Reference reference = this[name];
 
@@ -302,7 +302,7 @@ namespace LibGit2Sharp
         /// <param name="reference">The reference to delete.</param>
         public virtual void Remove(Reference reference)
         {
-            Ensure.ArgumentNotNull(reference, "reference");
+            Ensure.ArgumentNotNull(reference, nameof(reference));
 
             Proxy.git_reference_remove(repo.Handle, reference.CanonicalName);
         }
@@ -329,8 +329,8 @@ namespace LibGit2Sharp
         /// <returns>A new <see cref="Reference"/>.</returns>
         public virtual Reference Rename(Reference reference, string newName, string logMessage, bool allowOverwrite)
         {
-            Ensure.ArgumentNotNull(reference, "reference");
-            Ensure.ArgumentNotNullOrEmptyString(newName, "newName");
+            Ensure.ArgumentNotNull(reference, nameof(reference));
+            Ensure.ArgumentNotNullOrEmptyString(newName, nameof(newName));
 
             if (logMessage == null)
             {
@@ -398,7 +398,7 @@ namespace LibGit2Sharp
         public virtual Reference Rename(string currentName, string newName,
             string logMessage, bool allowOverwrite)
         {
-            Ensure.ArgumentNotNullOrEmptyString(currentName, "currentName");
+            Ensure.ArgumentNotNullOrEmptyString(currentName, nameof(currentName));
 
             Reference reference = this[currentName];
 
@@ -436,7 +436,7 @@ namespace LibGit2Sharp
 
         internal T Resolve<T>(string name) where T : Reference
         {
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
             using (ReferenceHandle referencePtr = RetrieveReferencePtr(name, false))
             {
@@ -455,8 +455,8 @@ namespace LibGit2Sharp
         /// <returns>A new <see cref="Reference"/>.</returns>
         public virtual Reference UpdateTarget(Reference directRef, ObjectId targetId, string logMessage)
         {
-            Ensure.ArgumentNotNull(directRef, "directRef");
-            Ensure.ArgumentNotNull(targetId, "targetId");
+            Ensure.ArgumentNotNull(directRef, nameof(directRef));
+            Ensure.ArgumentNotNull(targetId, nameof(targetId));
 
             if (directRef.CanonicalName == "HEAD")
             {
@@ -484,8 +484,8 @@ namespace LibGit2Sharp
         /// <returns>A new <see cref="Reference"/>.</returns>
         public virtual Reference UpdateTarget(Reference directRef, string objectish, string logMessage)
         {
-            Ensure.ArgumentNotNull(directRef, "directRef");
-            Ensure.ArgumentNotNull(objectish, "objectish");
+            Ensure.ArgumentNotNull(directRef, nameof(directRef));
+            Ensure.ArgumentNotNull(objectish, nameof(objectish));
 
             GitObject target = repo.Lookup(objectish);
 
@@ -514,8 +514,8 @@ namespace LibGit2Sharp
         /// <returns>A new <see cref="Reference"/>.</returns>
         public virtual Reference UpdateTarget(string name, string canonicalRefNameOrObjectish, string logMessage)
         {
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");
-            Ensure.ArgumentNotNullOrEmptyString(canonicalRefNameOrObjectish, "canonicalRefNameOrObjectish");
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
+            Ensure.ArgumentNotNullOrEmptyString(canonicalRefNameOrObjectish, nameof(canonicalRefNameOrObjectish));
 
             if (name == "HEAD")
             {
@@ -581,8 +581,8 @@ namespace LibGit2Sharp
         /// <returns>A new <see cref="Reference"/>.</returns>
         public virtual Reference UpdateTarget(Reference symbolicRef, Reference targetRef, string logMessage)
         {
-            Ensure.ArgumentNotNull(symbolicRef, "symbolicRef");
-            Ensure.ArgumentNotNull(targetRef, "targetRef");
+            Ensure.ArgumentNotNull(symbolicRef, nameof(symbolicRef));
+            Ensure.ArgumentNotNull(targetRef, nameof(targetRef));
 
             if (symbolicRef.CanonicalName == "HEAD")
             {
@@ -657,7 +657,7 @@ namespace LibGit2Sharp
 
         internal Reference UpdateHeadTarget(Reference target, string logMessage)
         {
-            Ensure.ArgumentConformsTo(target, r => (r is DirectReference || r is SymbolicReference), "target");
+            Ensure.ArgumentConformsTo(target, r => (r is DirectReference || r is SymbolicReference), nameof(target));
 
             Add("HEAD", target, logMessage, true);
 
@@ -685,7 +685,7 @@ namespace LibGit2Sharp
         /// <returns>A list of references, ready to be enumerated.</returns>
         public virtual IEnumerable<Reference> FromGlob(string pattern)
         {
-            Ensure.ArgumentNotNullOrEmptyString(pattern, "pattern");
+            Ensure.ArgumentNotNullOrEmptyString(pattern, nameof(pattern));
 
             return Proxy.git_reference_foreach_glob(repo.Handle, pattern, LaxUtf8Marshaler.FromNative)
                 .Select(n => this[n]);
@@ -715,8 +715,8 @@ namespace LibGit2Sharp
             IEnumerable<Reference> refSubset,
             IEnumerable<Commit> targets)
         {
-            Ensure.ArgumentNotNull(refSubset, "refSubset");
-            Ensure.ArgumentNotNull(targets, "targets");
+            Ensure.ArgumentNotNull(refSubset, nameof(refSubset));
+            Ensure.ArgumentNotNull(targets, nameof(targets));
 
             var refs = new List<Reference>(refSubset);
             if (refs.Count == 0)
@@ -790,7 +790,7 @@ namespace LibGit2Sharp
         /// <returns>a <see cref="ReflogCollection"/>, enumerable of <see cref="ReflogEntry"/></returns>
         public virtual ReflogCollection Log(string canonicalName)
         {
-            Ensure.ArgumentNotNullOrEmptyString(canonicalName, "canonicalName");
+            Ensure.ArgumentNotNullOrEmptyString(canonicalName, nameof(canonicalName));
 
             return new ReflogCollection(repo, canonicalName);
         }
@@ -802,7 +802,7 @@ namespace LibGit2Sharp
         /// <returns>a <see cref="ReflogCollection"/>, enumerable of <see cref="ReflogEntry"/></returns>
         public virtual ReflogCollection Log(Reference reference)
         {
-            Ensure.ArgumentNotNull(reference, "reference");
+            Ensure.ArgumentNotNull(reference, nameof(reference));
 
             return new ReflogCollection(repo, reference.CanonicalName);
         }
@@ -814,7 +814,7 @@ namespace LibGit2Sharp
         /// <param name="commitsToRewrite">The <see cref="Commit"/> objects to rewrite.</param>
         public virtual void RewriteHistory(RewriteHistoryOptions options, params Commit[] commitsToRewrite)
         {
-            Ensure.ArgumentNotNull(commitsToRewrite, "commitsToRewrite");
+            Ensure.ArgumentNotNull(commitsToRewrite, nameof(commitsToRewrite));
 
             RewriteHistory(options, commitsToRewrite.AsEnumerable());
         }
@@ -826,9 +826,9 @@ namespace LibGit2Sharp
         /// <param name="commitsToRewrite">The <see cref="Commit"/> objects to rewrite.</param>
         public virtual void RewriteHistory(RewriteHistoryOptions options, IEnumerable<Commit> commitsToRewrite)
         {
-            Ensure.ArgumentNotNull(commitsToRewrite, "commitsToRewrite");
-            Ensure.ArgumentNotNull(options, "options");
-            Ensure.ArgumentNotNullOrEmptyString(options.BackupRefsNamespace, "options.BackupRefsNamespace");
+            Ensure.ArgumentNotNull(commitsToRewrite, nameof(commitsToRewrite));
+            Ensure.ArgumentNotNull(options, nameof(options));
+            Ensure.ArgumentNotNullOrEmptyString(options.BackupRefsNamespace, nameof(options.BackupRefsNamespace));
 
             IList<Reference> originalRefs = this.ToList();
             if (originalRefs.Count == 0)

--- a/LibGit2Sharp/ReferenceWrapper.cs
+++ b/LibGit2Sharp/ReferenceWrapper.cs
@@ -40,9 +40,9 @@ namespace LibGit2Sharp
         /// <param name="canonicalNameSelector">A function to construct the reference's canonical name.</param>
         protected internal ReferenceWrapper(Repository repo, Reference reference, Func<Reference, string> canonicalNameSelector)
         {
-            Ensure.ArgumentNotNull(repo, "repo");
-            Ensure.ArgumentNotNull(reference, "reference");
-            Ensure.ArgumentNotNull(canonicalNameSelector, "canonicalNameSelector");
+            Ensure.ArgumentNotNull(repo, nameof(repo));
+            Ensure.ArgumentNotNull(reference, nameof(reference));
+            Ensure.ArgumentNotNull(canonicalNameSelector, nameof(canonicalNameSelector));
 
             this.repo = repo;
             canonicalName = canonicalNameSelector(reference);

--- a/LibGit2Sharp/ReflogCollection.cs
+++ b/LibGit2Sharp/ReflogCollection.cs
@@ -32,8 +32,8 @@ namespace LibGit2Sharp
         /// <param name="canonicalName">the canonical name of the <see cref="Reference"/> to retrieve reflog entries on.</param>
         internal ReflogCollection(Repository repo, string canonicalName)
         {
-            Ensure.ArgumentNotNullOrEmptyString(canonicalName, "canonicalName");
-            Ensure.ArgumentNotNull(repo, "repo");
+            Ensure.ArgumentNotNullOrEmptyString(canonicalName, nameof(canonicalName));
+            Ensure.ArgumentNotNull(repo, nameof(repo));
 
             if (!Reference.IsValidName(canonicalName))
             {

--- a/LibGit2Sharp/RemoteCollection.cs
+++ b/LibGit2Sharp/RemoteCollection.cs
@@ -41,7 +41,7 @@ namespace LibGit2Sharp
 
         internal Remote RemoteForName(string name, bool shouldThrowIfNotFound = true)
         {
-            Ensure.ArgumentNotNull(name, "name");
+            Ensure.ArgumentNotNull(name, nameof(name));
 
             RemoteHandle handle = Proxy.git_remote_lookup(repository.Handle, name, shouldThrowIfNotFound);
             return handle == null ? null : new Remote(handle, this.repository);
@@ -99,8 +99,8 @@ namespace LibGit2Sharp
         /// <returns>A new <see cref="Remote"/>.</returns>
         public virtual Remote Add(string name, string url)
         {
-            Ensure.ArgumentNotNull(name, "name");
-            Ensure.ArgumentNotNull(url, "url");
+            Ensure.ArgumentNotNull(name, nameof(name));
+            Ensure.ArgumentNotNull(url, nameof(url));
 
             RemoteHandle handle = Proxy.git_remote_create(repository.Handle, name, url);
             return new Remote(handle, this.repository);
@@ -115,9 +115,9 @@ namespace LibGit2Sharp
         /// <returns>A new <see cref="Remote"/>.</returns>
         public virtual Remote Add(string name, string url, string fetchRefSpec)
         {
-            Ensure.ArgumentNotNull(name, "name");
-            Ensure.ArgumentNotNull(url, "url");
-            Ensure.ArgumentNotNull(fetchRefSpec, "fetchRefSpec");
+            Ensure.ArgumentNotNull(name, nameof(name));
+            Ensure.ArgumentNotNull(url, nameof(url));
+            Ensure.ArgumentNotNull(fetchRefSpec, nameof(fetchRefSpec));
 
             RemoteHandle handle = Proxy.git_remote_create_with_fetchspec(repository.Handle, name, url, fetchRefSpec);
             return new Remote(handle, this.repository);
@@ -130,7 +130,7 @@ namespace LibGit2Sharp
         /// <returns>A new <see cref="Remote"/>.</returns>
         public virtual void Remove(string name)
         {
-            Ensure.ArgumentNotNull(name, "name");
+            Ensure.ArgumentNotNull(name, nameof(name));
 
             Proxy.git_remote_delete(repository.Handle, name);
         }
@@ -155,8 +155,8 @@ namespace LibGit2Sharp
         /// <returns>A new <see cref="Remote"/>.</returns>
         public virtual Remote Rename(string name, string newName, RemoteRenameFailureHandler callback)
         {
-            Ensure.ArgumentNotNull(name, "name");
-            Ensure.ArgumentNotNull(newName, "newName");
+            Ensure.ArgumentNotNull(name, nameof(name));
+            Ensure.ArgumentNotNull(newName, nameof(newName));
 
             Proxy.git_remote_rename(repository.Handle, name, newName, callback);
             return this[newName];

--- a/LibGit2Sharp/RemoteUpdater.cs
+++ b/LibGit2Sharp/RemoteUpdater.cs
@@ -24,8 +24,8 @@ namespace LibGit2Sharp
 
         internal RemoteUpdater(Repository repo, Remote remote)
         {
-            Ensure.ArgumentNotNull(repo, "repo");
-            Ensure.ArgumentNotNull(remote, "remote");
+            Ensure.ArgumentNotNull(repo, nameof(repo));
+            Ensure.ArgumentNotNull(remote, nameof(remote));
 
             this.repo = repo;
             this.remoteName = remote.Name;
@@ -36,8 +36,8 @@ namespace LibGit2Sharp
 
         internal RemoteUpdater(Repository repo, string remote)
         {
-            Ensure.ArgumentNotNull(repo, "repo");
-            Ensure.ArgumentNotNull(remote, "remote");
+            Ensure.ArgumentNotNull(repo, nameof(repo));
+            Ensure.ArgumentNotNull(remote, nameof(remote));
 
             this.repo = repo;
             this.remoteName = remote;
@@ -193,7 +193,7 @@ namespace LibGit2Sharp
 
             public void ReplaceAll(IEnumerable<T> newValues)
             {
-                Ensure.ArgumentNotNull(newValues, "newValues");
+                Ensure.ArgumentNotNull(newValues, nameof(newValues));
                 list.Value.Clear();
                 list.Value.AddRange(newValues);
                 Save();

--- a/LibGit2Sharp/Repository.cs
+++ b/LibGit2Sharp/Repository.cs
@@ -146,12 +146,12 @@ namespace LibGit2Sharp
         {
             if ((requiredParameter & RepositoryRequiredParameter.Path) == RepositoryRequiredParameter.Path)
             {
-                Ensure.ArgumentNotNullOrEmptyString(path, "path");
+                Ensure.ArgumentNotNullOrEmptyString(path, nameof(path));
             }
 
             if ((requiredParameter & RepositoryRequiredParameter.Options) == RepositoryRequiredParameter.Options)
             {
-                Ensure.ArgumentNotNull(options, "options");
+                Ensure.ArgumentNotNull(options, nameof(options));
             }
 
             try
@@ -251,7 +251,7 @@ namespace LibGit2Sharp
         /// <returns>True if a repository can be resolved through this path; false otherwise</returns>
         static public bool IsValid(string path)
         {
-            Ensure.ArgumentNotNull(path, "path");
+            Ensure.ArgumentNotNull(path, nameof(path));
 
             if (string.IsNullOrWhiteSpace(path))
             {
@@ -493,7 +493,7 @@ namespace LibGit2Sharp
         /// <returns>The path to the created repository.</returns>
         public static string Init(string path, bool isBare)
         {
-            Ensure.ArgumentNotNullOrEmptyString(path, "path");
+            Ensure.ArgumentNotNullOrEmptyString(path, nameof(path));
 
             using (RepositoryHandle repo = Proxy.git_repository_init_ext(null, path, isBare))
             {
@@ -510,8 +510,8 @@ namespace LibGit2Sharp
         /// <returns>The path to the created repository.</returns>
         public static string Init(string workingDirectoryPath, string gitDirectoryPath)
         {
-            Ensure.ArgumentNotNullOrEmptyString(workingDirectoryPath, "workingDirectoryPath");
-            Ensure.ArgumentNotNullOrEmptyString(gitDirectoryPath, "gitDirectoryPath");
+            Ensure.ArgumentNotNullOrEmptyString(workingDirectoryPath, nameof(workingDirectoryPath));
+            Ensure.ArgumentNotNullOrEmptyString(gitDirectoryPath, nameof(gitDirectoryPath));
 
             // When being passed a relative workdir path, libgit2 will evaluate it from the
             // path to the repository. We pass a fully rooted path in order for the LibGit2Sharp caller
@@ -571,7 +571,7 @@ namespace LibGit2Sharp
 
         internal GitObject LookupInternal(ObjectId id, GitObjectType type, string knownPath)
         {
-            Ensure.ArgumentNotNull(id, "id");
+            Ensure.ArgumentNotNull(id, nameof(id));
 
             using (ObjectHandle obj = Proxy.git_object_lookup(handle, id, type))
             {
@@ -602,7 +602,7 @@ namespace LibGit2Sharp
 
         internal GitObject Lookup(string objectish, GitObjectType type, LookUpOptions lookUpOptions)
         {
-            Ensure.ArgumentNotNullOrEmptyString(objectish, "objectish");
+            Ensure.ArgumentNotNullOrEmptyString(objectish, nameof(objectish));
 
             GitObject obj;
             using (ObjectHandle sh = Proxy.git_revparse_single(handle, objectish))
@@ -700,7 +700,7 @@ namespace LibGit2Sharp
         /// <returns>The references in the remote repository.</returns>
         public static IEnumerable<Reference> ListRemoteReferences(string url, CredentialsHandler credentialsProvider, ProxyOptions proxyOptions)
         {
-            Ensure.ArgumentNotNull(url, "url");
+            Ensure.ArgumentNotNull(url, nameof(url));
 
             proxyOptions ??= new();
 
@@ -774,8 +774,8 @@ namespace LibGit2Sharp
         /// <returns>The path to the created repository.</returns>
         public static string Clone(string sourceUrl, string workdirPath, CloneOptions options)
         {
-            Ensure.ArgumentNotNull(sourceUrl, "sourceUrl");
-            Ensure.ArgumentNotNull(workdirPath, "workdirPath");
+            Ensure.ArgumentNotNull(sourceUrl, nameof(sourceUrl));
+            Ensure.ArgumentNotNull(workdirPath, nameof(workdirPath));
 
             options ??= new CloneOptions();
 
@@ -1001,8 +1001,8 @@ namespace LibGit2Sharp
         /// <param name="opts">Collection of parameters controlling checkout behavior.</param>
         public void Reset(ResetMode resetMode, Commit commit, CheckoutOptions opts)
         {
-            Ensure.ArgumentNotNull(commit, "commit");
-            Ensure.ArgumentNotNull(opts, "opts");
+            Ensure.ArgumentNotNull(commit, nameof(commit));
+            Ensure.ArgumentNotNull(opts, nameof(opts));
 
             using (GitCheckoutOptsWrapper checkoutOptionsWrapper = new GitCheckoutOptsWrapper(opts))
             {
@@ -1022,8 +1022,8 @@ namespace LibGit2Sharp
         /// <param name="checkoutOptions">Collection of parameters controlling checkout behavior.</param>
         public void CheckoutPaths(string committishOrBranchSpec, IEnumerable<string> paths, CheckoutOptions checkoutOptions)
         {
-            Ensure.ArgumentNotNullOrEmptyString(committishOrBranchSpec, "committishOrBranchSpec");
-            Ensure.ArgumentNotNull(paths, "paths");
+            Ensure.ArgumentNotNullOrEmptyString(committishOrBranchSpec, nameof(committishOrBranchSpec));
+            Ensure.ArgumentNotNull(paths, nameof(paths));
 
             var listOfPaths = paths.ToList();
 
@@ -1193,8 +1193,8 @@ namespace LibGit2Sharp
         /// <returns>The <see cref="MergeResult"/> of the merge.</returns>
         public MergeResult Merge(Commit commit, Signature merger, MergeOptions options)
         {
-            Ensure.ArgumentNotNull(commit, "commit");
-            Ensure.ArgumentNotNull(merger, "merger");
+            Ensure.ArgumentNotNull(commit, nameof(commit));
+            Ensure.ArgumentNotNull(merger, nameof(merger));
 
             options = options ?? new MergeOptions();
 
@@ -1213,8 +1213,8 @@ namespace LibGit2Sharp
         /// <returns>The <see cref="MergeResult"/> of the merge.</returns>
         public MergeResult Merge(Branch branch, Signature merger, MergeOptions options)
         {
-            Ensure.ArgumentNotNull(branch, "branch");
-            Ensure.ArgumentNotNull(merger, "merger");
+            Ensure.ArgumentNotNull(branch, nameof(branch));
+            Ensure.ArgumentNotNull(merger, nameof(merger));
 
             options = options ?? new MergeOptions();
 
@@ -1234,8 +1234,8 @@ namespace LibGit2Sharp
         /// <returns>The <see cref="MergeResult"/> of the merge.</returns>
         public MergeResult Merge(string committish, Signature merger, MergeOptions options)
         {
-            Ensure.ArgumentNotNull(committish, "committish");
-            Ensure.ArgumentNotNull(merger, "merger");
+            Ensure.ArgumentNotNull(committish, nameof(committish));
+            Ensure.ArgumentNotNull(merger, nameof(merger));
 
             options = options ?? new MergeOptions();
 
@@ -1255,7 +1255,7 @@ namespace LibGit2Sharp
         /// <returns>The <see cref="MergeResult"/> of the merge.</returns>
         public MergeResult MergeFetchedRefs(Signature merger, MergeOptions options)
         {
-            Ensure.ArgumentNotNull(merger, "merger");
+            Ensure.ArgumentNotNull(merger, nameof(merger));
 
             options = options ?? new MergeOptions();
 
@@ -1304,8 +1304,8 @@ namespace LibGit2Sharp
         /// <returns>The result of the revert.</returns>
         public RevertResult Revert(Commit commit, Signature reverter, RevertOptions options)
         {
-            Ensure.ArgumentNotNull(commit, "commit");
-            Ensure.ArgumentNotNull(reverter, "reverter");
+            Ensure.ArgumentNotNull(commit, nameof(commit));
+            Ensure.ArgumentNotNull(reverter, nameof(reverter));
 
             if (Info.IsHeadUnborn)
             {
@@ -1393,8 +1393,8 @@ namespace LibGit2Sharp
         /// <returns>The result of the cherry pick.</returns>
         public CherryPickResult CherryPick(Commit commit, Signature committer, CherryPickOptions options)
         {
-            Ensure.ArgumentNotNull(commit, "commit");
-            Ensure.ArgumentNotNull(committer, "committer");
+            Ensure.ArgumentNotNull(commit, nameof(commit));
+            Ensure.ArgumentNotNull(committer, nameof(committer));
 
             options = options ?? new CherryPickOptions();
 
@@ -1691,7 +1691,7 @@ namespace LibGit2Sharp
         /// <returns>A <see cref="FileStatus"/> representing the state of the <paramref name="filePath"/> parameter.</returns>
         public FileStatus RetrieveStatus(string filePath)
         {
-            Ensure.ArgumentNotNullOrEmptyString(filePath, "filePath");
+            Ensure.ArgumentNotNullOrEmptyString(filePath, nameof(filePath));
 
             string relativePath = this.BuildRelativePathFrom(filePath);
 
@@ -1753,8 +1753,8 @@ namespace LibGit2Sharp
         /// <returns>A descriptive identifier for the commit based on the nearest annotated tag.</returns>
         public string Describe(Commit commit, DescribeOptions options)
         {
-            Ensure.ArgumentNotNull(commit, "commit");
-            Ensure.ArgumentNotNull(options, "options");
+            Ensure.ArgumentNotNull(commit, nameof(commit));
+            Ensure.ArgumentNotNull(options, nameof(options));
 
             return Proxy.git_describe_commit(handle, commit.Id, options);
         }

--- a/LibGit2Sharp/RepositoryExtensions.cs
+++ b/LibGit2Sharp/RepositoryExtensions.cs
@@ -171,7 +171,7 @@ namespace LibGit2Sharp
         /// <param name="committish">A revparse spec for the target commit object.</param>
         public static void Reset(this IRepository repository, ResetMode resetMode, string committish)
         {
-            Ensure.ArgumentNotNullOrEmptyString(committish, "committish");
+            Ensure.ArgumentNotNullOrEmptyString(committish, nameof(committish));
 
             Commit commit = LookUpCommit(repository, committish);
 

--- a/LibGit2Sharp/RepositoryStatus.cs
+++ b/LibGit2Sharp/RepositoryStatus.cs
@@ -196,7 +196,7 @@ namespace LibGit2Sharp
         {
             get
             {
-                Ensure.ArgumentNotNullOrEmptyString(path, "path");
+                Ensure.ArgumentNotNullOrEmptyString(path, nameof(path));
 
                 var entries = statusEntries.Where(e => string.Equals(e.FilePath, path, StringComparison.Ordinal)).ToList();
 

--- a/LibGit2Sharp/Signature.cs
+++ b/LibGit2Sharp/Signature.cs
@@ -32,10 +32,10 @@ namespace LibGit2Sharp
         /// <param name="when">The when.</param>
         public Signature(string name, string email, DateTimeOffset when)
         {
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");
-            Ensure.ArgumentNotNullOrEmptyString(email, "email");
-            Ensure.ArgumentDoesNotContainZeroByte(name, "name");
-            Ensure.ArgumentDoesNotContainZeroByte(email, "email");
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
+            Ensure.ArgumentNotNullOrEmptyString(email, nameof(email));
+            Ensure.ArgumentDoesNotContainZeroByte(name, nameof(name));
+            Ensure.ArgumentDoesNotContainZeroByte(email, nameof(email));
 
             this.name = name;
             this.email = email;
@@ -49,7 +49,7 @@ namespace LibGit2Sharp
         /// <param name="when">The when.</param>
         public Signature(Identity identity, DateTimeOffset when)
         {
-            Ensure.ArgumentNotNull(identity, "identity");
+            Ensure.ArgumentNotNull(identity, nameof(identity));
 
             this.name = identity.Name;
             this.email = identity.Email;

--- a/LibGit2Sharp/StashCollection.cs
+++ b/LibGit2Sharp/StashCollection.cs
@@ -122,7 +122,7 @@ namespace LibGit2Sharp
         /// <returns>the newly created <see cref="Stash"/></returns>
         public virtual Stash Add(Signature stasher, string message, StashModifiers options)
         {
-            Ensure.ArgumentNotNull(stasher, "stasher");
+            Ensure.ArgumentNotNull(stasher, nameof(stasher));
 
             string prettifiedMessage = Proxy.git_message_prettify(string.IsNullOrEmpty(message) ? string.Empty : message, null);
 

--- a/LibGit2Sharp/SubmoduleCollection.cs
+++ b/LibGit2Sharp/SubmoduleCollection.cs
@@ -39,7 +39,7 @@ namespace LibGit2Sharp
         {
             get
             {
-                Ensure.ArgumentNotNullOrEmptyString(name, "name");
+                Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
                 return Lookup(name, handle => new Submodule(repo, name,
                                                             Proxy.git_submodule_path(handle),

--- a/LibGit2Sharp/TagCollection.cs
+++ b/LibGit2Sharp/TagCollection.cs
@@ -37,7 +37,7 @@ namespace LibGit2Sharp
         {
             get
             {
-                Ensure.ArgumentNotNullOrEmptyString(name, "name");
+                Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
                 var canonicalName = NormalizeToCanonicalName(name);
                 var reference = repo.Refs.Resolve<Reference>(canonicalName);
                 return reference == null ? null : new Tag(repo, reference, canonicalName);
@@ -91,7 +91,7 @@ namespace LibGit2Sharp
         /// <param name="allowOverwrite">True to allow silent overwriting a potentially existing tag, false otherwise.</param>
         public virtual Tag Add(string name, string objectish, Signature tagger, string message, bool allowOverwrite)
         {
-            Ensure.ArgumentNotNullOrEmptyString(objectish, "target");
+            Ensure.ArgumentNotNullOrEmptyString(objectish, nameof(objectish));
 
             GitObject objectToTag = repo.Lookup(objectish, GitObjectType.Any, LookUpOptions.ThrowWhenNoGitObjectHasBeenFound);
 
@@ -116,7 +116,7 @@ namespace LibGit2Sharp
         /// <param name="allowOverwrite">True to allow silent overwriting a potentially existing tag, false otherwise.</param>
         public virtual Tag Add(string name, string objectish, bool allowOverwrite)
         {
-            Ensure.ArgumentNotNullOrEmptyString(objectish, "objectish");
+            Ensure.ArgumentNotNullOrEmptyString(objectish, nameof(objectish));
 
             GitObject objectToTag = repo.Lookup(objectish, GitObjectType.Any, LookUpOptions.ThrowWhenNoGitObjectHasBeenFound);
 
@@ -147,10 +147,10 @@ namespace LibGit2Sharp
         /// <returns>The added <see cref="Tag"/>.</returns>
         public virtual Tag Add(string name, GitObject target, Signature tagger, string message, bool allowOverwrite)
         {
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");
-            Ensure.ArgumentNotNull(target, "target");
-            Ensure.ArgumentNotNull(tagger, "tagger");
-            Ensure.ArgumentNotNull(message, "message");
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
+            Ensure.ArgumentNotNull(target, nameof(target));
+            Ensure.ArgumentNotNull(tagger, nameof(tagger));
+            Ensure.ArgumentNotNull(message, nameof(message));
 
             string prettifiedMessage = Proxy.git_message_prettify(message, null);
 
@@ -179,8 +179,8 @@ namespace LibGit2Sharp
         /// <returns>The added <see cref="Tag"/>.</returns>
         public virtual Tag Add(string name, GitObject target, bool allowOverwrite)
         {
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");
-            Ensure.ArgumentNotNull(target, "target");
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
+            Ensure.ArgumentNotNull(target, nameof(target));
 
             Proxy.git_tag_create_lightweight(repo.Handle, name, target, allowOverwrite);
 
@@ -193,7 +193,7 @@ namespace LibGit2Sharp
         /// <param name="name">The short or canonical name of the tag to delete.</param>
         public virtual void Remove(string name)
         {
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
             Proxy.git_tag_delete(repo.Handle, UnCanonicalizeName(name));
         }
@@ -204,14 +204,14 @@ namespace LibGit2Sharp
         /// <param name="tag">The tag to delete.</param>
         public virtual void Remove(Tag tag)
         {
-            Ensure.ArgumentNotNull(tag, "tag");
+            Ensure.ArgumentNotNull(tag, nameof(tag));
 
             Remove(tag.CanonicalName);
         }
 
         private static string NormalizeToCanonicalName(string name)
         {
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
             if (name.LooksLikeTag())
             {
@@ -223,7 +223,7 @@ namespace LibGit2Sharp
 
         private static string UnCanonicalizeName(string name)
         {
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
             if (!name.LooksLikeTag())
             {

--- a/LibGit2Sharp/TreeDefinition.cs
+++ b/LibGit2Sharp/TreeDefinition.cs
@@ -22,7 +22,7 @@ namespace LibGit2Sharp
         /// <returns>A new <see cref="TreeDefinition"/> holding the meta data of the <paramref name="tree"/>.</returns>
         public static TreeDefinition From(Tree tree)
         {
-            Ensure.ArgumentNotNull(tree, "tree");
+            Ensure.ArgumentNotNull(tree, nameof(tree));
 
             var td = new TreeDefinition();
 
@@ -41,7 +41,7 @@ namespace LibGit2Sharp
         /// <returns>A new <see cref="TreeDefinition"/> holding the meta data of the <paramref name="commit"/>'s <see cref="Tree"/>.</returns>
         public static TreeDefinition From(Commit commit)
         {
-            Ensure.ArgumentNotNull(commit, "commit");
+            Ensure.ArgumentNotNull(commit, nameof(commit));
 
             return From(commit.Tree);
         }
@@ -65,7 +65,7 @@ namespace LibGit2Sharp
         /// <returns>The current <see cref="TreeDefinition"/>.</returns>
         public virtual TreeDefinition Remove(IEnumerable<string> treeEntryPaths)
         {
-            Ensure.ArgumentNotNull(treeEntryPaths, "treeEntryPaths");
+            Ensure.ArgumentNotNull(treeEntryPaths, nameof(treeEntryPaths));
 
             foreach (var treeEntryPath in treeEntryPaths)
             {
@@ -82,7 +82,7 @@ namespace LibGit2Sharp
         /// <returns>The current <see cref="TreeDefinition"/>.</returns>
         public virtual TreeDefinition Remove(string treeEntryPath)
         {
-            Ensure.ArgumentNotNullOrEmptyString(treeEntryPath, "treeEntryPath");
+            Ensure.ArgumentNotNullOrEmptyString(treeEntryPath, nameof(treeEntryPath));
 
             if (this[treeEntryPath] == null)
             {
@@ -124,8 +124,8 @@ namespace LibGit2Sharp
         /// <returns>The current <see cref="TreeDefinition"/>.</returns>
         public virtual TreeDefinition Add(string targetTreeEntryPath, TreeEntryDefinition treeEntryDefinition)
         {
-            Ensure.ArgumentNotNullOrEmptyString(targetTreeEntryPath, "targetTreeEntryPath");
-            Ensure.ArgumentNotNull(treeEntryDefinition, "treeEntryDefinition");
+            Ensure.ArgumentNotNullOrEmptyString(targetTreeEntryPath, nameof(targetTreeEntryPath));
+            Ensure.ArgumentNotNull(treeEntryDefinition, nameof(treeEntryDefinition));
 
             if (treeEntryDefinition is TransientTreeTreeEntryDefinition)
             {
@@ -161,7 +161,7 @@ namespace LibGit2Sharp
         /// <returns>The current <see cref="TreeDefinition"/>.</returns>
         public virtual TreeDefinition Add(string targetTreeEntryPath, TreeEntry treeEntry)
         {
-            Ensure.ArgumentNotNull(treeEntry, "treeEntry");
+            Ensure.ArgumentNotNull(treeEntry, nameof(treeEntry));
 
             TreeEntryDefinition ted = TreeEntryDefinition.From(treeEntry);
 
@@ -177,8 +177,8 @@ namespace LibGit2Sharp
         /// <returns>The current <see cref="TreeDefinition"/>.</returns>
         public virtual TreeDefinition Add(string targetTreeEntryPath, Blob blob, Mode mode)
         {
-            Ensure.ArgumentNotNull(blob, "blob");
-            Ensure.ArgumentConformsTo(mode, m => m.HasAny(TreeEntryDefinition.BlobModes), "mode");
+            Ensure.ArgumentNotNull(blob, nameof(blob));
+            Ensure.ArgumentConformsTo(mode, m => m.HasAny(TreeEntryDefinition.BlobModes), nameof(mode));
 
             TreeEntryDefinition ted = TreeEntryDefinition.From(blob, mode);
 
@@ -195,7 +195,7 @@ namespace LibGit2Sharp
         /// <returns>The current <see cref="TreeDefinition"/>.</returns>
         public virtual TreeDefinition Add(string targetTreeEntryPath, string filePath, Mode mode)
         {
-            Ensure.ArgumentNotNullOrEmptyString(filePath, "filePath");
+            Ensure.ArgumentNotNullOrEmptyString(filePath, nameof(filePath));
 
             TreeEntryDefinition ted = TreeEntryDefinition.TransientBlobFrom(filePath, mode);
 
@@ -211,8 +211,8 @@ namespace LibGit2Sharp
         /// <returns>The current <see cref="TreeDefinition"/>.</returns>
         public virtual TreeDefinition Add(string targetTreeEntryPath, ObjectId id, Mode mode)
         {
-            Ensure.ArgumentNotNull(id, "id");
-            Ensure.ArgumentConformsTo(mode, m => m.HasAny(TreeEntryDefinition.BlobModes), "mode");
+            Ensure.ArgumentNotNull(id, nameof(id));
+            Ensure.ArgumentConformsTo(mode, m => m.HasAny(TreeEntryDefinition.BlobModes), nameof(mode));
 
             TreeEntryDefinition ted = TreeEntryDefinition.From(id, mode);
 
@@ -227,7 +227,7 @@ namespace LibGit2Sharp
         /// <returns>The current <see cref="TreeDefinition"/>.</returns>
         public virtual TreeDefinition Add(string targetTreeEntryPath, Tree tree)
         {
-            Ensure.ArgumentNotNull(tree, "tree");
+            Ensure.ArgumentNotNull(tree, nameof(tree));
 
             TreeEntryDefinition ted = TreeEntryDefinition.From(tree);
 
@@ -241,7 +241,7 @@ namespace LibGit2Sharp
         /// <returns>The current <see cref="TreeDefinition"/>.</returns>
         public virtual TreeDefinition Add(Submodule submodule)
         {
-            Ensure.ArgumentNotNull(submodule, "submodule");
+            Ensure.ArgumentNotNull(submodule, nameof(submodule));
 
             return AddGitLink(submodule.Path, submodule.HeadCommitId);
         }
@@ -256,7 +256,7 @@ namespace LibGit2Sharp
         /// <returns>The current <see cref="TreeDefinition"/>.</returns>
         public virtual TreeDefinition AddGitLink(string targetTreeEntryPath, ObjectId objectId)
         {
-            Ensure.ArgumentNotNull(objectId, "objectId");
+            Ensure.ArgumentNotNull(objectId, nameof(objectId));
 
             var ted = TreeEntryDefinition.From(objectId);
 
@@ -379,7 +379,7 @@ namespace LibGit2Sharp
         {
             get
             {
-                Ensure.ArgumentNotNullOrEmptyString(treeEntryPath, "treeEntryPath");
+                Ensure.ArgumentNotNullOrEmptyString(treeEntryPath, nameof(treeEntryPath));
 
                 Tuple<string, string> segments = ExtractPosixLeadingSegment(treeEntryPath);
 

--- a/LibGit2Sharp/TreeEntryDefinition.cs
+++ b/LibGit2Sharp/TreeEntryDefinition.cs
@@ -54,7 +54,7 @@ namespace LibGit2Sharp
 
         internal static TreeEntryDefinition From(Blob blob, Mode mode)
         {
-            Ensure.ArgumentNotNull(blob, "blob");
+            Ensure.ArgumentNotNull(blob, nameof(blob));
 
             return new TreeEntryDefinition
             {
@@ -67,8 +67,8 @@ namespace LibGit2Sharp
 
         internal static TreeEntryDefinition From(ObjectId id, Mode mode)
         {
-            Ensure.ArgumentNotNull(id, "id");
-            Ensure.ArgumentNotNull(mode, "mode");
+            Ensure.ArgumentNotNull(id, nameof(id));
+            Ensure.ArgumentNotNull(mode, nameof(mode));
 
             return new TreeEntryDefinition
             {
@@ -80,7 +80,7 @@ namespace LibGit2Sharp
 
         internal static TreeEntryDefinition TransientBlobFrom(string filePath, Mode mode)
         {
-            Ensure.ArgumentConformsTo(mode, m => m.HasAny(BlobModes), "mode");
+            Ensure.ArgumentConformsTo(mode, m => m.HasAny(BlobModes), nameof(mode));
 
             return new TransientBlobTreeEntryDefinition
             {

--- a/LibGit2Sharp/WorktreeCollection.cs
+++ b/LibGit2Sharp/WorktreeCollection.cs
@@ -37,7 +37,7 @@ namespace LibGit2Sharp
         {
             get
             {
-                Ensure.ArgumentNotNullOrEmptyString(name, "name");
+                Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
                 return Lookup(name, handle => new Worktree(repo,
                     name,


### PR DESCRIPTION
Generally where parameter names are mentioned, it's a best practice to use
the `nameof()` expression. This patch adds it where stringified names were
being used.