### PR TITLE
RetrieveStatus-take-so-long-time-about-5s - Add UpdateIndex to Status…

### DIFF
--- a/LibGit2Sharp.Tests/StatusFixture.cs
+++ b/LibGit2Sharp.Tests/StatusFixture.cs
@@ -660,5 +660,19 @@ namespace LibGit2Sharp.Tests
                 Assert.Equal(9, status.Count());
             }
         }
+
+        [Fact]
+        public void TestUpdateIndexDoesNotFail()
+        {
+            var path = SandboxStandardTestRepo();
+
+            using (var repo = new Repository(path))
+            {
+                // This option improves the performance of subsequent calls,
+                // but there isn't really an observable difference to assert
+                // Therefor enable the option and to ensure it doesn't trigger and exception is the only thing possible
+                repo.RetrieveStatus(new StatusOptions() { UpdateIndex = true });
+            }
+        }
     }
 }

--- a/LibGit2Sharp/RepositoryStatus.cs
+++ b/LibGit2Sharp/RepositoryStatus.cs
@@ -139,6 +139,12 @@ namespace LibGit2Sharp
                     GitStatusOptionFlags.IncludeUnmodified;
             }
 
+            if (options.UpdateIndex)
+            {
+                coreOptions.Flags |=
+                    GitStatusOptionFlags.UpdateIndex;
+            }
+
             return coreOptions;
         }
 

--- a/LibGit2Sharp/StatusOptions.cs
+++ b/LibGit2Sharp/StatusOptions.cs
@@ -105,5 +105,13 @@
         /// Include untracked files when scanning for status
         /// </summary>
         public bool IncludeUntracked { get; set; }
+
+        /// <summary>
+        /// Refresh out of date index and save it in index
+        /// </summary>
+        /// <remarks>
+        /// Will result in less work being done in subsequent calls
+        /// </remarks>
+        public bool UpdateIndex { get; set; }
     }
 }


### PR DESCRIPTION
…Options to improve performance for subsequent calls available on libgit2sharp API

Fixes: https://github.com/libgit2/libgit2sharp/issues/1570

When enabling this flag it should be possible to take the one time penalty and then use the optimized index 