### PR TITLE
Use LF for `end_of_line` in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,7 @@ indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true
 insert_final_newline = true
+end_of_line = lf
 
 ; Not change VS generated files
 [*.{sln,csproj}]


### PR DESCRIPTION
Sets editorconfig to use LF as the line terminator as to be in line with project guidelines