### PR TITLE
Bring the GitRemoteCallbacks structure in sync with libgit2

### DIFF
--- a/LibGit2Sharp/Core/GitRemoteCallbacks.cs
+++ b/LibGit2Sharp/Core/GitRemoteCallbacks.cs
@@ -33,10 +33,12 @@ namespace LibGit2Sharp.Core
 
         internal IntPtr transport;
 
-        private IntPtr padding; // TODO: add git_remote_ready_cb
+        internal IntPtr remote_ready; // TODO: add git_remote_ready_cb
 
         internal IntPtr payload;
 
         internal NativeMethods.url_resolve_callback resolve_url;
+
+        private IntPtr update_refs;
     }
 }


### PR DESCRIPTION
The marshaling was messed up due to missing extra field.

Fixes #2161