### PR TITLE
Propagate exceptions thrown by custom RpcSmartSubtransport

### DIFF
--- a/LibGit2Sharp/SmartSubtransportStream.cs
+++ b/LibGit2Sharp/SmartSubtransportStream.cs
@@ -119,6 +119,10 @@ namespace LibGit2Sharp
                 {
                     errorCode = ((NativeException)ret).ErrorCode;
                 }
+                else
+                {
+                    Proxy.git_error_set_str(GitErrorCategory.Unknown, caught);
+                }
 
                 return (int)errorCode;
             }


### PR DESCRIPTION
# Background
If an exception is thrown in a custom `RpcSmartSubtransport` the exception is consumed by the `SmartSubtransportStream.SetError` code.

Related Fork PR: https://github.com/OctopusDeploy/libgit2sharp/pull/9

# Result
This PR ensures that an exception thrown from within a `RpcSmartSubtransport` is passed to the `Proxy.git_error_set_str` call that is later re-retrieved and thrown to the consumer. 