### PR TITLE
Use raw commit message when rewriting history

### DIFF
--- a/LibGit2Sharp/Commit.cs
+++ b/LibGit2Sharp/Commit.cs
@@ -21,6 +21,7 @@ namespace LibGit2Sharp
         private readonly ILazy<Signature> lazyAuthor;
         private readonly ILazy<Signature> lazyCommitter;
         private readonly ILazy<string> lazyMessage;
+        private readonly ILazy<string> lazyMessageRaw;
         private readonly ILazy<string> lazyMessageShort;
         private readonly ILazy<string> lazyEncoding;
 
@@ -43,6 +44,7 @@ namespace LibGit2Sharp
             lazyCommitter = group1.AddLazy(Proxy.git_commit_committer);
             group2 = new GitObjectLazyGroup(this.repo, id);
             lazyMessage = group2.AddLazy(Proxy.git_commit_message);
+            lazyMessageRaw = group2.AddLazy(Proxy.git_commit_message_raw);
             lazyMessageShort = group2.AddLazy(Proxy.git_commit_summary);
             lazyEncoding = group2.AddLazy(RetrieveEncodingOf);
 
@@ -65,6 +67,11 @@ namespace LibGit2Sharp
         /// Gets the commit message.
         /// </summary>
         public virtual string Message { get { return lazyMessage.Value; } }
+
+        /// <summary>
+        /// Gets the raw, unmodified commit message.
+        /// </summary>
+        public virtual string MessageRaw { get { return lazyMessageRaw.Value; } }
 
         /// <summary>
         /// Gets the short commit message which is usually the first line of the commit.

--- a/LibGit2Sharp/CommitRewriteInfo.cs
+++ b/LibGit2Sharp/CommitRewriteInfo.cs
@@ -31,7 +31,7 @@ namespace LibGit2Sharp
             {
                 Author = commit.Author,
                 Committer = commit.Committer,
-                Message = commit.Message
+                Message = commit.MessageRaw
             };
         }
 

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -424,6 +424,10 @@ namespace LibGit2Sharp.Core
 
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))]
+        internal static extern unsafe string git_commit_message_raw(git_object* commit);
+
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
+        [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(LaxUtf8NoCleanupMarshaler))]
         internal static extern unsafe string git_commit_summary(git_object* commit);
 
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -388,6 +388,11 @@ namespace LibGit2Sharp.Core
             return NativeMethods.git_commit_message(obj);
         }
 
+        public static unsafe string git_commit_message_raw(ObjectHandle obj)
+        {
+            return NativeMethods.git_commit_message_raw(obj);
+        }
+
         public static unsafe string git_commit_summary(ObjectHandle obj)
         {
             return NativeMethods.git_commit_summary(obj);


### PR DESCRIPTION
This fixes a corner-case where un-touched commits were reconstructed with new hashes due to leading newlines in the commit message getting trimmed.

I will add test coverage if this PR has any chance of getting merged. Should I?