### PR TITLE
Add Depth to Commands.Fetch

### DIFF
--- a/LibGit2Sharp/Commands/Fetch.cs
+++ b/LibGit2Sharp/Commands/Fetch.cs
@@ -54,6 +54,7 @@ namespace LibGit2Sharp
                 var fetchOptions = fetchOptionsWrapper.Options;
                 fetchOptions.RemoteCallbacks = gitCallbacks;
                 fetchOptions.download_tags = Proxy.git_remote_autotag(remoteHandle);
+                fetchOptions.Depth = options.Depth;
 
                 if (options.TagFetchMode.HasValue)
                 {


### PR DESCRIPTION
Thanks to https://github.com/libgit2/libgit2sharp/pull/2070, it is now possible to Clone with shallow depth. In some cases you'd want to unshallow. The current workaround is to delete the local repo and re-Clone with full depth. To avoid this un-necessary step, the Depth could be respected by Fetch, the same way it is doing it for Clone.

This patch works for the cases I tested (don't forget to check `repo.Info.IsShallow`), but it seems too simple and I don't know what would be required to test and implement it properly. So I'd like to ask for help on this, thanks.