### PR TITLE
Remove windows-2019 test runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         arch: [ x64 ]
-        os: [ windows-2019, windows-2022, macos-13 ]
+        os: [ windows-2022, macos-13 ]
         tfm: [ net472, net8.0, net9.0 ]
         exclude:
           - os: macos-13


### PR DESCRIPTION
The windows-2019 test runner [has been deprecated](https://github.com/actions/runner-images/issues/12045) as of 2025-06-30.

Running these tests currently results in an error in GitHub Actions
<img width="3714" height="729" alt="image" src="https://github.com/user-attachments/assets/81085b43-5e24-4b37-9b2a-e59176fd0aba" />

