### PR TITLE
Do not use `LibGit2SharpException` overload for unknown message

### DIFF
--- a/LibGit2Sharp/Core/Ensure.cs
+++ b/LibGit2Sharp/Core/Ensure.cs
@@ -148,7 +148,7 @@ namespace LibGit2Sharp.Core
             Func<string, GitErrorCategory, LibGit2SharpException> exceptionBuilder;
             if (!GitErrorsToLibGit2SharpExceptions.TryGetValue((GitErrorCode)result, out exceptionBuilder))
             {
-                exceptionBuilder = (m, c) => new LibGit2SharpException(m, c);
+                exceptionBuilder = (m, c) => new LibGit2SharpException($"{m}{(c == GitErrorCategory.Unknown ? string.Empty: $"\nGitErrorCode{c}")}");
             }
 
             throw exceptionBuilder(errorMessage, errorCategory);


### PR DESCRIPTION
# Background
The `LibGit2SharpException` class has a constructor overload that takes two parameters and attempts to call `String.Format` to convert the values into a single string.

Unfortunately if the provided message contains text between curly braces then the string.format throws an exception.

Related PR https://github.com/OctopusDeploy/libgit2sharp/pull/10

## Result
Since this message could have any value, it seems risky to assume that the provided string will have a `{0}` that will accept the `GitErrorCategory` as a replacement value. In fact it seems rather unlikely that this would typically apply at all. As a result this handler would ignore the error category in the best case, or throw an exception in the worst case.

## Alternative
I'd also be happy to ignore the category entirely since its likely that it is of type `GitErrorCategory.Unknown` anyway

Alternative snippet
```
exceptionBuilder = (m, c) => new LibGit2SharpException(m);
```

