### PR TITLE
Fix config discovery under Native AOT (GitBuf marshalling)

### DIFF
--- a/LibGit2Sharp/Core/GitBuf.cs
+++ b/LibGit2Sharp/Core/GitBuf.cs
@@ -3,6 +3,16 @@ using System.Runtime.InteropServices;
 
 namespace LibGit2Sharp.Core.Handles
 {
+    /// <summary>
+    /// Managed mirror of libgit2's <c>git_buf</c> for APIs that still pass a
+    /// sequential-layout class through the runtime marshaller.
+    /// </summary>
+    /// <remarks>
+    /// Prefer <see cref="GitBufNative"/> for new or Native AOT-sensitive call
+    /// sites. Under Native AOT, class-based sequential marshalling is effectively
+    /// [In]-only, so native writes to <c>ptr</c>/<c>size</c> never appear in
+    /// managed code.
+    /// </remarks>
     [StructLayout(LayoutKind.Sequential)]
     internal class GitBuf : IDisposable
     {
@@ -14,5 +24,18 @@ namespace LibGit2Sharp.Core.Handles
         {
             Proxy.git_buf_dispose(this);
         }
+    }
+
+    /// <summary>
+    /// Blittable <c>git_buf</c> for P/Invoke via <c>ref</c>. Required for Native AOT
+    /// so that libgit2 can write <c>ptr</c>/<c>asize</c>/<c>size</c> back to managed
+    /// memory (class marshalling does not).
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct GitBufNative
+    {
+        public IntPtr ptr;
+        public UIntPtr asize;
+        public UIntPtr size;
     }
 }

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -361,6 +361,9 @@ namespace LibGit2Sharp.Core
         internal static extern void git_buf_dispose(GitBuf buf);
 
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void git_buf_dispose(ref GitBufNative buf);
+
+        [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe int git_checkout_tree(
             git_repository* repo,
             git_object* treeish,
@@ -468,17 +471,19 @@ namespace LibGit2Sharp.Core
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string regexp,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictUtf8Marshaler))] string value);
 
+        // Use ref GitBufNative (not class GitBuf): under Native AOT, sequential
+        // class marshalling does not write ptr/size back to the managed object.
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int git_config_find_global(GitBuf global_config_path);
+        internal static extern int git_config_find_global(ref GitBufNative global_config_path);
 
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int git_config_find_system(GitBuf system_config_path);
+        internal static extern int git_config_find_system(ref GitBufNative system_config_path);
 
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int git_config_find_xdg(GitBuf xdg_config_path);
+        internal static extern int git_config_find_xdg(ref GitBufNative xdg_config_path);
 
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int git_config_find_programdata(GitBuf programdata_config_path);
+        internal static extern int git_config_find_programdata(ref GitBufNative programdata_config_path);
 
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe void git_config_free(git_config* cfg);
@@ -1522,7 +1527,7 @@ namespace LibGit2Sharp.Core
 
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int git_repository_discover(
-            GitBuf buf,
+            ref GitBufNative buf,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath start_path,
             [MarshalAs(UnmanagedType.Bool)] bool across_fs,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalCookie = UniqueId.UniqueIdentifier, MarshalTypeRef = typeof(StrictFilePathMarshaler))] FilePath ceiling_dirs);

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -2447,7 +2447,7 @@ namespace LibGit2Sharp.Core
 
         public static FilePath git_repository_discover(FilePath start_path)
         {
-            return ConvertPath(buf => NativeMethods.git_repository_discover(buf, start_path, false, null));
+            return ConvertPath((ref GitBufNative buf) => NativeMethods.git_repository_discover(ref buf, start_path, false, null));
         }
 
         public static unsafe bool git_repository_head_detached(RepositoryHandle repo)
@@ -3830,11 +3830,19 @@ namespace LibGit2Sharp.Core
             return (res == 1);
         }
 
-        private static FilePath ConvertPath(Func<GitBuf, int> pathRetriever)
+        private delegate int PathRetriever(ref GitBufNative buf);
+
+        /// <summary>
+        /// Invokes a native path-returning API using a blittable <see cref="GitBufNative"/>.
+        /// Must not use class <see cref="GitBuf"/>: Native AOT marshalling does not
+        /// copy native fills of ptr/size back onto sequential-layout classes.
+        /// </summary>
+        private static FilePath ConvertPath(PathRetriever pathRetriever)
         {
-            using (var buf = new GitBuf())
+            var buf = new GitBufNative();
+            try
             {
-                int result = pathRetriever(buf);
+                int result = pathRetriever(ref buf);
 
                 if (result == (int)GitErrorCode.NotFound)
                 {
@@ -3843,6 +3851,10 @@ namespace LibGit2Sharp.Core
 
                 Ensure.ZeroResult(result);
                 return LaxFilePathMarshaler.FromNative(buf.ptr);
+            }
+            finally
+            {
+                NativeMethods.git_buf_dispose(ref buf);
             }
         }
 


### PR DESCRIPTION
## Summary

- Native AOT fails to load global/system git config because sequential-layout **class** `GitBuf` marshalling does not write `ptr`/`size` back to managed code after `git_config_find_*`.
- That makes `Configuration.BuildSignature` return null when `user.name` / `user.email` are only in global config (including via `include.path`).
- Introduce blittable `GitBufNative` and use `ref` P/Invoke for path-find APIs and `ConvertPath`, so config discovery matches CoreCLR/`dotnet run` behavior.

## Root cause (brief)

Under Native AOT, class-based sequential marshalling is effectively `[In]`-only. `git_config_find_global` can return success while managed `GitBuf.ptr` stays zero, so discovery returns no path and only local repo config is loaded.

## Test plan

- [x] Build `LibGit2Sharp` for all TFMs
- [x] AOT publish of a small app using `repo.Config.BuildSignature`: `HasConfig(Global)` / `HasConfig(System)` true, signature non-null when identity is in global config
- [x] CoreCLR / `dotnet run` path still resolves global config and builds signature
- [ ] CI on this PR

Fixes #2187